### PR TITLE
Add fallback service

### DIFF
--- a/charts/mirrorbits/Chart.yaml
+++ b/charts/mirrorbits/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.5.1"
 description: Mirrobits helm chart for Kubernetes
 name: mirrorbits
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: olblak
     email: me@olblak.com

--- a/charts/mirrorbits/templates/ingress.yaml
+++ b/charts/mirrorbits/templates/ingress.yaml
@@ -32,14 +32,11 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          # First match policy
-          - path: /
+        {{- range .paths }}
+          - path: {{ .path }}
             backend:
-              serviceName: {{ $fullName }}-files
+              serviceName: {{ if .serviceNameSuffix }}{{ $fullName }}-{{ .serviceNameSuffix }}{{ else }}{{ $fullName }}{{ end }}
               servicePort: 80
-          - path: /.*[.](deb|hpi|war|rpm|msi|pkg|sha256|md5sum|zip|gz|pdf|json|svg|sh|jpeg|ico|png|html)$
-            backend:
-              serviceName: {{ $fullName }}
-              servicePort: 80
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/mirrorbits/values.yaml
+++ b/charts/mirrorbits/values.yaml
@@ -47,13 +47,20 @@ service:
     port: 80
 
 ingress:
-  enabled: false
+  enabled: true
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
-      paths: []
+      paths:
+        - path: /
+          serviceNameSuffix: files
+        - path: /.*[.](deb|hpi|war|rpm|msi|pkg|sha256|md5sum|zip|gz|pdf|json|svg|sh|jpeg|ico|png|html)$
+    - host: fallback.chart-example.local
+      paths:
+        - path: /
+          serviceNameSuffix: files
 
   tls: []
   #  - secretName: chart-example-tls

--- a/config/default/mirrorbits.yaml
+++ b/config/default/mirrorbits.yaml
@@ -19,21 +19,26 @@ resources:
         memory: 256Mi
 
 ingress:
-  enabled: true
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
-    # For now deploy this service on the private ingress
     "kubernetes.io/ingress.class": "public-ingress"
     "nginx.ingress.kubernetes.io/ssl-redirect": "false"
     "nginx.ingress.kubernetes.io/hsts": "false"
   hosts:
     - host: get.jenkins.io
       paths:
-        - /
+        - path: /
+          serviceNameSuffix: files
+        - path: /.*[.](deb|hpi|war|rpm|msi|pkg|sha256|md5sum|zip|gz|pdf|json|svg|sh|jpeg|ico|png|html)$
+    - host: fallback.get.jenkins.io
+      paths:
+        - path: /
+          serviceNameSuffix: files
   tls:
     - secretName: mirrorbits-tls
       hosts:
         - get.jenkins.io
+        - fallback.get.jenkins.io
 
 repository:
   name: mirrorbits-binary


### PR DESCRIPTION
Archives is too slow, mirrors take ~15-20 minutes to sync, we should be fine to serve from Azure till then.
Especially for security releases we need better performance while that
is happening.