### PR TITLE
chore(secrets) cleanup sops secrets configuration

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -13,7 +13,8 @@ creation_rules:
             - '56D8342434B84E2D1CCF53D96E9A025D52210D3D' # Olblak
             - '6699E555C6730CAED9083B7AD40F4AD2F55AF15F' # timja
             - '29B84443F41DE582F71599AFB47082DEE225AE06' # dduportal
-            - '837CD965F821949EE5DD45131046E0D5ED9B51BC' # gevans
+            - '81B0C54A1BA2C92EAD985025A2B9560AF24FF1AD' # hlemeur
+            - 'E104B7543ECCCC68EA1EB35DD9B2DBFB59AD8344' # markewaite
 
     - path_regex: secrets/config/jenkins-wiki-exporter/secrets.yaml
       key_groups:
@@ -26,7 +27,8 @@ creation_rules:
             - '56D8342434B84E2D1CCF53D96E9A025D52210D3D' # Olblak
             - '6699E555C6730CAED9083B7AD40F4AD2F55AF15F' # timja
             - '29B84443F41DE582F71599AFB47082DEE225AE06' # dduportal
-            - '837CD965F821949EE5DD45131046E0D5ED9B51BC' # gevans
+            - '81B0C54A1BA2C92EAD985025A2B9560AF24FF1AD' # hlemeur
+            - 'E104B7543ECCCC68EA1EB35DD9B2DBFB59AD8344' # markewaite
 
     - path_regex: secrets/config/plugin-site/secrets.yaml
       key_groups:
@@ -39,19 +41,8 @@ creation_rules:
             - '6699E555C6730CAED9083B7AD40F4AD2F55AF15F' # timja
             - '56D8342434B84E2D1CCF53D96E9A025D52210D3D' # Olblak
             - '29B84443F41DE582F71599AFB47082DEE225AE06' # dduportal
-            - '837CD965F821949EE5DD45131046E0D5ED9B51BC' # gevans
-
-    # Let's keep the number of people with access to the release environment
-    # as small as possible (max 3)
-    - path_regex: secrets/config/release/
-      key_groups:
-        - azure_keyvault:
-          - vaultUrl: 'https://prodjenkinsinfra.vault.azure.net'
-            key: 'sops'
-            version: '252fc7e646ac40f184ab4a6016484725'
-          pgp:
-            - '6699E555C6730CAED9083B7AD40F4AD2F55AF15F' # timja
-            - '56D8342434B84E2D1CCF53D96E9A025D52210D3D' # Olblak
+            - '81B0C54A1BA2C92EAD985025A2B9560AF24FF1AD' # hlemeur
+            - 'E104B7543ECCCC68EA1EB35DD9B2DBFB59AD8344' # markewaite
 
     - key_groups:
         - azure_keyvault:
@@ -62,5 +53,5 @@ creation_rules:
             - '56D8342434B84E2D1CCF53D96E9A025D52210D3D' # Olblak
             - '6699E555C6730CAED9083B7AD40F4AD2F55AF15F' # timja
             - '29B84443F41DE582F71599AFB47082DEE225AE06' # dduportal
-            - '837CD965F821949EE5DD45131046E0D5ED9B51BC' # gevans
             - 'E104B7543ECCCC68EA1EB35DD9B2DBFB59AD8344' # markewaite
+            - '81B0C54A1BA2C92EAD985025A2B9560AF24FF1AD' # hlemeur


### PR DESCRIPTION
This PR updates the SOPS configuration to:

- Remove Gareth Evans
- Add Herver Le Meur, Damien Duportal and Mark Waite to all secrets


The secrets had already been re-encrypted on the charts-secrets side.