### PR TITLE
feat: add wiki chart to publick8s [INFRA-3092]

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -27,3 +27,4 @@ helmfiles:
   - path: "../helmfile.d/custom-distribution-site.yaml"
   - path: "../helmfile.d/incrementals-publisher.yaml"
   - path: "../helmfile.d/keycloak.yaml"
+  - path: "../helmfile.d/wiki.yaml"

--- a/config/default/wiki.yaml
+++ b/config/default/wiki.yaml
@@ -1,0 +1,26 @@
+ingress:
+  enabled: true
+  ingressClassName: public-nginx
+  # annotations:
+  #   "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+  #   "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+  hosts:
+    - host: wiki.jenkins.io
+      paths:
+        - path: /
+    - host: wiki.jenkins-ci.org
+      paths:
+        - path: /
+  # tls:
+  #   - secretName: wiki-tls
+  #     hosts:
+  #       - wiki.jenkins.io
+  #       - wiki.jenkins-ci.org
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi

--- a/helmfile.d/00-repositories.yaml
+++ b/helmfile.d/00-repositories.yaml
@@ -10,3 +10,5 @@ repositories:
     url: https://charts.helm.sh/stable
   - name: ingress-nginx
     url: https://kubernetes.github.io/ingress-nginx
+  - name: jenkins-infra
+    url: https://jenkins-infra.github.io/public-charts

--- a/helmfile.d/wiki.yaml
+++ b/helmfile.d/wiki.yaml
@@ -1,0 +1,10 @@
+releases:
+  - name: wiki
+    namespace: wiki
+    chart: jenkins-infra/wiki
+    version: 0.1.1
+    wait: false
+    values:
+      - "../config/default/wiki.yaml"
+    # secrets:
+    #   - "../secrets/config/wiki/secrets.yaml"


### PR DESCRIPTION
Add [wiki chart](https://github.com/jenkins-infra/public-charts/tree/main/charts/wiki) serving [confluence-data content](https://github.com/jenkins-infra/confluence-data)

TODO:
- [ ] host docker image on jenkins-infra
- [ ] set final domain
- [ ] automate building and co

Ref: https://issues.jenkins.io/browse/INFRA-3092