### PR TITLE
Add jenkins.io to infra.ci

### DIFF
--- a/config/jenkins-infra.yaml
+++ b/config/jenkins-infra.yaml
@@ -51,7 +51,7 @@ controller:
     - name: SECRETS
       value: /var/jenkins_secrets
   overwritePlugins: true
-  secretsFilesSecret: 'jenkins-secrets'
+  secretsFilesSecret: "jenkins-secrets"
   serviceType: "ClusterIP"
   javaOpts: >
     -XshowSettings:vm -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:MaxRAM=4g -XX:+AlwaysPreTouch -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/ -XX:+UseG1GC -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.websocketConnectionTimeout=60
@@ -475,6 +475,7 @@ controller:
                 [ name: 'Helm Charts', GHOrganization: 'jenkins-infra', repository: 'helm-charts', internalId: '2021122217', jenkinsfilePath: 'Jenkinsfile_k8s'],
                 [ name: 'Plugin Site', GHOrganization: 'jenkins-infra', repository: 'plugin-site', internalId: '2019081603', jenkinsfilePath: 'Jenkinsfile_k8s'],
                 [ name: 'Packer Images', GHOrganization: 'jenkins-infra', repository: 'packer-images', internalId: '2021090101', jenkinsfilePath: 'Jenkinsfile_k8s'],
+                [ name: 'Jenkins.io', GHOrganization: 'jenkins-infra', repository: 'jenkins.io', internalId: '2021122501', jenkinsfilePath: 'Jenkinsfile_k8s'],
               ].each { config ->
                 multibranchPipelineJob(config.repository) {
                   displayName config.name


### PR DESCRIPTION
I didn't know if it should be added to the docker images folder, but err'd with the general list thingie.

Mostly to support https://github.com/jenkins-infra/jenkins.io/pull/4782