### PR TITLE
fix(plugin-site-issues) enable (again) plugin-site-issues management

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -127,15 +127,14 @@ releases:
       - "../config/plugin-site.yaml"
     secrets:
       - "../secrets/config/plugin-site/secrets.yaml"
-  ## Commented until https://github.com/jenkins-infra/kubernetes-management/issues/1862 is solved
-  # - name: plugin-site-issues
-  #   namespace: plugin-site
-  #   chart: jenkins-infra/plugin-site-issues
-  #   version: 0.1.2
-  #   values:
-  #     - "../config/plugin-site-issues.yaml"
-  #   secrets:
-  #     - "../secrets/config/plugin-site-issues/secrets.yaml"
+  - name: plugin-site-issues
+    namespace: plugin-site
+    chart: jenkins-infra/plugin-site-issues
+    version: 0.1.2
+    values:
+      - "../config/plugin-site-issues.yaml"
+    secrets:
+      - "../secrets/config/plugin-site-issues/secrets.yaml"
   - name: chatbot
     namespace: chatbot
     chart: jenkins-infra/chatbot


### PR DESCRIPTION
This PR fixes #1862 by adding the following changes:

- Enable automatic management of the service "plugin-site-issues" again (in `prodpublick8s`)
- Ensures that secrets had been updated with the correct YAML keys:
  - https://github.com/jenkins-infra/kubernetes-management/issues/1862#issuecomment-1003029019
  - https://github.com/jenkins-infra/charts-secrets/commit/f42a9e08212b40f7cbc73dc5d7270a4cd89912f5 (private repository)