### PR TITLE
fix(infra.ci) use the correct Jenkins URL

### DIFF
--- a/config/jenkins-infra.yaml
+++ b/config/jenkins-infra.yaml
@@ -255,6 +255,7 @@ controller:
           clouds:
             - kubernetes:
                 containerCapStr: "100"
+                # Kubernetes internal URL to stay within private networks
                 jenkinsUrl: "http://jenkins-infra.jenkins-infra.svc:8080"
                 maxRequestsPerHostStr: "300"
                 webSocket: true
@@ -613,7 +614,7 @@ controller:
       pipeline-library: |
         unclassified:
           location:
-            url: "http://jenkins-infra.jenkins-infra.svc:8080"
+            url: "https://infra.ci.jenkins.io"
           globalLibraries:
             libraries:
             - defaultVersion: "master"


### PR DESCRIPTION
This PR ensures that:

- Github checks are generating correct links
- That no UI redirects are failing to redirect user
- That pipeline_library can deploy docker images under the `jenkinciinfra` instead of `jenkins4eval`