### PR TITLE
Feat: add a public nginx ingress to temp-privatek8s

### DIFF
--- a/clusters/temp-privatek8s.yaml
+++ b/clusters/temp-privatek8s.yaml
@@ -30,6 +30,12 @@ releases:
       - "../config/cert-manager.yaml"
     secrets:
       - "../secrets/config/acme/secrets.yaml"
+  - name: public-nginx-ingress
+    namespace: public-nginx-ingress
+    chart: ingress-nginx/ingress-nginx
+    version: 4.0.13
+    values:
+      - "../config/temp-privatek8s/public-nginx-ingress.yaml"
   - name: private-nginx-ingress
     namespace: private-nginx-ingress
     chart: ingress-nginx/ingress-nginx

--- a/config/public-nginx-ingress.yaml
+++ b/config/public-nginx-ingress.yaml
@@ -50,8 +50,6 @@ controller:
   service:
     annotations:
       service.beta.kubernetes.io/azure-load-balancer-internal: false
-      service.beta.kubernetes.io/azure-load-balancer-internal-subnet: app-tier
-      service.beta.kubernetes.io/azure-load-balancer-resource-group: prodpublick8s
       prometheus.io/scrape: "true"
       prometheus.io/port: "10254"
     loadBalancerIP: 52.167.253.43

--- a/config/temp-privatek8s/public-nginx-ingress.yaml
+++ b/config/temp-privatek8s/public-nginx-ingress.yaml
@@ -24,10 +24,6 @@ defaultBackend:
 controller:
   config:
     log-format-upstream: '[$proxy_add_x_forwarded_for] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id'
-    # In order to use geoIP from the ingress controller,
-    # we need to provide a maxmind license key.
-    # I doubt we need it at the moment, hence this comment.
-    # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-geoip2
     use-geoip2: "true"
     hsts: "true"
     hsts-preload: "true"

--- a/config/temp-privatek8s/public-nginx-ingress.yaml
+++ b/config/temp-privatek8s/public-nginx-ingress.yaml
@@ -1,0 +1,56 @@
+defaultBackend:
+  enabled: true
+  image:
+    repository: jenkinsciinfra/404
+    tag: 0.3.1
+    pullPolicy: IfNotPresent
+  ## Unprivileged port as non root user and no escalation allowed
+  port: 8080
+  ## Volumes are required because rootfs is readonly
+  extraVolumeMounts:
+    - name: nginx-cache
+      mountPath: /var/cache/nginx
+    - name: nginx-rundir
+      mountPath: /var/run/nginx
+    - name: nginx-logs
+      mountPath: /var/logs/nginx
+  extraVolumes:
+    - name: nginx-cache
+      emptyDir: {}
+    - name: nginx-rundir
+      emptyDir: {}
+    - name: nginx-logs
+      emptyDir: {}
+controller:
+  config:
+    log-format-upstream: '[$proxy_add_x_forwarded_for] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id'
+    # In order to use geoIP from the ingress controller,
+    # we need to provide a maxmind license key.
+    # I doubt we need it at the moment, hence this comment.
+    # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-geoip2
+    use-geoip2: "true"
+    hsts: "true"
+    hsts-preload: "true"
+    hsts-include-subdomains: "true"
+    # Should be 2 years as per https://hstspreload.org/
+    # 24 hours, as a first gradual HSTS deployment - see INFRA-2998
+    hsts-max-age: "86400"
+    ## Only allow GitHub's webhooks requests - https://github.blog/changelog/2019-04-09-webhooks-ip-changes/
+    whitelist-source-range: "140.82.112.0/20,192.30.252.0/22"
+  replicaCount: 1
+  ingressClassResource:
+    enabled: true
+    default: false
+    controllerValue: k8s.io/ingress-public-nginx
+    name: public-nginx
+    # Parameters is a link to a custom resource containing additional
+    # configuration for the controller. This is optional if the controller
+    # does not require extra parameters.
+    parameters: {}
+  service:
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-internal: false
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "10254"
+    loadBalancerIP: 20.97.148.67
+    externalTrafficPolicy: Local


### PR DESCRIPTION
- Ingress controller installed manually one time:
  - Created a "Public IP" in Azure, and a DNS record pointing to this IP
  - Defined the `loadBalancerIP` of the ingress's config to this predefined IP
  - Installed the controller

Please note that there is also a cleanup of the prodpublick8s annotations