### PR TITLE
Fix: updatecli for temp-privatek8s + existing

### DIFF
--- a/updatecli/updatecli.d/charts/accountapp.yaml
+++ b/updatecli/updatecli.d/charts/accountapp.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for accountapp"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/accountapp((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/accountapp${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/acme.yaml
+++ b/updatecli/updatecli.d/charts/acme.yaml
@@ -6,11 +6,27 @@ sources:
       url: https://jenkins-infra.github.io/helm-charts
       name: acme
 targets:
-  updateChartVersion:
+  updateChartVersionPublic:
     name: "Update the chart version for acme"
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
+      matchPattern: 'chart: jenkins-infra\/acme((\r\n|\r|\n)(\s+))version: .*'
+      replacePattern: 'chart: jenkins-infra/acme${1}version: {{ source `lastChartVersion` }}'
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updateChartVersionPrivate:
+    name: "Update the chart version for acme"
+    kind: file
+    spec:
+      file: clusters/temp-privatek8s.yaml
       matchPattern: 'chart: jenkins-infra\/acme((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/acme${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/acme.yaml
+++ b/updatecli/updatecli.d/charts/acme.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for acme"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/acme((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/acme${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/certmanager.yaml
+++ b/updatecli/updatecli.d/charts/certmanager.yaml
@@ -10,7 +10,7 @@ targets:
     name: "jetstack/cert-manager Helm Chart"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jetstack\/cert-manager((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jetstack/cert-manager${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/certmanager.yaml
+++ b/updatecli/updatecli.d/charts/certmanager.yaml
@@ -6,11 +6,27 @@ sources:
       url: https://charts.jetstack.io
       name: cert-manager
 targets:
-  updateChartVersion:
+  updateChartVersionPublic:
     name: "jetstack/cert-manager Helm Chart"
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
+      matchPattern: 'chart: jetstack\/cert-manager((\r\n|\r|\n)(\s+))version: .*'
+      replacePattern: 'chart: jetstack/cert-manager${1}version: {{ source `lastChartVersion` }}'
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updateChartVersionPrivate:
+    name: "jetstack/cert-manager Helm Chart"
+    kind: file
+    spec:
+      file: clusters/temp-privatek8s.yaml
       matchPattern: 'chart: jetstack\/cert-manager((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jetstack/cert-manager${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/chatbot.yaml
+++ b/updatecli/updatecli.d/charts/chatbot.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for chatbot"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/chatbot((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/chatbot${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/codecentric-keycloak.yaml
+++ b/updatecli/updatecli.d/charts/codecentric-keycloak.yaml
@@ -10,7 +10,7 @@ targets:
     name: "codecentric/keycloak Helm Chart"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: codecentric\/keycloak((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: codecentric/keycloak${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/custom-distribution-service.yaml
+++ b/updatecli/updatecli.d/charts/custom-distribution-service.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for custom-distribution-service"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/custom-distribution-service((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/custom-distribution-service${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/datadog.yaml
+++ b/updatecli/updatecli.d/charts/datadog.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Datadog Helm Chart"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: datadog\/datadog((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: datadog/datadog${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/env-jenkins-release.yaml
+++ b/updatecli/updatecli.d/charts/env-jenkins-release.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for env-jenkins-release"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/env-jenkins-release((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/env-jenkins-release${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/falco.yaml
+++ b/updatecli/updatecli.d/charts/falco.yaml
@@ -10,7 +10,7 @@ targets:
     name: "falco/falco Helm Chart"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: falco\/falco((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: falco/falco${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/grafana-loki.yaml
+++ b/updatecli/updatecli.d/charts/grafana-loki.yaml
@@ -10,7 +10,7 @@ targets:
     name: "grafana/loki Helm Chart"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: grafana\/loki((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: grafana/loki${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/grafana-promtail.yaml
+++ b/updatecli/updatecli.d/charts/grafana-promtail.yaml
@@ -11,7 +11,7 @@ targets:
     name: "grafana/promtail Helm Chart"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: grafana\/promtail((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: grafana/promtail${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/grafana.yaml
+++ b/updatecli/updatecli.d/charts/grafana.yaml
@@ -10,7 +10,7 @@ targets:
     name: "grafana/grafana Helm Chart"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: grafana\/grafana((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: grafana/grafana${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/incrementals-publisher.yaml
+++ b/updatecli/updatecli.d/charts/incrementals-publisher.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for incrementals-publisher"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/incrementals-publisher((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/incrementals-publisher${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/javadoc.yaml
+++ b/updatecli/updatecli.d/charts/javadoc.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for javadoc"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/javadoc((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/javadoc${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/jenkins-additional.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-additional.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for jenkins-additional"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/jenkins-additional((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/jenkins-additional${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/jenkins-additional.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-additional.yaml
@@ -6,11 +6,27 @@ sources:
       url: https://jenkins-infra.github.io/helm-charts
       name: jenkins-additional
 targets:
-  updateChartVersion:
+  updateChartVersionPublic:
     name: "Update the chart version for jenkins-additional"
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
+      matchPattern: 'chart: jenkins-infra\/jenkins-additional((\r\n|\r|\n)(\s+))version: .*'
+      replacePattern: 'chart: jenkins-infra/jenkins-additional${1}version: {{ source `lastChartVersion` }}'
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updateChartVersionPrivate:
+    name: "Update the chart version for jenkins-additional"
+    kind: file
+    spec:
+      file: clusters/temp-privatek8s.yaml
       matchPattern: 'chart: jenkins-infra\/jenkins-additional((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/jenkins-additional${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/jenkins-infra-keycloak.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-infra-keycloak.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for jenkins-infra-keycloak"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/keycloak((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/keycloak${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/jenkins-wiki-exporter.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-wiki-exporter.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for jenkins-wiki-exporter"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/jenkins-wiki-exporter((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/jenkins-wiki-exporter${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/jenkins.yaml
+++ b/updatecli/updatecli.d/charts/jenkins.yaml
@@ -1,4 +1,4 @@
-title: Bump Jenkins Upstream Helm Charts 
+title: Bump Jenkins Upstream Helm Charts
 sources:
   lastChartVersion:
     kind: helmChart
@@ -10,7 +10,7 @@ targets:
     name: "jenkinsci/jenkins Helm Chart"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins\/jenkins((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins/jenkins${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/jenkinsio.yaml
+++ b/updatecli/updatecli.d/charts/jenkinsio.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for jenkinsio"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/jenkinsio((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/jenkinsio${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/ldap.yaml
+++ b/updatecli/updatecli.d/charts/ldap.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for ldap"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/ldap((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/ldap${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/mirrorbits.yaml
+++ b/updatecli/updatecli.d/charts/mirrorbits.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for mirrorbits"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/mirrorbits((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/mirrorbits${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/nginx-ingress.yaml
+++ b/updatecli/updatecli.d/charts/nginx-ingress.yaml
@@ -11,7 +11,7 @@ targets:
     name: "Update the version of the Helm chart ingress-nginx for public-ingress"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: ingress-nginx\/ingress-nginx((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: ingress-nginx/ingress-nginx${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/nginx-ingress.yaml
+++ b/updatecli/updatecli.d/charts/nginx-ingress.yaml
@@ -23,7 +23,7 @@ targets:
         token: "{{ requiredEnv .github.token }}"
         username: "{{ .github.username }}"
         branch: "{{ .github.branch }}"
-  updateChartVersionTempPrivate:
+  updateChartVersionPrivate:
     name: "Update the version of the Helm chart ingress-nginx for temp-privatek8s"
     kind: file
     spec:

--- a/updatecli/updatecli.d/charts/plugin-site-issues.yaml
+++ b/updatecli/updatecli.d/charts/plugin-site-issues.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for plugin-site-issues"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/plugin-site-issues((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/plugin-site-issues${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/plugin-site.yaml
+++ b/updatecli/updatecli.d/charts/plugin-site.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for plugin-site"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/plugin-site((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/plugin-site${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/prometheus.yaml
+++ b/updatecli/updatecli.d/charts/prometheus.yaml
@@ -10,7 +10,7 @@ targets:
     name: "stable/prometheus Helm Chart"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: prometheus-community\/prometheus((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: prometheus-community/prometheus${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/reports.yaml
+++ b/updatecli/updatecli.d/charts/reports.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for reports"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/reports((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/reports${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/traefik.yaml
+++ b/updatecli/updatecli.d/charts/traefik.yaml
@@ -10,7 +10,7 @@ targets:
     name: "traefik/traefik Helm Chart"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: traefik\/traefik((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: traefik/traefik${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/uplink.yaml
+++ b/updatecli/updatecli.d/charts/uplink.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for uplink"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/uplink((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/uplink${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/charts/wiki.yaml
+++ b/updatecli/updatecli.d/charts/wiki.yaml
@@ -10,7 +10,7 @@ targets:
     name: "Update the chart version for wiki"
     kind: file
     spec:
-      file: clusters/publick8s.yaml
+      file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/wiki((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/wiki${1}version: {{ source `lastChartVersion` }}'
     scm:

--- a/updatecli/updatecli.d/docker-images/404.yaml
+++ b/updatecli/updatecli.d/docker-images/404.yaml
@@ -16,7 +16,7 @@ conditions:
     spec:
       image: "jenkinsciinfra/404"
 targets:
-  updatePrivateNginxIngress404:
+  updatePrivateNginxIngress404Public:
     name: "Update 404 docker image tag"
     kind: yaml
     spec:
@@ -31,11 +31,41 @@ targets:
         token: "{{ requiredEnv .github.token }}"
         username: "{{ .github.username }}"
         branch: "{{ .github.branch }}"
-  updatePublicNginxIngress404:
+  updatePublicNginxIngress404Public:
     name: "Update 404 docker image tag"
     kind: yaml
     spec:
       file: "config/public-nginx-ingress.yaml"
+      key: "defaultBackend.image.tag"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updatePrivateNginxIngress404Private:
+    name: "Update 404 docker image tag"
+    kind: yaml
+    spec:
+      file: "config/temp-privatek8s/private-nginx-ingress.yaml"
+      key: "defaultBackend.image.tag"
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+  updatePublicNginxIngress404Private:
+    name: "Update 404 docker image tag"
+    kind: yaml
+    spec:
+      file: "config/temp-privatek8s/public-nginx-ingress.yaml"
       key: "defaultBackend.image.tag"
     scm:
       github:


### PR DESCRIPTION
This PR aims at fixing updatecli process after the 2 major changes:

- Renaming `clusters/publick8s.yaml` to `clusters/temp-privatek8s`
- Adding `cluster/temp-privatek8s`