### PR TITLE
feat(incremental) Delegate Docker image version to the charts's default value

### DIFF
--- a/config/incrementals-publisher.yaml
+++ b/config/incrementals-publisher.yaml
@@ -12,6 +12,3 @@ ingress:
     - secretName: incrementals-tls
       hosts:
         - incrementals.jenkins.io
-image:
-  tag: "v1.4.1"
-  pullPolicy: IfNotPresent


### PR DESCRIPTION
It explains why the 1.4.2 of hte incremental publisher webapp wasn't released despite the helm-chart 0.4.4 correctly deployed.

It's a remnant of a cleanup of the repository, and we to apply the same change (e.g. removing from the helm'fils values) on all of our images