### PR TITLE
fix(infra.ci) correct JobDSL to allow jenkins.io to deploy to netlify

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -539,7 +539,7 @@ controller:
                             strategies {
                               buildChangeRequests {
                                 ignoreTargetOnlyChanges(true)
-                                ignoreUntrustedChanges(!allowUntrustedChanges)
+                                ignoreUntrustedChanges(!config.allowUntrustedChanges)
                               }
                               buildRegularBranches()
                               buildTags {


### PR DESCRIPTION
Follows up #1907 

Tested in "live" production by editing the configmap