### PR TITLE
infra.ci: fix indentation of agent-settings in jenkins config as code

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -317,115 +317,115 @@ controller:
                 useInstanceProfileForCredentials: false
                 templates:
                 - ami: "ami-07096113cf2ec6768" # https://github.com/jenkins-infra/packer-images/
-                    amiOwners: "200564066411"
-                    amiType:
-                      unixData:
-                        sshPort: "22"
-                    associatePublicIp: true
-                    connectBySSHProcess: false
-                    connectionStrategy: PUBLIC_IP
-                    deleteRootOnTermination: true
-                    description: "AMD64 Ubuntu 20.04"
-                    ebsOptimized: false
-                    hostKeyVerificationStrategy: ACCEPT_NEW           # Secure: more flexible to save some time at startup
-                    idleTerminationMinutes: "5"
-                    instanceCapStr: "10"
-                    labelString: "linux-amd64 linux-amd64-docker"
-                    launchTimeoutStr: "180"
-                    maxTotalUses: 1
-                    minimumNumberOfInstances: 0
-                    minimumNumberOfSpareInstances: 0
-                    mode: EXCLUSIVE
-                    monitoring: true
-                    numExecutors: 1
-                    remoteAdmin: "jenkins"
-                    remoteFS: "/home/jenkins"
-                    securityGroups: "ec2_agents_infraci"
-                    stopOnTerminate: false
-                    t2Unlimited: false
-                    tags:
-                    - name: "architecture"
-                      value: "amd64"
-                    - name: "os"
-                      value: "linux"
-                    - name: "jenkins"
-                      value: "infra.ci.jenkins.io"
-                    type: T3Medium
-                    useEphemeralDevices: true
-                  - ami: "ami-0d2d7ce8555684cbb" # https://github.com/jenkins-infra/packer-images/
-                    amiOwners: "200564066411"
-                    amiType:
-                      unixData:
-                        sshPort: "22"
-                    associatePublicIp: true
-                    connectBySSHProcess: false
-                    connectionStrategy: PUBLIC_IP
-                    deleteRootOnTermination: true
-                    description: "ARM64 Ubuntu 20.04"
-                    ebsOptimized: false
-                    hostKeyVerificationStrategy: ACCEPT_NEW           # Secure: more flexible to save some time at startup
-                    idleTerminationMinutes: "5"
-                    instanceCapStr: "10"
-                    labelString: "arm64 linux-arm64 linux-arm64-docker"
-                    launchTimeoutStr: "180"
-                    maxTotalUses: 1
-                    minimumNumberOfInstances: 0
-                    minimumNumberOfSpareInstances: 0
-                    mode: EXCLUSIVE
-                    monitoring: true
-                    numExecutors: 1
-                    remoteAdmin: "jenkins"
-                    remoteFS: "/home/jenkins"
-                    securityGroups: "ec2_agents_infraci"
-                    stopOnTerminate: false
-                    t2Unlimited: false
-                    tags:
-                    - name: "architecture"
-                      value: "arm64"
-                    - name: "os"
-                      value: "linux"
-                    - name: "jenkins"
-                      value: "infra.ci.jenkins.io"
-                    type: T4gMedium
-                    useEphemeralDevices: true
-                  - ami: "ami-0c3f1d709a2270b04" # https://github.com/jenkins-infra/packer-images/
-                    amiOwners: "200564066411"
-                    amiType:
-                      unixData:
-                        sshPort: "22"
-                    associatePublicIp: true
-                    connectBySSHProcess: false
-                    connectionStrategy: PUBLIC_IP
-                    deleteRootOnTermination: true
-                    description: "Windows 2019 AMD64"
-                    ebsOptimized: false
-                    hostKeyVerificationStrategy: ACCEPT_NEW     # TODO: set it CHECK_NEW_HARD (slower but safer)
-                    idleTerminationMinutes: "30"                # Windows instances are billed per hour, let's reuse
-                    instanceCapStr: "10"
-                    labelString: "windows windows-amd64 windows-amd64-docker docker-windows"
-                    launchTimeoutStr: "600"                     # Wait for Windows to start all the EC2 launch services
-                    maxTotalUses: 10                            # Windows instances are billed per hour, let's reuse
-                    minimumNumberOfInstances: 0
-                    minimumNumberOfSpareInstances: 0
-                    mode: EXCLUSIVE
-                    monitoring: false
-                    numExecutors: 1
-                    remoteAdmin: "Administrator"
-                    remoteFS: "C:\\Jenkins"
-                    securityGroups: "ec2_agents_infraci"
-                    stopOnTerminate: false
-                    t2Unlimited: false
-                    tags:
-                    - name: "architecture"
-                      value: "amd64"
-                    - name: "os"
-                      value: "windows"
-                    - name: "jenkins"
-                      value: "infra.ci.jenkins.io"
-                    tenancy: Default
-                    tmpDir: "C:\\\\Temp"                          # Mandatory because EC2 plugins assumes SSH = Unix and searches for /tmp
-                    type: T3Medium
-                    useEphemeralDevices: true
+                  amiOwners: "200564066411"
+                  amiType:
+                    unixData:
+                      sshPort: "22"
+                  associatePublicIp: true
+                  connectBySSHProcess: false
+                  connectionStrategy: PUBLIC_IP
+                  deleteRootOnTermination: true
+                  description: "AMD64 Ubuntu 20.04"
+                  ebsOptimized: false
+                  hostKeyVerificationStrategy: ACCEPT_NEW           # Secure: more flexible to save some time at startup
+                  idleTerminationMinutes: "5"
+                  instanceCapStr: "10"
+                  labelString: "linux-amd64 linux-amd64-docker"
+                  launchTimeoutStr: "180"
+                  maxTotalUses: 1
+                  minimumNumberOfInstances: 0
+                  minimumNumberOfSpareInstances: 0
+                  mode: EXCLUSIVE
+                  monitoring: true
+                  numExecutors: 1
+                  remoteAdmin: "jenkins"
+                  remoteFS: "/home/jenkins"
+                  securityGroups: "ec2_agents_infraci"
+                  stopOnTerminate: false
+                  t2Unlimited: false
+                  tags:
+                  - name: "architecture"
+                    value: "amd64"
+                  - name: "os"
+                    value: "linux"
+                  - name: "jenkins"
+                    value: "infra.ci.jenkins.io"
+                  type: T3Medium
+                  useEphemeralDevices: true
+                - ami: "ami-0d2d7ce8555684cbb" # https://github.com/jenkins-infra/packer-images/
+                  amiOwners: "200564066411"
+                  amiType:
+                    unixData:
+                      sshPort: "22"
+                  associatePublicIp: true
+                  connectBySSHProcess: false
+                  connectionStrategy: PUBLIC_IP
+                  deleteRootOnTermination: true
+                  description: "ARM64 Ubuntu 20.04"
+                  ebsOptimized: false
+                  hostKeyVerificationStrategy: ACCEPT_NEW           # Secure: more flexible to save some time at startup
+                  idleTerminationMinutes: "5"
+                  instanceCapStr: "10"
+                  labelString: "arm64 linux-arm64 linux-arm64-docker"
+                  launchTimeoutStr: "180"
+                  maxTotalUses: 1
+                  minimumNumberOfInstances: 0
+                  minimumNumberOfSpareInstances: 0
+                  mode: EXCLUSIVE
+                  monitoring: true
+                  numExecutors: 1
+                  remoteAdmin: "jenkins"
+                  remoteFS: "/home/jenkins"
+                  securityGroups: "ec2_agents_infraci"
+                  stopOnTerminate: false
+                  t2Unlimited: false
+                  tags:
+                  - name: "architecture"
+                    value: "arm64"
+                  - name: "os"
+                    value: "linux"
+                  - name: "jenkins"
+                    value: "infra.ci.jenkins.io"
+                  type: T4gMedium
+                  useEphemeralDevices: true
+                - ami: "ami-0c3f1d709a2270b04" # https://github.com/jenkins-infra/packer-images/
+                  amiOwners: "200564066411"
+                  amiType:
+                    unixData:
+                      sshPort: "22"
+                  associatePublicIp: true
+                  connectBySSHProcess: false
+                  connectionStrategy: PUBLIC_IP
+                  deleteRootOnTermination: true
+                  description: "Windows 2019 AMD64"
+                  ebsOptimized: false
+                  hostKeyVerificationStrategy: ACCEPT_NEW     # TODO: set it CHECK_NEW_HARD (slower but safer)
+                  idleTerminationMinutes: "30"                # Windows instances are billed per hour, let's reuse
+                  instanceCapStr: "10"
+                  labelString: "windows windows-amd64 windows-amd64-docker docker-windows"
+                  launchTimeoutStr: "600"                     # Wait for Windows to start all the EC2 launch services
+                  maxTotalUses: 10                            # Windows instances are billed per hour, let's reuse
+                  minimumNumberOfInstances: 0
+                  minimumNumberOfSpareInstances: 0
+                  mode: EXCLUSIVE
+                  monitoring: false
+                  numExecutors: 1
+                  remoteAdmin: "Administrator"
+                  remoteFS: "C:\\Jenkins"
+                  securityGroups: "ec2_agents_infraci"
+                  stopOnTerminate: false
+                  t2Unlimited: false
+                  tags:
+                  - name: "architecture"
+                    value: "amd64"
+                  - name: "os"
+                    value: "windows"
+                  - name: "jenkins"
+                    value: "infra.ci.jenkins.io"
+                  tenancy: Default
+                  tmpDir: "C:\\\\Temp"                          # Mandatory because EC2 plugins assumes SSH = Unix and searches for /tmp
+                  type: T3Medium
+                  useEphemeralDevices: true
       # To add a job, choose if you want to add it as a map, inside the corresponding arrays below
       # - A GH Org. requires a name, the GH Org (or user handle) of the repo and the pattern to capture the repo (s) name
       # - A Multibranch requires a name, the GH Org (or user handle) of the repo, the repo name, an string identifier (we use the YYYYMMDDXX format with XX being a suffix integer)


### PR DESCRIPTION
fix the crashloopbackoff caused by #1920 

jenkins infra.ci pod logs 

```console
while parsing a block mapping
 in /var/jenkins_home/casc_configs/agent-settings.yaml, line 67, column 11:
            - ami: "ami-07096113cf2ec6768" # h ... 
              ^
expected <block end>, but found '<block mapping start>'
 in /var/jenkins_home/casc_configs/agent-settings.yaml, line 68, column 13:
                amiOwners: "200564066411"
```