### PR TITLE
chore(updatecli) ensure that only nginx stable version is tracked 

### DIFF
--- a/updatecli/updatecli.d/docker-images/nginx.yaml
+++ b/updatecli/updatecli.d/docker-images/nginx.yaml
@@ -11,7 +11,7 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       branch: "{{ .github.branch }}"
-  nginx-gh-mirror:
+  nginxGithubMirror:
     kind: git
     spec:
       url: "https://github.com/nginx/nginx.git"
@@ -21,7 +21,7 @@ sources:
   latestRelease:
     name: Get latest stable version of nginx
     kind: gitTag
-    scmID: nginx-gh-mirror
+    scmID: nginxGithubMirror
     spec:
       versionFilter:
         kind: regex

--- a/updatecli/updatecli.d/docker-images/nginx.yaml
+++ b/updatecli/updatecli.d/docker-images/nginx.yaml
@@ -14,7 +14,7 @@ scms:
   nginxGithubMirror:
     kind: git
     spec:
-      url: "https://github.com/nginx/nginx.git"
+      url: "https://github.com/nginx/nginx"
       branch: "master"
 
 sources:

--- a/updatecli/updatecli.d/docker-images/nginx.yaml
+++ b/updatecli/updatecli.d/docker-images/nginx.yaml
@@ -11,38 +11,35 @@ scms:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       branch: "{{ .github.branch }}"
+  nginx-gh-mirror:
+    kind: git
+    spec:
+      url: "https://github.com/nginx/nginx.git"
+      branch: "master"
 
 sources:
   latestRelease:
-    kind: githubRelease
-    name: Get latest nginx/nginx version
-    # We should retrieve only the minor even version to get the stable, but it requires an updatecli fix on its regexp parser, adding unwanted backslashes
+    name: Get latest stable version of nginx
+    kind: gitTag
+    scmID: nginx-gh-mirror
     spec:
-      owner: nginx
-      repository: nginx
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
       versionFilter:
-        kind: latest
+        kind: regex
+        ## Nginx stable version have the minor digit as an even number
+        pattern: 'release-(\d+)\.(\d*[0|2|4|6|8])\.(\d+)'
     transformers:
-    - trimPrefix: "release-"
-    - addSuffix: "-alpine"
-    # problem with nginxinc/docker-nginx repository: all tags aren't present in its releases
-    # spec:
-    #   owner: "nginxinc"
-    #   repository: "docker-nginx"
-    #   token: "{{ requiredEnv .github.token }}"
-    #   username: "{{ .github.username }}"
-    #   versionFilter:
-    #     kind: regexp
-    #     pattern: '(\d+)\.(\d*[0|2|4|6|8])\.(\d+)'
+      - trimPrefix: "release-"
+      - addSuffix: "-alpine"
 
 conditions:
   checkDockerImagePublished:
     name: "Test nginx:<latest_version> docker image tag"
     kind: dockerImage
+    sourceID: latestRelease
     spec:
       image: "nginx"
+      architecture: amd64
+      # tag comes from the source input value
 
 targets:
   updateENJenkinsio:


### PR DESCRIPTION
This change is allowed because of the release of https://github.com/updatecli/updatecli/releases/tag/v0.18.3 that fixed the filtering of git tag resources.