### PR TITLE
feat(release.ci.jenkins.io) enable automated management + cherry pick secrets/mounts changes from infra.ci

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -187,28 +187,24 @@ releases:
       - "../config/mirrorbits.yaml"
     secrets:
       - "../secrets/config/mirrorbits/secrets.yaml"
-#  - name: default-release-jenkins
-#    namespace: release
-#    chart: jenkins/jenkins
-#    version: 3.11.3
-#    timeout: 600
-#    set:
-#      - name: namespace
-#        value: release
-#    values:
-#    - ../config/ext_jenkins-release.yaml
-  - name: jenkins-infra-additional
+  - name: default-release-jenkins
     namespace: release
-    chart: jenkins-infra/jenkins-additional
-    version: 0.0.3
+    chart: jenkins/jenkins
+    version: 3.11.3
+    timeout: 600
+    set:
+      - name: namespace
+        value: release
+    values:
+      - ../config/ext_jenkins-release.yaml
     secrets:
-      - "../secrets/config/release/jenkins/secrets.yaml"
+      - "../secrets/config/release.ci.jenkins.io/jenkins-secrets.yaml"
   - name: default-release-jenkins-env
     namespace: release
     chart: jenkins-infra/env-jenkins-release
     version: 0.1.1
     secrets:
-      - ../secrets/config/release/env-jenkins/secrets.yaml
+      - ../secrets/config/release.ci.jenkins.io/env-jenkins-secrets.yaml
   - name: custom-distribution-service
     namespace: custom-distribution-service
     chart: jenkins-infra/custom-distribution-service

--- a/config/ext_jenkins-release.yaml
+++ b/config/ext_jenkins-release.yaml
@@ -10,14 +10,6 @@ rbac:
 persistence:
   enabled: true
   size: 50Gi
-  volumes:
-    - name: jenkins-secrets
-      secret:
-        secretName: jenkins-secrets
-  mounts:
-    - name: jenkins-secrets
-      mountPath: /var/jenkins_secrets
-      readOnly: true
 agent:
   componentName: "agent"
 networkPolicy:
@@ -51,13 +43,12 @@ controller:
     readinessProbe:
       initialDelaySeconds: 120
   testEnabled: false
-  runAsUser: 1000
-  fsGroup: 1000
-  containerEnv:
-    - name: SECRETS
-      value: /var/jenkins_secrets
+  podSecurityContextOverride:
+    runAsNonRoot: true
+    runAsUser: 1000
+    supplementalGroups: [1000]
   overwritePlugins: true
-  secretsFilesSecret: 'jenkins-secrets'
+
   serviceType: "ClusterIP"
   javaOpts: >
     -XshowSettings:vm -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:MaxRAM=4g -XX:+AlwaysPreTouch -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/ -XX:+UseG1GC -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.websocketConnectionTimeout=60

--- a/updatecli/updatecli.d/charts/jenkins.yaml
+++ b/updatecli/updatecli.d/charts/jenkins.yaml
@@ -20,14 +20,14 @@ sources:
       name: jenkins
 
 targets:
-  # updateReleaseCIChartVersion:
-  #   name: "jenkinsci/jenkins Helm Chart"
-  #   kind: file
-  #   spec:
-  #     file: clusters/prodpublick8s.yaml
-  #     matchPattern: 'chart: jenkins\/jenkins((\r\n|\r|\n)(\s+))version: .*'
-  #     replacePattern: 'chart: jenkins/jenkins${1}version: {{ source `lastChartVersion` }}'
-  #   scmID: default
+  updateReleaseCIChartVersion:
+    name: "jenkinsci/jenkins Helm Chart"
+    kind: file
+    spec:
+      file: clusters/prodpublick8s.yaml
+      matchPattern: 'chart: jenkins\/jenkins((\r\n|\r|\n)(\s+))version: .*'
+      replacePattern: 'chart: jenkins/jenkins${1}version: {{ source `lastChartVersion` }}'
+    scmID: default
   updateInfraCIChartVersion:
     name: "jenkinsci/jenkins Helm Chart"
     kind: file
@@ -42,7 +42,7 @@ pullrequests:
     kind: github
     scmID: default
     targets:
-      # - updateReleaseCIChartVersion
+      - updateReleaseCIChartVersion
       - updateInfraCIChartVersion
     spec:
       labels:


### PR DESCRIPTION
- Now that the security release of 2022-02-09 has been delivered, we can enable back the automatic management of release.ci (reverts the behavior of #1979 )
- Manage secrets with the jenkins/jenkins helm chart instead of the custom "jenkins-additional", which is the same kind of change as we did for infra.ci in #1985)
- Fine tune the Azure volume used for the JENKINS_HOME of release.ci, as we did for infra.ci in #1986 (and which proved really efficient)