### PR TITLE
feat(infra.ci) add datadog terraform's credential

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -237,11 +237,6 @@ controller:
                     description: Datadog application key for infra.ci
                 - string:
                     scope: GLOBAL
-                    id: "terraform-datadog-azure-backend-account-key"
-                    secret: "${TERRAFORM_AZURE_BACKEND_ACCOUNT_KEY}"
-                    description: Account key for the Azure terraform backend used for datadog's management
-                - string:
-                    scope: GLOBAL
                     id: "packer-aws-access-key-id"
                     secret: "${CI_PACKER_AWS_ACCESS_KEY_ID}"
                     description: AWS API key for the account ci-packer

--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -178,6 +178,11 @@ controller:
                     scope: GLOBAL
                     secretBytes: "${base64:${PRODUCTION_TERRAFORM_DIGITALOCEAN_BACKEND_CONFIG}}"
                 - file:
+                    fileName: "backend-config"
+                    id: "production-terraform-datadog-backend-config"
+                    scope: GLOBAL
+                    secretBytes: "${base64:${PRODUCTION_TERRAFORM_DATADOG_BACKEND_CONFIG}}"
+                - file:
                     fileName: "kubeconfig"
                     id: "kubeconfig-cik8s"
                     description: "Kubeconfig file for cik8s"


### PR DESCRIPTION
This PR adds the Terraform's backend configuration file used in https://github.com/jenkins-infra/datadog 