### PR TITLE
chore(pipeline) do not fail if updatecli diff fails

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -32,6 +32,7 @@ pipeline {
               steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                   updatecli(action: 'diff')
+                }
               }
             } // stage
             stage('Apply Configuration Update') {
@@ -43,7 +44,9 @@ pipeline {
                 }
               }
               steps {
-                updatecli(action: 'apply')
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                  updatecli(action: 'apply')
+                }
               }
             } // stage
           }

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -30,7 +30,8 @@ pipeline {
             stage('Check Configuration Update') {
               // Run updatecli's diff on both push and pull requests (in case a configuration change breaks updatecli)
               steps {
-                sh 'updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.yaml'
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                  updatecli(action: 'diff')
               }
             } // stage
             stage('Apply Configuration Update') {
@@ -42,7 +43,7 @@ pipeline {
                 }
               }
               steps {
-                sh 'updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.yaml'
+                updatecli(action: 'apply')
               }
             } // stage
           }


### PR DESCRIPTION
In https://github.com/jenkins-infra/kubernetes-management/pull/2048, the checks failed and weren't able to validate that the introduce helmfile code was working as expected.

We merged the PR taking the risk of breaking the main branch, but we should not.

The core reason is that we run updatecli diff/apply *before* the helmfile stuff, because we use declarative pipeline syntax.
We could either switch to scripted or migrate all the updatecli tasks to a centralized multibranch repo (and remove updatecli code from this pipeline).

But for now, this PR will ensure that diff does not fail the whole pipeline.