### PR TITLE
feat(infra.ci) Bump Docker image to 0.44.0-2.337

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -20,7 +20,7 @@ networkPolicy:
       name: "jenkins-infra"
 controller:
   image: jenkinsciinfra/jenkins-weekly
-  tag: 0.43.2-2.336
+  tag: 0.44.0-2.337
   pullPolicy: IfNotPresent
   resources:
     limits:


### PR DESCRIPTION
Since https://github.com/jenkins-infra/helpdesk/issues/2803, there haven't been any updatecli update due to jobs not triggered.

This PR bumps to latest weekly (hoping it would also fix the cron trigger issue).