### PR TITLE
chore(updatecli) cleanup updatecli manifest to fix errors and warnings

### DIFF
--- a/updatecli/updatecli.d/docker-images/404.yaml
+++ b/updatecli/updatecli.d/docker-images/404.yaml
@@ -29,6 +29,8 @@ conditions:
     kind: dockerImage
     spec:
       image: "jenkinsciinfra/404"
+      ## Tag from source
+      architecture: amd64
 
 targets:
   updatePrivateNginxIngress404Public:

--- a/updatecli/updatecli.d/docker-images/datadog.yaml
+++ b/updatecli/updatecli.d/docker-images/datadog.yaml
@@ -19,6 +19,7 @@ sources:
     spec:
       image: "jenkinsciinfra/datadog"
       tag: "latest"
+      architecture: amd64
 
 # no condition to test docker image availability as we're using a digest from docker hub
 

--- a/updatecli/updatecli.d/docker-images/jenkins-lts.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-lts.yaml
@@ -29,6 +29,8 @@ conditions:
     kind: dockerImage
     spec:
       image: "jenkinsciinfra/jenkins-lts"
+      ## Tag from source
+      architecture: amd64
 
 targets:
   updateReleaseInConfig:

--- a/updatecli/updatecli.d/docker-images/jenkins-weekly.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-weekly.yaml
@@ -29,6 +29,8 @@ conditions:
     kind: dockerImage
     spec:
       image: "jenkinsciinfra/jenkins-weekly"
+      ## Tag from source
+      architecture: amd64
 
 targets:
   updateReleaseInConfig:

--- a/updatecli/updatecli.d/docker-images/keycloack-theme.yaml
+++ b/updatecli/updatecli.d/docker-images/keycloack-theme.yaml
@@ -29,6 +29,8 @@ conditions:
     kind: dockerImage
     spec:
       image: "jenkinsciinfra/keycloak-theme"
+      ## Tag from source
+      architecture: amd64
 
 targets:
   updateReleaseInConfig:

--- a/updatecli/updatecli.d/pod-templates/helmfile.yaml
+++ b/updatecli/updatecli.d/pod-templates/helmfile.yaml
@@ -30,6 +30,7 @@ conditions:
     spec:
       image: "jenkinsciinfra/helmfile"
       ## tag come from the input source
+      architecture: amd64
   checkPodTemplate:
     name: "Is container 'helmfile' correctly defined in PodTemplates.yaml"
     kind: yaml
@@ -54,7 +55,7 @@ pullrequests:
     kind: github
     scmID: default
     targets:
-      - updateChartVersion
+      - updateImage
     spec:
       labels:
         - dependencies

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,5 +1,5 @@
 github:
-  user: "updatebot"
+  user: "Jenkins Infra Bot (updatecli)"
   email: "60776566+jenkins-infra-bot@users.noreply.github.com"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,6 +1,5 @@
 github:
   user: "updatebot"
-  user: "Jenkins Infra Bot (updatecli)"
   email: "60776566+jenkins-infra-bot@users.noreply.github.com"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"


### PR DESCRIPTION
- 1 fixed error comes from a duplicated value in `updatecli/values.yaml` from https://github.com/jenkins-infra/kubernetes-management/pull/2051. Ping @lemeurherve can you check that I've set the correct value for `github.user`?
- 1 fixed error comes from a `pullrequest` block not specifying the correct `target`
- Warnings around Docker image missing architecture