### PR TITLE
chore: remove UPDATECLI_GITHUB_TOKEN env var as it's now integrated in updatecli shared pipeline

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -23,7 +23,6 @@ pipeline {
             }
           }
           environment {
-            UPDATECLI_GITHUB_TOKEN  = credentials('updatecli-github-token')
             AWS_ACCESS_KEY_ID     = credentials('packer-aws-access-key-id')
             AWS_SECRET_ACCESS_KEY = credentials('packer-aws-secret-access-key')
             AWS_DEFAULT_REGION    = 'us-east-2'


### PR DESCRIPTION
Depends on https://github.com/jenkins-infra/pipeline-library/pull/320
Part of https://github.com/jenkins-infra/helpdesk/issues/2817