### PR TITLE
Revert "[updatecli] Bump jenkins-infra helmfile docker image" (updatecli to 0.21.0)

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -14,7 +14,7 @@ pipeline {
   }
 
   stages {
-    stage('Chore Tasks') {      
+    stage('Chore Tasks') {
       parallel {
         stage('Dependency Management') {
           agent {
@@ -32,7 +32,9 @@ pipeline {
               // Run updatecli's diff on both push and pull requests (in case a configuration change breaks updatecli)
               steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                  updatecli(action: 'diff', cronTriggerExpression: cronExpr)
+                  updatecli(action: 'diff', cronTriggerExpression: cronExpr,
+                    updatecliDockerImage: 'jenkinsciinfra/helmfile:2.3.7', // Tracked by updatecli
+                  )
                 }
               }
             } // stage
@@ -42,7 +44,9 @@ pipeline {
               }
               steps {
                 catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                  updatecli(action: 'apply', cronTriggerExpression: cronExpr)
+                  updatecli(action: 'apply', cronTriggerExpression: cronExpr,
+                    updatecliDockerImage: 'jenkinsciinfra/helmfile:2.3.7', // Tracked by updatecli,
+                  )
                 }
               }
             } // stage

--- a/PodTemplates.yaml
+++ b/PodTemplates.yaml
@@ -32,7 +32,7 @@ spec:
                 values:
                   - highmemlinux
   containers:
-    - image: "jenkinsciinfra/helmfile:2.3.10"
+    - image: "jenkinsciinfra/helmfile:2.3.7"
       imagePullPolicy: "IfNotPresent"
       name: "jnlp"
       resources:

--- a/PodTemplates.yaml
+++ b/PodTemplates.yaml
@@ -37,10 +37,10 @@ spec:
       name: "jnlp"
       resources:
         limits:
-          memory: "1512Mi"
-          cpu: "400m"
+          memory: "2048Mi"
+          cpu: "2"
         requests:
-          memory: "1512Mi"
-          cpu: "400m"
+          memory: "2048Mi"
+          cpu: "2"
       securityContext:
         privileged: false

--- a/updatecli/updatecli.d/pod-templates/helmfile.yaml
+++ b/updatecli/updatecli.d/pod-templates/helmfile.yaml
@@ -39,8 +39,9 @@ conditions:
       file: "PodTemplates.yaml"
       key: spec.containers[0].name
       value: "jnlp"
+
 targets:
-  updateImage:
+  updatePodImage:
     name: "Update helmfile container's image in PodTemplates.yaml"
     kind: yaml
     transformers:
@@ -49,14 +50,25 @@ targets:
       file: "PodTemplates.yaml"
       key: spec.containers[0].image
     scmID: default
+  updatePipelineImage:
+    name: Update docker-helmfile in Jenkinsfile
+    kind: file
+    spec:
+      file: Jenkinsfile_k8s
+      # Please note that the patterns are specified as "block scalars" (>) with the last endline trimmed (-) to avoid tedious escaping of simple quotes
+      matchpattern: >-
+        'jenkinsciinfra/helmfile:(.*)'
+      replacepattern: >-
+        'jenkinsciinfra/helmfile:{{ source `lastRelease` }}'
+    scmID: default
 
 pullrequests:
   default:
     kind: github
     scmID: default
     targets:
-      - updateImage
+      - updatePodImage
+      - updatePipelineImage
     spec:
       labels:
         - dependencies
-        - acme


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#2095 because we are suffering from https://github.com/updatecli/updatecli/issues/583.

*Why didn't the check caught this issue*

- We are currently ignoring the failure of `updatecli diff` which hides the error. 
- This would be fixed once https://github.com/updatecli/updatecli/issues/465 is implemented in updatecli
- Until then, we **might** want to run updatecli in parallel of the kubernetes matrix to avoid blocking the process, OR not fail the pipeline when updatecli apply fail.



This PR also includes the following changes:

- Give memory /cpu to the pipeline process
- Ensure that updatecli runs in the same docker image as the rest of the pipeline (to ensure that we have the correct updatecli version and same tooling in exact same version)
