### PR TITLE
feat(infra.ci) add azure terraform job

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -479,7 +479,7 @@ controller:
           - script: >
               [
                 [ name: 'Docker Builds', GHOrganization: 'jenkins-infra', repoPattern: 'rating|docker-.*$', jenkinsfilePath: 'Jenkinsfile_k8s'],
-                [ name: 'Terraform Jobs', GHOrganization: 'jenkins-infra', repoPattern: 'aws|datadog|digitalocean$', jenkinsfilePath: 'Jenkinsfile_k8s'],
+                [ name: 'Terraform Jobs', GHOrganization: 'jenkins-infra', repoPattern: 'aws|azure|datadog|digitalocean$', jenkinsfilePath: 'Jenkinsfile_k8s'],
               ].each { config ->
                 organizationFolder(config.name) {
                   description(config.name)

--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -265,6 +265,35 @@ controller:
                     scope: GLOBAL
                     subscriptionId: "${PACKER_AZURE_SUBSCRIPTION_ID}"
                     tenant: "${PACKER_AZURE_TENANT_ID}"
+                - azure:
+                    azureEnvironmentName: "Azure"
+                    clientId: "${PRODUCTION_TERRAFORM_AZURE_CLIENT_ID}"
+                    clientSecret: "${PRODUCTION_TERRAFORM_AZURE_CLIENT_SECRET_VALUE}"
+                    description: "Azure Service Principal credential used by terraform for azure production"
+                    id: "production-terraform-azure-serviceprincipal"
+                    scope: GLOBAL
+                    subscriptionId: "${PRODUCTION_TERRAFORM_AZURE_SUBSCRIPTION_ID}"
+                    tenant: "${PRODUCTION_TERRAFORM_AZURE_TENANT_ID}"
+                - file:
+                    fileName: "backend-config"
+                    id: "production-terraform-azure-backend-config"
+                    scope: GLOBAL
+                    secretBytes: "${base64:${PRODUCTION_TERRAFORM_AZURE_BACKEND_CONFIG}}"
+                - azure:
+                    azureEnvironmentName: "Azure"
+                    clientId: "${STAGING_TERRAFORM_AZURE_CLIENT_ID}"
+                    clientSecret: "${STAGING_TERRAFORM_AZURE_CLIENT_SECRET_VALUE}"
+                    description: "Azure Service Principal credential used by terraform for azure staging"
+                    id: "production-terraform-azure-serviceprincipal"
+                    scope: GLOBAL
+                    subscriptionId: "${STAGING_TERRAFORM_AZURE_SUBSCRIPTION_ID}"
+                    tenant: "${STAGING_TERRAFORM_AZURE_TENANT_ID}"
+                - file:
+                    fileName: "backend-config"
+                    id: "staging-terraform-azure-backend-config"
+                    scope: GLOBAL
+                    secretBytes: "${base64:${STAGING_TERRAFORM_AZURE_BACKEND_CONFIG}}"
+
       agent-settings: |
         jenkins:
           numExecutors: 0


### PR DESCRIPTION
As part of https://github.com/jenkins-infra/helpdesk/issues/2683, this PR adds the following elements:

- Azure repository is now part of the "Terraform Jobs", watching for `Jenkinsfile_k8s` pipelines
- Credentials for azure management by terraform:
  - 2 new backends config based on the aurerm backends for production and staging introduces in jenkins-infra/terraform-states
  - 2 new Azure Service Principals for terraform (production and staging) to allow Terraform to manage Azure infrastructure