### PR TITLE
fix: suppress log output in github checks

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -491,6 +491,17 @@ controller:
                       credentialsId('github-app-infra')
 
                       traits {
+                        gitHubSCMSourceStatusChecksTrait {
+                            // Note: changing this name might have impact on github branch protections if they specify status names
+                            name('[infra.ci.jenkins.io] ' + config.name)
+                            skip(false)
+                            // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
+                            skipNotifications(false)
+                            skipProgressUpdates(false)
+                            // Default value: false. Warning: risk of secret leak in console if the build fails
+                            suppressLogs(true)
+                            unstableBuildNeutral(false)
+                        }
                         gitHubTagDiscovery()
                         cloneOptionTrait {
                           extension {


### PR DESCRIPTION
Avoid secret leaks when build fails