### PR TITLE
fix(infra.ci) correct the scope of the netlify token 

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -233,15 +233,15 @@ jobsDefinition:
     name: Website Jobs
     description: "Folder hosting all the Website jobs"
     kind: folder
+    credentials:
+      netlify-auth-token:
+        description: "Auth token to communicate with netlify"
+        secret: "${NETLIFY_AUTH_TOKEN}"
     children:
       jenkins.io:
         name: Jenkins.io
         description: "Jenkins.io Website"
         allowUntrustedChanges: true
-        credentials:
-          netlify-auth-token:
-            description: "Auth token to communicate with netlify"
-            secret: "${NETLIFY_AUTH_TOKEN}"
       jenkins-is-the-way:
         name: Jenkins Is The Way
         description: "Jenkins Is The Way Website"


### PR DESCRIPTION
to allow plugin-site and jenkins.is.the.way jobs to succeed.

Consequence of https://github.com/jenkins-infra/helpdesk/issues/2840.