### PR TITLE
feat(infra.ci) initial import of jenkins-infra/infra-report jobs 

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -123,6 +123,61 @@ jobsDefinition:
       jenkins-wiki-exporter:
         name: Wiki Exporter
         jenkinsfilePath: Jenkinsfile
+  reports:
+    name: Reports
+    description: Folder hosting all the reporting tasks jobs
+    kind: folder
+    children:
+      artifactory-users-report:
+        name: "Artifactory Users Report"
+        repository: "infra-reports"
+        jenkinsfilePath: "artifactory-users-report/Jenkinsfile"
+        credentials:
+          artifactoryAdmin:
+            description: "Artifactory API for updating permissions"
+            username: "${ARTIFACTORY_API_INFRA_REPORTS_USERNAME}"
+            usernameSecret: true
+            password: "${ARTIFACTORY_API_INFRA_REPORTS_PASSWORD}"
+      fork-report:
+        name: "GitHub Forks Report"
+        repository: "infra-reports"
+        jenkinsfilePath: "fork-report/Jenkinsfile"
+        credentials:
+          jenkins-infra-reports:
+            description: "Github App installed on jenkinsci org for https://github.com/jenkins-infra/infra-reports scripts"
+            appId: "${GITHUB_APP_JENKINSCI_INFRA_REPORTS_ID}"
+            owner: "jenkinsci"
+            privateKey: "${GITHUB_APP_JENKINSCI_INFRA_REPORTS_PRIVATE_KEY}"
+      jira-users-report:
+        name: "Jira Users Report"
+        repository: "infra-reports"
+        jenkinsfilePath: "jira-users-report/Jenkinsfile"
+        credentials:
+          jiraAuth:
+            description: "Credentials (curl <user>:<password>) for the infra-reports LDAP user to access Jira"
+            username: "${JIRA_API_INFRA_REPORTS_USERNAME}"
+            usernameSecret: true
+            password: "${JIRA_API_INFRA_REPORTS_PASSWORD}"
+      maintainers-info-report:
+        name: "Maintainers Jira Info"
+        repository: "infra-reports"
+        jenkinsfilePath: "maintainers-info-report/Jenkinsfile"
+        credentials:
+          jiraAuth:
+            description: "Credentials (curl <user>:<password>) for the infra-reports LDAP user to access Jira"
+            username: "${JIRA_API_INFRA_REPORTS_USERNAME}"
+            usernameSecret: true
+            password: "${JIRA_API_INFRA_REPORTS_PASSWORD}"
+      permissions-report:
+        name: "Maintainers Jira Info"
+        repository: "infra-reports"
+        jenkinsfilePath: "permissions-report/Jenkinsfile"
+        credentials:
+          jenkins-infra-reports:
+            description: "Github App installed on jenkinsci org for https://github.com/jenkins-infra/infra-reports scripts"
+            appID: "${GITHUB_APP_JENKINSCI_INFRA_REPORTS_ID}"
+            owner: "jenkinsci"
+            privateKey: "${GITHUB_APP_JENKINSCI_INFRA_REPORTS_PRIVATE_KEY}"
   terraform-jobs:
     name: Terraform Jobs
     description: Folder hosting all the Terraform-related jobs

--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -45,10 +45,10 @@ jobsDefinition:
       packer-images:
         name: Packer Images
         credentials:
-          packer-aws-access-key-id:
+          packer-aws-access-key-id: &packer-aws-access-key-id-def
             description: AWS API key for the account ci-packer
             secret: "${CI_PACKER_AWS_ACCESS_KEY_ID}"
-          packer-aws-secret-access-key:
+          packer-aws-secret-access-key: &packer-aws-secret-access-key-def
             description: AWS Secret key for the account ci-packer
             secret: "${CI_PACKER_AWS_SECRET_ACCESS_KEY}"
           packer-azure-serviceprincipal:
@@ -79,13 +79,9 @@ jobsDefinition:
             secret: "${SOPS_TENANT_ID}"
             description: Azure tenant id used by sops to decrypt secrets
           # Used by updatecli to retrieve AMIs
-          packer-aws-access-key-id:
-            description: AWS API key for the account ci-packer
-            secret: "${CI_PACKER_AWS_ACCESS_KEY_ID}"
+          packer-aws-access-key-id: *packer-aws-access-key-id-def
           # Used by updatecli to retrieve AMIs
-          packer-aws-secret-access-key:
-            description: AWS Secret key for the account ci-packer
-            secret: "${CI_PACKER_AWS_SECRET_ACCESS_KEY}"
+          packer-aws-secret-access-key: *packer-aws-secret-access-key-def
           production-terraform-digitalocean-pat:
             secret: "${PRODUCTION_TERRAFORM_DIGITALOCEAN_PAT}"
             description: "Digital Ocean PAT for production"
@@ -143,7 +139,7 @@ jobsDefinition:
         repository: "infra-reports"
         jenkinsfilePath: "fork-report/Jenkinsfile"
         credentials:
-          jenkins-infra-reports:
+          jenkins-infra-reports: &jenkins-infra-reports-def
             description: "Github App installed on jenkinsci org for https://github.com/jenkins-infra/infra-reports scripts"
             appId: "${GITHUB_APP_JENKINSCI_INFRA_REPORTS_ID}"
             owner: "jenkinsci"
@@ -173,11 +169,7 @@ jobsDefinition:
         repository: "infra-reports"
         jenkinsfilePath: "permissions-report/Jenkinsfile"
         credentials:
-          jenkins-infra-reports:
-            description: "Github App installed on jenkinsci org for https://github.com/jenkins-infra/infra-reports scripts"
-            appID: "${GITHUB_APP_JENKINSCI_INFRA_REPORTS_ID}"
-            owner: "jenkinsci"
-            privateKey: "${GITHUB_APP_JENKINSCI_INFRA_REPORTS_PRIVATE_KEY}"
+          jenkins-infra-reports: *jenkins-infra-reports-def
   terraform-jobs:
     name: Terraform Jobs
     description: Folder hosting all the Terraform-related jobs


### PR DESCRIPTION
This PR is part of https://github.com/jenkins-infra/helpdesk/issues/2789.

Requirements:

- [x] implement the type "githubApp" of credential in the helm-chart `jenkins-infra/jenkins-jobs` - https://github.com/jenkins-infra/helm-charts/issues/109
- [x] deploy the new jenkins-infra/jenkins-jobs" helm chart with the githubapp support - #2168
- [x] insert credentials into SOPS from trusted.ci.jenkins.io
- [x] cleanup SOPS unused credentials 


It creates a new folder with 5 sub-jobs (multibranch jobs), each one for 1 kind of report. The pipeline https://github.com/jenkins-infra/infra-reports/blob/master/Jenkinsfile#L51 will be split in an upcoming PR.
