### PR TITLE
debug: disable health probes until a first instance is running

### DIFF
--- a/config/ext_jenkins-weekly.yaml
+++ b/config/ext_jenkins-weekly.yaml
@@ -28,6 +28,7 @@ controller:
     requests:
       cpu: "2"
       memory: "4Gi"
+  healthProbes: false
   probes:
     startupProbe:
       initialDelaySeconds: 120


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/2855#issuecomment-1089042558