### PR TITLE
chore: add cluster name in one stage name

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -89,7 +89,7 @@ pipeline {
         AWS_SHARED_CREDENTIALS_FILE       = credentials('eks_charter_awsconfig')
       }
         stages {
-          stage('Prepare Environment'){
+          stage('Prepare Environment for "${K8S_CLUSTER}"'){
             steps {
               // Retrieve the private repository holding the SOPS encrypted YAML secrets into the local directory "./secrets"
               dir ('secrets'){


### PR DESCRIPTION
As the "matrix" label is cut when displayed in Blue Ocean