### PR TITLE
feat(infra.ci) add the azure storage key required for publishing reports from infra-reports

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -123,6 +123,10 @@ jobsDefinition:
     name: Reports
     description: Folder hosting all the reporting tasks jobs
     kind: folder
+    credentials:
+      azure-reports-access-key:
+        description: "Azure Storage Key used by infra-reports to publish to a storage bucket"
+        secret: "${AZURE_INFRA_REPORTS_STORAGE_KEY}"
     children:
       artifactory-users-report:
         name: "Artifactory Users Report"


### PR DESCRIPTION
As part of https://github.com/jenkins-infra/helpdesk/issues/2789, the pipeline [library step `publishReports()` has to be allowed from infra.ci](https://github.com/jenkins-infra/pipeline-library/pull/348).

It requires a credential to allow sending the JSON reports into the correct Azure bucket hence the credential to be added.

The scope of this credential is only the folder `infra-reports` of course.