### PR TITLE
fix(weekly.ci.jenkins.io) Finish bootstrap + fix pipeline-library credz

### DIFF
--- a/config/ext_jenkins-weekly.yaml
+++ b/config/ext_jenkins-weekly.yaml
@@ -141,7 +141,7 @@ controller:
     annotations:
       "cert-manager.io/cluster-issuer": "letsencrypt-prod"
       "nginx.ingress.kubernetes.io/proxy-body-size": "500m"
-    ingressClassName: private-nginx
+    ingressClassName: public-nginx
     tls:
       - hosts:
           - weekly.ci.jenkins.io

--- a/config/ext_jenkins-weekly.yaml
+++ b/config/ext_jenkins-weekly.yaml
@@ -41,8 +41,6 @@ controller:
     runAsNonRoot: true
     runAsUser: 1000
     supplementalGroups: [1000]
-    runAsGroup: 1000
-    fsGroup: 1000
     fsGroupChangePolicy: "OnRootMismatch"
   overwritePlugins: true
   serviceType: "ClusterIP"

--- a/config/ext_jenkins-weekly.yaml
+++ b/config/ext_jenkins-weekly.yaml
@@ -28,7 +28,6 @@ controller:
     requests:
       cpu: "2"
       memory: "4Gi"
-  healthProbes: false
   probes:
     startupProbe:
       initialDelaySeconds: 120
@@ -41,7 +40,6 @@ controller:
     runAsNonRoot: true
     runAsUser: 1000
     supplementalGroups: [1000]
-    fsGroupChangePolicy: "OnRootMismatch"
   overwritePlugins: true
   serviceType: "ClusterIP"
   javaOpts: >-

--- a/config/ext_jenkins-weekly.yaml
+++ b/config/ext_jenkins-weekly.yaml
@@ -17,7 +17,7 @@ networkPolicy:
     allowed: true
     namespaceLabels:
       name: "jenkins-weekly"
-systemMessage: "Don't miss the <b> new Design Library</b> here: https://weekly.ci.jenkins.io/design-library"
+systemMessage: "Don't miss the <b>new Design Library</b> here: https://weekly.ci.jenkins.io/design-library"
 controller:
   image: jenkinsciinfra/jenkins-weekly
   tag: 0.52.0-2.342

--- a/config/ext_jenkins-weekly.yaml
+++ b/config/ext_jenkins-weekly.yaml
@@ -99,7 +99,7 @@ controller:
                 modernSCM:
                   scm:
                     git:
-                      id: "github-app-weekly"
+                      credentialsId: "github-app-weekly"
                       remote: "https://github.com/jenkins-infra/pipeline-library.git"
       matrix-settings: |
         jenkins:

--- a/config/ext_jenkins-weekly.yaml
+++ b/config/ext_jenkins-weekly.yaml
@@ -17,7 +17,7 @@ networkPolicy:
     allowed: true
     namespaceLabels:
       name: "jenkins-weekly"
-systemMessage: "Don't miss the Design Library here: https://weekly.ci.jenkins.io/design-library"
+systemMessage: "Don't miss the <b> new Design Library</b> here: https://weekly.ci.jenkins.io/design-library"
 controller:
   image: jenkinsciinfra/jenkins-weekly
   tag: 0.52.0-2.342

--- a/config/ext_jenkins-weekly.yaml
+++ b/config/ext_jenkins-weekly.yaml
@@ -41,6 +41,9 @@ controller:
     runAsNonRoot: true
     runAsUser: 1000
     supplementalGroups: [1000]
+    runAsGroup: 1000
+    fsGroup: 1000
+    fsGroupChangePolicy: "OnRootMismatch"
   overwritePlugins: true
   serviceType: "ClusterIP"
   javaOpts: >-

--- a/config/ext_jenkins-weekly.yaml
+++ b/config/ext_jenkins-weekly.yaml
@@ -17,6 +17,7 @@ networkPolicy:
     allowed: true
     namespaceLabels:
       name: "jenkins-weekly"
+systemMessage: "Don't miss the Design Library here: https://weekly.ci.jenkins.io/design-library"
 controller:
   image: jenkinsciinfra/jenkins-weekly
   tag: 0.52.0-2.342


### PR DESCRIPTION
Fixes "/var/jenkins_config/apply_config.sh: cannot create /var/jenkins_home/jenkins.install.UpgradeWizard.state: Permission denied"

From https://github.com/jenkinsci/helm-charts/issues/210\#issuecomment-916217915

Part of https://github.com/jenkins-infra/helpdesk/issues/2855