### PR TITLE
fix: use new `files` property for updatecli targets of type `file`

### DIFF
--- a/updatecli/updatecli.d/charts/accountapp.yaml
+++ b/updatecli/updatecli.d/charts/accountapp.yaml
@@ -23,7 +23,7 @@ targets:
   updateChartVersion:
     name: "Update the chart version for accountapp"
     kind: file
-    scmID: default
+    scmid: default
     spec:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/accountapp((\r\n|\r|\n)(\s+))version: .*'
@@ -32,7 +32,7 @@ targets:
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/acme.yaml
+++ b/updatecli/updatecli.d/charts/acme.yaml
@@ -29,12 +29,12 @@ targets:
       - clusters/temp-privatek8s.yaml
       matchPattern: 'chart: jenkins-infra\/acme((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/acme${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/acme.yaml
+++ b/updatecli/updatecli.d/charts/acme.yaml
@@ -20,19 +20,13 @@ sources:
       name: acme
 
 targets:
-  updateChartVersionPublic:
+  updateChartVersion:
     name: "Update the chart version for acme"
     kind: file
     spec:
-      file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/acme((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/acme${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
-  updateChartVersionPrivate:
-    name: "Update the chart version for acme"
-    kind: file
-    spec:
-      file: clusters/temp-privatek8s.yaml
+      files:
+      - clusters/prodpublick8s.yaml
+      - clusters/temp-privatek8s.yaml
       matchPattern: 'chart: jenkins-infra\/acme((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/acme${1}version: {{ source `lastChartVersion` }}'
     scmID: default
@@ -42,8 +36,7 @@ pullrequests:
     kind: github
     scmID: default
     targets:
-      - updateChartVersionPublic
-      - updateChartVersionPrivate
+      - updateChartVersion
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/autoscaler.yaml
+++ b/updatecli/updatecli.d/charts/autoscaler.yaml
@@ -23,7 +23,7 @@ targets:
   updateChartVersion:
     name: "autoscaler/cluster-autoscaler Helm Chart"
     kind: file
-    scmID: default
+    scmid: default
     spec:
       file: clusters/cik8s.yaml
       matchPattern: 'chart: autoscaler\/cluster-autoscaler((\r\n|\r|\n)(\s+))version: .*'
@@ -32,7 +32,7 @@ targets:
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/aws-node-termination-handler.yaml
+++ b/updatecli/updatecli.d/charts/aws-node-termination-handler.yaml
@@ -23,7 +23,7 @@ targets:
   updateChartVersion:
     name: "eks/aws-node-termination-handler Helm Chart"
     kind: file
-    scmID: default
+    scmid: default
     spec:
       file: clusters/cik8s.yaml
       matchPattern: 'chart: eks\/aws-node-termination-handler((\r\n|\r|\n)(\s+))version: .*'
@@ -32,7 +32,7 @@ targets:
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/cert-manager.yaml
+++ b/updatecli/updatecli.d/charts/cert-manager.yaml
@@ -20,19 +20,13 @@ sources:
       name: cert-manager
 
 targets:
-  updateChartVersionPublic:
+  updateChartVersion:
     name: "jetstack/cert-manager Helm Chart"
     kind: file
     spec:
-      file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jetstack\/cert-manager((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jetstack/cert-manager${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
-  updateChartVersionPrivate:
-    name: "jetstack/cert-manager Helm Chart"
-    kind: file
-    spec:
-      file: clusters/temp-privatek8s.yaml
+      files:
+      - clusters/prodpublick8s.yaml
+      - clusters/temp-privatek8s.yaml
       matchPattern: 'chart: jetstack\/cert-manager((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jetstack/cert-manager${1}version: {{ source `lastChartVersion` }}'
     scmID: default
@@ -42,9 +36,8 @@ pullrequests:
     kind: github
     scmID: default
     targets:
-      - updateChartVersionPublic
-      - updateChartVersionPrivate
+      - updateChartVersion
     spec:
       labels:
         - dependencies
-        - certmanager
+        - cert-manager

--- a/updatecli/updatecli.d/charts/cert-manager.yaml
+++ b/updatecli/updatecli.d/charts/cert-manager.yaml
@@ -29,12 +29,12 @@ targets:
       - clusters/temp-privatek8s.yaml
       matchPattern: 'chart: jetstack\/cert-manager((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jetstack/cert-manager${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/codecentric-keycloak.yaml
+++ b/updatecli/updatecli.d/charts/codecentric-keycloak.yaml
@@ -23,7 +23,7 @@ targets:
   updateChartVersion:
     name: "codecentric/keycloak Helm Chart"
     kind: file
-    scmID: default
+    scmid: default
     spec:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: codecentric\/keycloak((\r\n|\r|\n)(\s+))version: .*'
@@ -32,7 +32,7 @@ targets:
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/datadog.yaml
+++ b/updatecli/updatecli.d/charts/datadog.yaml
@@ -20,30 +20,15 @@ sources:
       name: datadog
 
 targets:
-  updateProdpublick8s:
+  updateClusters:
     name: "Datadog Helm Chart"
     kind: file
     scmID: default
     spec:
-      file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: datadog\/datadog((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: datadog/datadog${1}version: {{ source `lastChartVersion` }}'
-
-  updateCik8s:
-    name: "Datadog Helm Chart"
-    kind: file
-    scmID: default
-    spec:
-      file: clusters/cik8s.yaml
-      matchPattern: 'chart: datadog\/datadog((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: datadog/datadog${1}version: {{ source `lastChartVersion` }}'
-
-  updateDoks:
-    name: "Datadog Helm Chart"
-    kind: file
-    scmID: default
-    spec:
-      file: clusters/doks.yaml
+      files:
+      - clusters/cik8s.yaml
+      - clusters/doks.yaml
+      - clusters/prodpublick8s.yaml
       matchPattern: 'chart: datadog\/datadog((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: datadog/datadog${1}version: {{ source `lastChartVersion` }}'
 
@@ -52,9 +37,7 @@ pullrequests:
     kind: github
     scmID: default
     targets:
-      - updateProdpublick8s
-      - updateCik8s
-      - updateDoks
+      - updateClusters
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/datadog.yaml
+++ b/updatecli/updatecli.d/charts/datadog.yaml
@@ -23,7 +23,7 @@ targets:
   updateClusters:
     name: "Datadog Helm Chart"
     kind: file
-    scmID: default
+    scmid: default
     spec:
       files:
       - clusters/cik8s.yaml
@@ -35,7 +35,7 @@ targets:
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateClusters
     spec:

--- a/updatecli/updatecli.d/charts/env-jenkins-release.yaml
+++ b/updatecli/updatecli.d/charts/env-jenkins-release.yaml
@@ -23,7 +23,7 @@ targets:
   updateChartVersion:
     name: "Update the chart version for env-jenkins-release"
     kind: file
-    scmID: default
+    scmid: default
     spec:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/env-jenkins-release((\r\n|\r|\n)(\s+))version: .*'
@@ -32,7 +32,7 @@ targets:
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/falco.yaml
+++ b/updatecli/updatecli.d/charts/falco.yaml
@@ -23,7 +23,7 @@ targets:
   updateChartVersion:
     name: "falco/falco Helm Chart"
     kind: file
-    scmID: default
+    scmid: default
     spec:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: falco\/falco((\r\n|\r|\n)(\s+))version: .*'
@@ -32,7 +32,7 @@ targets:
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/grafana-loki.yaml
+++ b/updatecli/updatecli.d/charts/grafana-loki.yaml
@@ -23,7 +23,7 @@ targets:
   updateChartVersion:
     name: "grafana/loki Helm Chart"
     kind: file
-    scmID: default
+    scmid: default
     spec:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: grafana\/loki((\r\n|\r|\n)(\s+))version: .*'
@@ -32,7 +32,7 @@ targets:
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/grafana-promtail.yaml
+++ b/updatecli/updatecli.d/charts/grafana-promtail.yaml
@@ -24,7 +24,7 @@ targets:
   updateChartVersion:
     name: "grafana/promtail Helm Chart"
     kind: file
-    scmID: default
+    scmid: default
     spec:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: grafana\/promtail((\r\n|\r|\n)(\s+))version: .*'
@@ -33,7 +33,7 @@ targets:
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/grafana.yaml
+++ b/updatecli/updatecli.d/charts/grafana.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: grafana\/grafana((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: grafana/grafana${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/incrementals-publisher.yaml
+++ b/updatecli/updatecli.d/charts/incrementals-publisher.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/incrementals-publisher((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/incrementals-publisher${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/ircbot.yaml
+++ b/updatecli/updatecli.d/charts/ircbot.yaml
@@ -23,7 +23,7 @@ targets:
   updateChartVersion:
     name: "Update the chart version for ircbot"
     kind: file
-    scmID: default
+    scmid: default
     spec:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/ircbot((\r\n|\r|\n)(\s+))version: .*'
@@ -32,7 +32,7 @@ targets:
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/javadoc.yaml
+++ b/updatecli/updatecli.d/charts/javadoc.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/javadoc((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/javadoc${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/jenkins-additional.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-additional.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/temp-privatek8s.yaml
       matchPattern: 'chart: jenkins-infra\/jenkins-additional((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/jenkins-additional${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersionPrivate
     spec:

--- a/updatecli/updatecli.d/charts/jenkins-agents-infra-release.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-agents-infra-release.yaml
@@ -71,7 +71,7 @@ targets:
       file: config/ext_jenkins-infra.yaml
       matchPattern: '- ami: ".*"(.*)LINUXAMD64'
       replacePattern: '- ami: "{{ source `getLatestUbuntuAgentAMIAmd64` }}"${1}LINUXAMD64'
-    scmID: default
+    scmid: default
   setUbuntuAgentAMIArm64:
     name: "Bump AMI ID for ARM 64"
     kind: file
@@ -80,7 +80,7 @@ targets:
       file: config/ext_jenkins-infra.yaml
       matchPattern: '- ami: ".*"(.*)LINUXARM64'
       replacePattern: '- ami: "{{ source `getLatestUbuntuAgentAMIArm64` }}"${1}LINUXARM64'
-    scmID: default
+    scmid: default
   setWindowsAgentAMIamd64:
     name: "Bump AMI ID for Windows AMD 64"
     kind: file
@@ -89,12 +89,12 @@ targets:
       file: config/ext_jenkins-infra.yaml
       matchPattern: '- ami: ".*"(.*)WINDOWSAMD64'
       replacePattern: '- ami: "{{ source `getLatestWindowsAgentAMIAmd64` }}"${1}WINDOWSAMD64'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - setUbuntuAgentAMIAmd64
       - setUbuntuAgentAMIArm64

--- a/updatecli/updatecli.d/charts/jenkins-infra-and-release-securitygroups.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-infra-and-release-securitygroups.yaml
@@ -43,7 +43,7 @@ targets:
       file: config/ext_jenkins-infra.yaml
       matchPattern: 'securityGroups: ".*"'
       replacePattern: 'securityGroups: "{{ source `getNewJenkinsInfraSecurityGroup` }}"'
-    scmID: default
+    scmid: default
   setJenkinsReleaseSecurityGroup:
     name: "Bump Release Security Group"
     kind: file
@@ -52,12 +52,12 @@ targets:
       file: config/ext_jenkins-release.yaml
       matchPattern: 'securityGroups: ".*"'
       replacePattern: 'securityGroups: "{{ source `getNewJenkinsReleaseSecurityGroup` }}"'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - setJenkinsInfraSecurityGroup
       - setJenkinsReleaseSecurityGroup

--- a/updatecli/updatecli.d/charts/jenkins-infra-keycloak.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-infra-keycloak.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/keycloak((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/keycloak${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/jenkins-jobs.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-jobs.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/temp-privatek8s.yaml
       matchPattern: 'chart: jenkins-infra\/jenkins-jobs((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/jenkins-jobs${1}version: {{ source "lastChartVersion" }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersionPrivate
     spec:

--- a/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
@@ -1,4 +1,4 @@
-title: "Bump Jenkins Kubernetes Agents Helm Chart Version"
+title: "Bump jenkins-kubernetes-agents Helm Chart Version"
 
 scms:
   default:
@@ -20,19 +20,13 @@ sources:
       name: jenkins-kubernetes-agents
 
 targets:
-  updateCik8sChartVersion:
+  updateChartVersion:
     name: "Update the chart version for jenkins kubernetes agent"
     kind: file
     spec:
-      file: clusters/cik8s.yaml
-      matchPattern: 'chart: jenkins-infra\/jenkins-kubernetes-agents((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/jenkins-kubernetes-agents${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
-  updateDoksChartVersion:
-    name: "Update the chart version for jenkins kubernetes agent"
-    kind: file
-    spec:
-      file: clusters/doks.yaml
+      files:
+      - clusters/cik8s.yaml
+      - clusters/doks.yaml
       matchPattern: 'chart: jenkins-infra\/jenkins-kubernetes-agents((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/jenkins-kubernetes-agents${1}version: {{ source `lastChartVersion` }}'
     scmID: default
@@ -42,8 +36,7 @@ pullrequests:
     kind: github
     scmID: default
     targets:
-      - updateCik8sChartVersion
-      - updateDoksChartVersion
+      - updateChartVersion
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
@@ -29,12 +29,12 @@ targets:
       - clusters/doks.yaml
       matchPattern: 'chart: jenkins-infra\/jenkins-kubernetes-agents((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/jenkins-kubernetes-agents${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/jenkins-wiki-exporter.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-wiki-exporter.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/jenkins-wiki-exporter((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/jenkins-wiki-exporter${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/jenkins.yaml
+++ b/updatecli/updatecli.d/charts/jenkins.yaml
@@ -29,12 +29,12 @@ targets:
       - clusters/temp-privatek8s.yaml
       matchPattern: 'chart: jenkins\/jenkins((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins/jenkins${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/jenkins.yaml
+++ b/updatecli/updatecli.d/charts/jenkins.yaml
@@ -20,19 +20,13 @@ sources:
       name: jenkins
 
 targets:
-  updateReleaseAndWeeklyCIChartVersion:
+  updateChartVersion:
     name: "jenkinsci/jenkins Helm Chart"
     kind: file
     spec:
-      file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins\/jenkins((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins/jenkins${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
-  updateInfraCIChartVersion:
-    name: "jenkinsci/jenkins Helm Chart"
-    kind: file
-    spec:
-      file: clusters/temp-privatek8s.yaml
+      files:
+      - clusters/prodpublick8s.yaml
+      - clusters/temp-privatek8s.yaml
       matchPattern: 'chart: jenkins\/jenkins((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins/jenkins${1}version: {{ source `lastChartVersion` }}'
     scmID: default
@@ -42,8 +36,7 @@ pullrequests:
     kind: github
     scmID: default
     targets:
-      - updateReleaseAndWeeklyCIChartVersion
-      - updateInfraCIChartVersion
+      - updateChartVersion
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/jenkinsio.yaml
+++ b/updatecli/updatecli.d/charts/jenkinsio.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/jenkinsio((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/jenkinsio${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/ldap.yaml
+++ b/updatecli/updatecli.d/charts/ldap.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/ldap((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/ldap${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/mirrorbits.yaml
+++ b/updatecli/updatecli.d/charts/mirrorbits.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/mirrorbits((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/mirrorbits${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/nginx-ingress.yaml
+++ b/updatecli/updatecli.d/charts/nginx-ingress.yaml
@@ -30,12 +30,12 @@ targets:
       - clusters/temp-privatek8s.yaml
       matchPattern: 'chart: ingress-nginx\/ingress-nginx((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: ingress-nginx/ingress-nginx${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/nginx-ingress.yaml
+++ b/updatecli/updatecli.d/charts/nginx-ingress.yaml
@@ -21,19 +21,13 @@ sources:
       name: ingress-nginx
 
 targets:
-  updateChartVersionPublic:
-    name: "Update the version of the Helm chart ingress-nginx for public-ingress"
+  updateChartVersion:
+    name: "Update the version of the Helm chart ingress-nginx"
     kind: file
     spec:
-      file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: ingress-nginx\/ingress-nginx((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: ingress-nginx/ingress-nginx${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
-  updateChartVersionPrivate:
-    name: "Update the version of the Helm chart ingress-nginx for temp-privatek8s"
-    kind: file
-    spec:
-      file: clusters/temp-privatek8s.yaml
+      files:
+      - clusters/prodpublick8s.yaml
+      - clusters/temp-privatek8s.yaml
       matchPattern: 'chart: ingress-nginx\/ingress-nginx((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: ingress-nginx/ingress-nginx${1}version: {{ source `lastChartVersion` }}'
     scmID: default
@@ -43,9 +37,8 @@ pullrequests:
     kind: github
     scmID: default
     targets:
-      - updateChartVersionPublic
-      - updateChartVersionPrivate
+      - updateChartVersion
     spec:
       labels:
         - dependencies
-        - nginx
+        - nginx-ingress

--- a/updatecli/updatecli.d/charts/plugin-site-issues.yaml
+++ b/updatecli/updatecli.d/charts/plugin-site-issues.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/plugin-site-issues((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/plugin-site-issues${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/plugin-site.yaml
+++ b/updatecli/updatecli.d/charts/plugin-site.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/plugin-site((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/plugin-site${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/prometheus.yaml
+++ b/updatecli/updatecli.d/charts/prometheus.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: prometheus-community\/prometheus((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: prometheus-community/prometheus${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/reports.yaml
+++ b/updatecli/updatecli.d/charts/reports.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/reports((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/reports${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/uplink.yaml
+++ b/updatecli/updatecli.d/charts/uplink.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/uplink((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/uplink${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/charts/wiki.yaml
+++ b/updatecli/updatecli.d/charts/wiki.yaml
@@ -27,12 +27,12 @@ targets:
       file: clusters/prodpublick8s.yaml
       matchPattern: 'chart: jenkins-infra\/wiki((\r\n|\r|\n)(\s+))version: .*'
       replacePattern: 'chart: jenkins-infra/wiki${1}version: {{ source `lastChartVersion` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateChartVersion
     spec:

--- a/updatecli/updatecli.d/docker-images/404.yaml
+++ b/updatecli/updatecli.d/docker-images/404.yaml
@@ -39,33 +39,33 @@ targets:
     spec:
       file: "config/ext_private-nginx-ingress.yaml"
       key: "defaultBackend.image.tag"
-    scmID: default
+    scmid: default
   updatePublicNginxIngress404Public:
     name: "Update 404 docker image tag"
     kind: yaml
     spec:
       file: "config/ext_public-nginx-ingress.yaml"
       key: "defaultBackend.image.tag"
-    scmID: default
+    scmid: default
   updatePrivateNginxIngress404Private:
     name: "Update 404 docker image tag"
     kind: yaml
     spec:
       file: "config/temp-privatek8s/ext_private-nginx-ingress.yaml"
       key: "defaultBackend.image.tag"
-    scmID: default
+    scmid: default
   updatePublicNginxIngress404Private:
     name: "Update 404 docker image tag"
     kind: yaml
     spec:
       file: "config/temp-privatek8s/ext_public-nginx-ingress.yaml"
       key: "defaultBackend.image.tag"
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updatePrivateNginxIngress404Public
       - updatePublicNginxIngress404Public

--- a/updatecli/updatecli.d/docker-images/datadog.yaml
+++ b/updatecli/updatecli.d/docker-images/datadog.yaml
@@ -32,12 +32,12 @@ targets:
       file: config/ext_datadog.yaml.gotmpl
       matchPattern: 'repository: "jenkinsciinfra/datadog@sha256"((\r\n|\r|\n)(\s+))tag:.*'
       replacePattern: 'repository: "jenkinsciinfra/datadog@sha256"${1}tag: "{{ source `latestDigest` }}"'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateDigestInConfig
     spec:

--- a/updatecli/updatecli.d/docker-images/jenkins-lts.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-lts.yaml
@@ -39,12 +39,12 @@ targets:
     spec:
       file: "config/ext_jenkins-release.yaml"
       key: "controller.tag"
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateReleaseInConfig
     spec:

--- a/updatecli/updatecli.d/docker-images/jenkins-weekly.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-weekly.yaml
@@ -39,19 +39,19 @@ targets:
     spec:
       file: "config/ext_jenkins-infra.yaml"
       key: "controller.tag"
-    scmID: default
+    scmid: default
   updateReleaseInWeeklyConfig:
     name: "Update jenkinsciinfra/jenkins-weekly docker image tag"
     kind: yaml
     spec:
       file: "config/ext_jenkins-weekly.yaml"
       key: "controller.tag"
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateReleaseInConfig
       - updateReleaseInWeeklyConfig

--- a/updatecli/updatecli.d/docker-images/keycloack-theme.yaml
+++ b/updatecli/updatecli.d/docker-images/keycloack-theme.yaml
@@ -40,12 +40,12 @@ targets:
       file: config/ext_keycloak.yaml
       matchPattern: 'image: jenkinsciinfra/keycloak-theme:.*'
       replacePattern: 'image: jenkinsciinfra/keycloak-theme:{{ source `latestRelease` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateReleaseInConfig
     spec:

--- a/updatecli/updatecli.d/docker-images/nginx.yaml
+++ b/updatecli/updatecli.d/docker-images/nginx.yaml
@@ -21,7 +21,7 @@ sources:
   latestRelease:
     name: Get latest stable version of nginx
     kind: gitTag
-    scmID: nginxGithubMirror
+    scmid: nginxGithubMirror
     spec:
       versionFilter:
         kind: regex
@@ -48,40 +48,40 @@ targets:
     spec:
       file: config/jenkinsio.yaml
       key: images.en.tag
-    scmID: default
+    scmid: default
   updateZHJenkinsio:
     name: "Update nginx:stable docker image version for jenkins.io/zh"
     kind: yaml
     spec:
       file: config/jenkinsio.yaml
       key: images.zh.tag
-    scmID: default
+    scmid: default
   updateJavadoc:
     name: "Update nginx:stable docker image version for javadoc"
     kind: yaml
     spec:
       file: config/javadoc.yaml
       key: image.tag
-    scmID: default
+    scmid: default
   updatePluginsite:
     name: "Update nginx:stable docker image version for plugin-site"
     kind: yaml
     spec:
       file: config/plugin-site.yaml
       key: frontend.image.tag
-    scmID: default
+    scmid: default
   updateReports:
     name: "Update nginx:stable docker image version for reports"
     kind: yaml
     spec:
       file: config/reports.yaml
       key: image.tag
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updateENJenkinsio
       - updateZHJenkinsio

--- a/updatecli/updatecli.d/pod-templates/helmfile.yaml
+++ b/updatecli/updatecli.d/pod-templates/helmfile.yaml
@@ -49,7 +49,7 @@ targets:
     spec:
       file: "PodTemplates.yaml"
       key: spec.containers[0].image
-    scmID: default
+    scmid: default
   updatePipelineImage:
     name: Update docker-helmfile in Jenkinsfile
     kind: file
@@ -60,12 +60,12 @@ targets:
         'jenkinsciinfra/helmfile:(.*)'
       replacepattern: >-
         'jenkinsciinfra/helmfile:{{ source `lastRelease` }}'
-    scmID: default
+    scmid: default
 
 pullrequests:
   default:
     kind: github
-    scmID: default
+    scmid: default
     targets:
       - updatePodImage
       - updatePipelineImage


### PR DESCRIPTION
Since the [release of updatecli version 0.23](https://github.com/updatecli/updatecli/releases/tag/v0.23.0), we can now [specify more than one file as target of version upgrade](https://github.com/updatecli/updatecli/issues/435)