### PR TITLE
fix(jenkinsio) enable again missing security headers 

### DIFF
--- a/config/jenkinsio.yaml
+++ b/config/jenkinsio.yaml
@@ -4,6 +4,9 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "nginx.ingress.kubernetes.io/ssl-redirect": "false"
+    "nginx.ingress.kubernetes.io/configuration-snippet": |
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "X-Frame-Options: DENY";
   hosts:
     - host: jenkins.io
       paths:


### PR DESCRIPTION
This PR closes [jenkins-infra/helpdesk#2553](https://github.com/jenkins-infra/helpdesk/issues/2553).

Since https://github.com/jenkins-infra/kubernetes-management/pull/1724 that fixed the ingress chart upgrade from `4.0.6` to `4.0.8`, the configuration snippets were deleted.

With the last versions of the nginx controller, the snippet annotation is working as expected again, and the protection  against the attacks described by the [CVE-2021-25742](https://github.com/kubernetes/ingress-nginx/issues/7837) are avoided by filtering out some keywords from snippets: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#annotation-value-word-blocklist (alternative is to define the custom headers at the ingress controller installation level through the configmap).


The PR here adds again the 2 security headers that were request a few months ago, but only at the ingress rule level (e.g. in the annotation snippet, only for jenkinsio).

Tested manually:

```
$  curl -v https://www.origin.jenkins.io/doc/ -H "Host: www.jenkins.io" -o /dev/null
# ...
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 200 
< date: Fri, 08 Apr 2022 12:27:35 GMT
< content-type: text/html
< content-length: 27558
< last-modified: Fri, 08 Apr 2022 07:23:20 GMT
< etag: "624fe2e8-6ba6"
< expires: Fri, 08 Apr 2022 13:27:35 GMT
< cache-control: max-age=3600
< cache-control: public
< accept-ranges: bytes
< strict-transport-security: max-age=86400; includeSubDomains; preload
< x-content-type-options: nosniff
< x-frame-options: DENY
```