### PR TITLE
chore(updatecli) manifest fixed for 0.23.1

### DIFF
--- a/updatecli/updatecli.d/charts/accountapp.yaml
+++ b/updatecli/updatecli.d/charts/accountapp.yaml
@@ -26,8 +26,8 @@ targets:
     scmid: default
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/accountapp((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/accountapp${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/accountapp((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/accountapp${1}version: {{ source "lastChartVersion" }}'
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/charts/acme.yaml
+++ b/updatecli/updatecli.d/charts/acme.yaml
@@ -25,10 +25,10 @@ targets:
     kind: file
     spec:
       files:
-      - clusters/prodpublick8s.yaml
-      - clusters/temp-privatek8s.yaml
-      matchPattern: 'chart: jenkins-infra\/acme((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/acme${1}version: {{ source `lastChartVersion` }}'
+        - clusters/prodpublick8s.yaml
+        - clusters/temp-privatek8s.yaml
+      matchpattern: 'chart: jenkins-infra\/acme((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/acme${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/autoscaler.yaml
+++ b/updatecli/updatecli.d/charts/autoscaler.yaml
@@ -26,8 +26,8 @@ targets:
     scmid: default
     spec:
       file: clusters/cik8s.yaml
-      matchPattern: 'chart: autoscaler\/cluster-autoscaler((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: autoscaler/cluster-autoscaler${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: autoscaler\/cluster-autoscaler((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: autoscaler/cluster-autoscaler${1}version: {{ source "lastChartVersion" }}'
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/charts/aws-node-termination-handler.yaml
+++ b/updatecli/updatecli.d/charts/aws-node-termination-handler.yaml
@@ -26,8 +26,8 @@ targets:
     scmid: default
     spec:
       file: clusters/cik8s.yaml
-      matchPattern: 'chart: eks\/aws-node-termination-handler((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: eks/aws-node-termination-handler${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: eks\/aws-node-termination-handler((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: eks/aws-node-termination-handler${1}version: {{ source "lastChartVersion" }}'
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/charts/cert-manager.yaml
+++ b/updatecli/updatecli.d/charts/cert-manager.yaml
@@ -25,10 +25,10 @@ targets:
     kind: file
     spec:
       files:
-      - clusters/prodpublick8s.yaml
-      - clusters/temp-privatek8s.yaml
-      matchPattern: 'chart: jetstack\/cert-manager((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jetstack/cert-manager${1}version: {{ source `lastChartVersion` }}'
+        - clusters/prodpublick8s.yaml
+        - clusters/temp-privatek8s.yaml
+      matchpattern: 'chart: jetstack\/cert-manager((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jetstack/cert-manager${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/codecentric-keycloak.yaml
+++ b/updatecli/updatecli.d/charts/codecentric-keycloak.yaml
@@ -26,8 +26,8 @@ targets:
     scmid: default
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: codecentric\/keycloak((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: codecentric/keycloak${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: codecentric\/keycloak((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: codecentric/keycloak${1}version: {{ source "lastChartVersion" }}'
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/charts/datadog.yaml
+++ b/updatecli/updatecli.d/charts/datadog.yaml
@@ -26,11 +26,11 @@ targets:
     scmid: default
     spec:
       files:
-      - clusters/cik8s.yaml
-      - clusters/doks.yaml
-      - clusters/prodpublick8s.yaml
-      matchPattern: 'chart: datadog\/datadog((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: datadog/datadog${1}version: {{ source `lastChartVersion` }}'
+        - clusters/cik8s.yaml
+        - clusters/doks.yaml
+        - clusters/prodpublick8s.yaml
+      matchpattern: 'chart: datadog\/datadog((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: datadog/datadog${1}version: {{ source "lastChartVersion" }}'
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/charts/env-jenkins-release.yaml
+++ b/updatecli/updatecli.d/charts/env-jenkins-release.yaml
@@ -26,8 +26,8 @@ targets:
     scmid: default
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/env-jenkins-release((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/env-jenkins-release${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/env-jenkins-release((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/env-jenkins-release${1}version: {{ source "lastChartVersion" }}'
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/charts/falco.yaml
+++ b/updatecli/updatecli.d/charts/falco.yaml
@@ -26,8 +26,8 @@ targets:
     scmid: default
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: falco\/falco((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: falco/falco${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: falco\/falco((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: falco/falco${1}version: {{ source "lastChartVersion" }}'
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/charts/grafana-loki.yaml
+++ b/updatecli/updatecli.d/charts/grafana-loki.yaml
@@ -26,8 +26,8 @@ targets:
     scmid: default
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: grafana\/loki((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: grafana/loki${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: grafana\/loki((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: grafana/loki${1}version: {{ source "lastChartVersion" }}'
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/charts/grafana-promtail.yaml
+++ b/updatecli/updatecli.d/charts/grafana-promtail.yaml
@@ -1,4 +1,3 @@
-
 title: Bump promtail helm chart version
 
 scms:
@@ -27,8 +26,8 @@ targets:
     scmid: default
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: grafana\/promtail((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: grafana/promtail${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: grafana\/promtail((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: grafana/promtail${1}version: {{ source "lastChartVersion" }}'
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/charts/grafana.yaml
+++ b/updatecli/updatecli.d/charts/grafana.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: grafana\/grafana((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: grafana/grafana${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: grafana\/grafana((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: grafana/grafana${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/incrementals-publisher.yaml
+++ b/updatecli/updatecli.d/charts/incrementals-publisher.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/incrementals-publisher((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/incrementals-publisher${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/incrementals-publisher((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/incrementals-publisher${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/ircbot.yaml
+++ b/updatecli/updatecli.d/charts/ircbot.yaml
@@ -26,8 +26,8 @@ targets:
     scmid: default
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/ircbot((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/ircbot${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/ircbot((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/ircbot${1}version: {{ source "lastChartVersion" }}'
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/charts/javadoc.yaml
+++ b/updatecli/updatecli.d/charts/javadoc.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/javadoc((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/javadoc${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/javadoc((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/javadoc${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/jenkins-additional.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-additional.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/temp-privatek8s.yaml
-      matchPattern: 'chart: jenkins-infra\/jenkins-additional((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/jenkins-additional${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/jenkins-additional((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/jenkins-additional${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/jenkins-agents-infra-release.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-agents-infra-release.yaml
@@ -66,29 +66,29 @@ targets:
   setUbuntuAgentAMIAmd64:
     name: "Bump AMI ID for AMD 64"
     kind: file
-    sourceID: getLatestUbuntuAgentAMIAmd64
+    sourceid: getLatestUbuntuAgentAMIAmd64
     spec:
       file: config/ext_jenkins-infra.yaml
-      matchPattern: '- ami: ".*"(.*)LINUXAMD64'
-      replacePattern: '- ami: "{{ source `getLatestUbuntuAgentAMIAmd64` }}"${1}LINUXAMD64'
+      matchpattern: '- ami: ".*"(.*)LINUXAMD64'
+      replacepattern: '- ami: "{{ source `getLatestUbuntuAgentAMIAmd64` }}"${1}LINUXAMD64'
     scmid: default
   setUbuntuAgentAMIArm64:
     name: "Bump AMI ID for ARM 64"
     kind: file
-    sourceID: getLatestUbuntuAgentAMIArm64
+    sourceid: getLatestUbuntuAgentAMIArm64
     spec:
       file: config/ext_jenkins-infra.yaml
-      matchPattern: '- ami: ".*"(.*)LINUXARM64'
-      replacePattern: '- ami: "{{ source `getLatestUbuntuAgentAMIArm64` }}"${1}LINUXARM64'
+      matchpattern: '- ami: ".*"(.*)LINUXARM64'
+      replacepattern: '- ami: "{{ source `getLatestUbuntuAgentAMIArm64` }}"${1}LINUXARM64'
     scmid: default
   setWindowsAgentAMIamd64:
     name: "Bump AMI ID for Windows AMD 64"
     kind: file
-    sourceID: getLatestWindowsAgentAMIAmd64
+    sourceid: getLatestWindowsAgentAMIAmd64
     spec:
       file: config/ext_jenkins-infra.yaml
-      matchPattern: '- ami: ".*"(.*)WINDOWSAMD64'
-      replacePattern: '- ami: "{{ source `getLatestWindowsAgentAMIAmd64` }}"${1}WINDOWSAMD64'
+      matchpattern: '- ami: ".*"(.*)WINDOWSAMD64'
+      replacepattern: '- ami: "{{ source `getLatestWindowsAgentAMIAmd64` }}"${1}WINDOWSAMD64'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/jenkins-infra-and-release-securitygroups.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-infra-and-release-securitygroups.yaml
@@ -17,41 +17,41 @@ sources:
     kind: file
     spec:
       file: https://raw.githubusercontent.com/jenkins-infra/aws/main/locals.tf
-      matchPattern: 'aws_security_group.*\["(.*?):'
-    transformers: 
-      - findSubMatch: 
+      matchpattern: 'aws_security_group.*\["(.*?):'
+    transformers:
+      - findSubMatch:
           pattern: 'aws_security_group.*\["(.*?):'
           captureIndex: 1
-      - addPrefix: 'ec2_agents_'
+      - addPrefix: "ec2_agents_"
   getNewJenkinsReleaseSecurityGroup:
     kind: file
     spec:
       file: https://raw.githubusercontent.com/jenkins-infra/aws/main/locals.tf
-      matchPattern: 'aws_security_group.*\[".*", "(.*?):'
-    transformers: 
-      - findSubMatch: 
+      matchpattern: 'aws_security_group.*\[".*", "(.*?):'
+    transformers:
+      - findSubMatch:
           pattern: 'aws_security_group.*\[".*", "(.*?):'
           captureIndex: 1
-      - addPrefix: 'ec2_agents_'
+      - addPrefix: "ec2_agents_"
 
 targets:
   setJenkinsInfraSecurityGroup:
     name: "Bump infra Security Group"
     kind: file
-    sourceID: getNewJenkinsInfraSecurityGroup
+    sourceid: getNewJenkinsInfraSecurityGroup
     spec:
       file: config/ext_jenkins-infra.yaml
-      matchPattern: 'securityGroups: ".*"'
-      replacePattern: 'securityGroups: "{{ source `getNewJenkinsInfraSecurityGroup` }}"'
+      matchpattern: 'securityGroups: ".*"'
+      replacepattern: 'securityGroups: "{{ source `getNewJenkinsInfraSecurityGroup` }}"'
     scmid: default
   setJenkinsReleaseSecurityGroup:
     name: "Bump Release Security Group"
     kind: file
-    sourceID: getNewJenkinsReleaseSecurityGroup
+    sourceid: getNewJenkinsReleaseSecurityGroup
     spec:
       file: config/ext_jenkins-release.yaml
-      matchPattern: 'securityGroups: ".*"'
-      replacePattern: 'securityGroups: "{{ source `getNewJenkinsReleaseSecurityGroup` }}"'
+      matchpattern: 'securityGroups: ".*"'
+      replacepattern: 'securityGroups: "{{ source `getNewJenkinsReleaseSecurityGroup` }}"'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/jenkins-infra-keycloak.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-infra-keycloak.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/keycloak((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/keycloak${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/keycloak((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/keycloak${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/jenkins-jobs.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-jobs.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/temp-privatek8s.yaml
-      matchPattern: 'chart: jenkins-infra\/jenkins-jobs((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/jenkins-jobs${1}version: {{ source "lastChartVersion" }}'
+      matchpattern: 'chart: jenkins-infra\/jenkins-jobs((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/jenkins-jobs${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
@@ -25,10 +25,10 @@ targets:
     kind: file
     spec:
       files:
-      - clusters/cik8s.yaml
-      - clusters/doks.yaml
-      matchPattern: 'chart: jenkins-infra\/jenkins-kubernetes-agents((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/jenkins-kubernetes-agents${1}version: {{ source `lastChartVersion` }}'
+        - clusters/cik8s.yaml
+        - clusters/doks.yaml
+      matchpattern: 'chart: jenkins-infra\/jenkins-kubernetes-agents((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/jenkins-kubernetes-agents${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/jenkins-wiki-exporter.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-wiki-exporter.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/jenkins-wiki-exporter((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/jenkins-wiki-exporter${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/jenkins-wiki-exporter((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/jenkins-wiki-exporter${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/jenkins.yaml
+++ b/updatecli/updatecli.d/charts/jenkins.yaml
@@ -25,10 +25,10 @@ targets:
     kind: file
     spec:
       files:
-      - clusters/prodpublick8s.yaml
-      - clusters/temp-privatek8s.yaml
-      matchPattern: 'chart: jenkins\/jenkins((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins/jenkins${1}version: {{ source `lastChartVersion` }}'
+        - clusters/prodpublick8s.yaml
+        - clusters/temp-privatek8s.yaml
+      matchpattern: 'chart: jenkins\/jenkins((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins/jenkins${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/jenkinsio.yaml
+++ b/updatecli/updatecli.d/charts/jenkinsio.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/jenkinsio((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/jenkinsio${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/jenkinsio((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/jenkinsio${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/ldap.yaml
+++ b/updatecli/updatecli.d/charts/ldap.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/ldap((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/ldap${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/ldap((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/ldap${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/mirrorbits.yaml
+++ b/updatecli/updatecli.d/charts/mirrorbits.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/mirrorbits((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/mirrorbits${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/mirrorbits((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/mirrorbits${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/nginx-ingress.yaml
+++ b/updatecli/updatecli.d/charts/nginx-ingress.yaml
@@ -26,10 +26,10 @@ targets:
     kind: file
     spec:
       files:
-      - clusters/prodpublick8s.yaml
-      - clusters/temp-privatek8s.yaml
-      matchPattern: 'chart: ingress-nginx\/ingress-nginx((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: ingress-nginx/ingress-nginx${1}version: {{ source `lastChartVersion` }}'
+        - clusters/prodpublick8s.yaml
+        - clusters/temp-privatek8s.yaml
+      matchpattern: 'chart: ingress-nginx\/ingress-nginx((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: ingress-nginx/ingress-nginx${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/plugin-site-issues.yaml
+++ b/updatecli/updatecli.d/charts/plugin-site-issues.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/plugin-site-issues((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/plugin-site-issues${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/plugin-site-issues((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/plugin-site-issues${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/plugin-site.yaml
+++ b/updatecli/updatecli.d/charts/plugin-site.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/plugin-site((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/plugin-site${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/plugin-site((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/plugin-site${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/prometheus.yaml
+++ b/updatecli/updatecli.d/charts/prometheus.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: prometheus-community\/prometheus((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: prometheus-community/prometheus${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: prometheus-community\/prometheus((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: prometheus-community/prometheus${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/reports.yaml
+++ b/updatecli/updatecli.d/charts/reports.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/reports((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/reports${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/reports((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/reports${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/uplink.yaml
+++ b/updatecli/updatecli.d/charts/uplink.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/uplink((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/uplink${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/uplink((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/uplink${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/charts/wiki.yaml
+++ b/updatecli/updatecli.d/charts/wiki.yaml
@@ -25,8 +25,8 @@ targets:
     kind: file
     spec:
       file: clusters/prodpublick8s.yaml
-      matchPattern: 'chart: jenkins-infra\/wiki((\r\n|\r|\n)(\s+))version: .*'
-      replacePattern: 'chart: jenkins-infra/wiki${1}version: {{ source `lastChartVersion` }}'
+      matchpattern: 'chart: jenkins-infra\/wiki((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/wiki${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/docker-images/datadog.yaml
+++ b/updatecli/updatecli.d/docker-images/datadog.yaml
@@ -30,8 +30,8 @@ targets:
     kind: file
     spec:
       file: config/ext_datadog.yaml.gotmpl
-      matchPattern: 'repository: "jenkinsciinfra/datadog@sha256"((\r\n|\r|\n)(\s+))tag:.*'
-      replacePattern: 'repository: "jenkinsciinfra/datadog@sha256"${1}tag: "{{ source `latestDigest` }}"'
+      matchpattern: 'repository: "jenkinsciinfra/datadog@sha256"((\r\n|\r|\n)(\s+))tag:.*'
+      replacepattern: 'repository: "jenkinsciinfra/datadog@sha256"${1}tag: "{{ source `latestDigest` }}"'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/docker-images/keycloack-theme.yaml
+++ b/updatecli/updatecli.d/docker-images/keycloack-theme.yaml
@@ -38,8 +38,8 @@ targets:
     kind: file
     spec:
       file: config/ext_keycloak.yaml
-      matchPattern: 'image: jenkinsciinfra/keycloak-theme:.*'
-      replacePattern: 'image: jenkinsciinfra/keycloak-theme:{{ source `latestRelease` }}'
+      matchpattern: "image: jenkinsciinfra/keycloak-theme:.*"
+      replacepattern: 'image: jenkinsciinfra/keycloak-theme:{{ source "latestRelease" }}'
     scmid: default
 
 pullrequests:

--- a/updatecli/updatecli.d/docker-images/nginx.yaml
+++ b/updatecli/updatecli.d/docker-images/nginx.yaml
@@ -35,7 +35,7 @@ conditions:
   checkDockerImagePublished:
     name: "Test nginx:<latest_version> docker image tag"
     kind: dockerImage
-    sourceID: latestRelease
+    sourceid: latestRelease
     spec:
       image: "nginx"
       architecture: amd64

--- a/updatecli/updatecli.d/pod-templates/helmfile.yaml
+++ b/updatecli/updatecli.d/pod-templates/helmfile.yaml
@@ -26,7 +26,7 @@ conditions:
   checkDockerImage:
     name: Ensure that the image "jenkinsciinfra/helmfile:<found_version>" is published
     kind: dockerImage
-    sourceID: lastRelease
+    sourceid: lastRelease
     spec:
       image: "jenkinsciinfra/helmfile"
       ## tag come from the input source


### PR DESCRIPTION
Beetween YAML auto formatting issues + casing of attributes, that was a bunch of manifests to fix.

Please note that we should also use updatecli 0.23.1 (update of docker-helmfile incoming)