### PR TITLE
feat(infra.ci) ensure that all github checks are disabled

### DIFF
--- a/clusters/temp-privatek8s.yaml
+++ b/clusters/temp-privatek8s.yaml
@@ -58,7 +58,7 @@ releases:
   - name: jenkins-jobs
     namespace: jenkins-infra
     chart: jenkins-infra/jenkins-jobs
-    version: 0.2.0
+    version: 0.3.0
     values:
       - "../config/ext_jenkins-infra-jobs.yaml"
   - name: jenkins-infra-additional

--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -132,7 +132,6 @@ jobsDefinition:
         name: "Artifactory Users Report"
         repository: "infra-reports"
         jenkinsfilePath: "artifactory-users-report/Jenkinsfile"
-        disableGitHubChecks: true ## Only build status, no more
         credentials:
           artifactoryAdmin:
             description: "Artifactory API for updating permissions"
@@ -143,7 +142,6 @@ jobsDefinition:
         name: "GitHub Forks Report"
         repository: "infra-reports"
         jenkinsfilePath: "fork-report/Jenkinsfile"
-        disableGitHubChecks: true ## Only build status, no more
         credentials:
           jenkins-infra-reports:
             description: "Github App installed on jenkinsci org for https://github.com/jenkins-infra/infra-reports scripts"
@@ -154,7 +152,6 @@ jobsDefinition:
         name: "Jira Users Report"
         repository: "infra-reports"
         jenkinsfilePath: "jira-users-report/Jenkinsfile"
-        disableGitHubChecks: true ## Only build status, no more
         credentials:
           jiraAuth:
             description: "Credentials (curl <user>:<password>) for the infra-reports LDAP user to access Jira"
@@ -165,7 +162,6 @@ jobsDefinition:
         name: "Maintainers Jira Infos"
         repository: "infra-reports"
         jenkinsfilePath: "maintainers-info-report/Jenkinsfile"
-        disableGitHubChecks: true ## Only build status, no more
         credentials:
           jiraAuth:
             description: "Credentials (curl <user>:<password>) for the infra-reports LDAP user to access Jira"
@@ -176,7 +172,6 @@ jobsDefinition:
         name: "GitHub Permissions Report"
         repository: "infra-reports"
         jenkinsfilePath: "permissions-report/Jenkinsfile"
-        disableGitHubChecks: true ## Only build status, no more
         credentials:
           githubapp-jenkins-infra-reports-private-key-b64:
             description: "Base64 encoded private key of the Github App installed on jenkinsci org for https://github.com/jenkins-infra/infra-reports scripts"


### PR DESCRIPTION
(Superseeds and closes #2246 )

Ref. https://github.com/jenkins-infra/helpdesk/issues/2884

(edited to answer questions)
This PR introduces the following changes:
- Bump the helm chart jenkins-jobs to [0.3.0](https://github.com/jenkins-infra/helm-charts/releases/tag/jenkins-jobs-0.3.0), which makes github check disabled by default as per https://github.com/jenkins-infra/helm-charts/pull/120
- Cleanup current config to remove the deprecated `disableGitHubChecks` attributes