### PR TITLE
fix(datadog) increase agent updated at the same time during a rolling update

### DIFF
--- a/config/ext_datadog.yaml.gotmpl
+++ b/config/ext_datadog.yaml.gotmpl
@@ -34,6 +34,10 @@ agents:
     # we must skip version test while we use the docker image digest
     doNotCheckTag: true
     pullPolicy: IfNotPresent
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: "33%"
+    type: RollingUpdate
 clusterAgents:
   enabled: true
   metricsProvider:


### PR DESCRIPTION
This PR should fix the (frequent) datadog helm chart errors on datadog on cik8s (AWS EKS) or doks (DigitalOcean).

The error is the chart rolling update (usually when updating the image... each week) reaches a timeout.

Looking at the namespace `datadog` on `cik8s`, it appeared tha datadog agents (members of a daemonset - https://github.com/DataDog/helm-charts/blob/main/charts/datadog/templates/daemonset.yaml) were updated one at a time.

With ~25s to stop, pull, start, be ready per pod, It's fine for a cluster with less than 10 nodes (300s of timeout). But bigger clusters, such as cik8s or doks (when scaled up) are reaching the timeout.


Following the documentations at https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/ and https://github.com/DataDog/helm-charts/tree/main/charts/datadog, this PR increases the maximum amount of datadog agent pods that should be updated at the same time.

- Example for a 15 nodes clusters:
  - Before: 1 node ( int[15/10] = 1) at a time
  - After: 5 nodes ( int[15/3] = 5) at a time