### PR TITLE
Feat(release.ci): adding a dockerhub credential for PULL (warning readonly)

### DIFF
--- a/config/ext_jenkins-release.yaml
+++ b/config/ext_jenkins-release.yaml
@@ -180,6 +180,12 @@ controller:
                     id: "ec2-agents-credentials"
                     scope: SYSTEM
                     secretKey: "${EC2_AWS_SECRET_ACCESS_KEY}"
+                - usernamePassword:
+                    scope: GLOBAL
+                    description: Docker hub credential for release.ci PULL
+                    id: releasecijenkinsio-dockerhub-pull
+                    username: releasecijenkinsio
+                    password: "${DOCKER_HUB_TOKEN_RELEASECI_PULL}"
       agent-settings: |
         jenkins:
           clouds:


### PR DESCRIPTION
as per Helpdesk#2837 
and the runbook (private): https://github.com/jenkins-infra/runbooks/pull/47
sops secret (private): https://github.com/jenkins-infra/charts-secrets/commit/5d25abb25e5d61a98619d4a008ea11ae626ce1f3