### PR TITLE
fix(infra.ci) do not includ shared libraries for pipeline triggers and changelog + add caching

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -314,6 +314,9 @@ controller:
             - defaultVersion: "master"
               implicit: true
               name: "pipeline-library"
+              includeInChangesets: false
+              cachingConfiguration:
+                refreshTimeMinutes: 180
               retriever:
                 modernSCM:
                   scm:


### PR DESCRIPTION
The repository jenkins-infra/pipeline-library is receiving GitHub checks from infra.ci.jenkins.io while there is no job in this controller associated with this project: https://github.com/jenkins-infra/pipeline-library/runs/6290480632.

These checks are referencing builds that are using the shared library such as https://infra.ci.jenkins.io/job/website-jobs/job/jenkins.io/job/PR-5106/3/.

The build details shows that the pipeline-library changelog is cumulated with the code of the built project itself:

<img width="1014" alt="Capture d’écran 2022-05-05 à 11 12 20" src="https://user-images.githubusercontent.com/1522731/166894469-3c2b7d74-2c48-4579-8a49-0a497aa12727.png">

There are no logs related to the pipeline-library in the multibranch events of the job, neither on the Scan repository log (but I don't know if it would be the case).


This PR is an attempt to fix these "unwanted" checks, and a formal fix for the performance of infra.ci, by:

- Changing the default behavior of the shared library to "NOT include in build changelogs and NO trigger"
  - If one of our job requires coupling with the shared library, the annotation `@Library(value="pipeline-library@master", changelog=true) `. That would make the requirement explicit for these (eventual) projects and would revert the previous behavior Only for this job.
- Add caching with a 180 min TTL
  - Cache can be manually cleaned up on the admin of the controller. 