### PR TITLE
feat(mirrors) enforce HTTPS + handle former domain

### DIFF
--- a/config/mirrorbits.yaml
+++ b/config/mirrorbits.yaml
@@ -33,6 +33,11 @@ ingress:
         - path: /
           serviceNameSuffix: files
         - path: /.*[.](deb|hpi|war|rpm|msi|pkg|sha256|md5sum|zip|gz|pdf|json|svg|sh|jpeg|ico|png|html)$
+    - host: mirrors.jenkins-ci.org
+      paths:
+        - path: /
+          serviceNameSuffix: files
+        - path: /.*[.](deb|hpi|war|rpm|msi|pkg|sha256|md5sum|zip|gz|pdf|json|svg|sh|jpeg|ico|png|html)$
     - host: fallback.get.jenkins.io
       paths:
         - path: /
@@ -42,6 +47,7 @@ ingress:
       hosts:
         - get.jenkins.io
         - mirrors.jenkins.io
+        - mirrors.jenkins-ci.org
         - fallback.get.jenkins.io
 repository:
   name: mirrorbits-binary

--- a/config/mirrorbits.yaml
+++ b/config/mirrorbits.yaml
@@ -21,7 +21,7 @@ ingress:
   className: public-nginx
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
-    "nginx.ingress.kubernetes.io/ssl-redirect": "false"
+    "nginx.ingress.kubernetes.io/ssl-redirect": "true"
   hosts:
     - host: get.jenkins.io
       paths:


### PR DESCRIPTION
As part of https://github.com/jenkins-infra/helpdesk/issues/2888:

- Enforce HTTPS on mirrors (all domains)
- handle requests from the domain mirrors.jenkins-ci.org