### PR TITLE
fix(jenkinsistheway-redirect) ensure that the URL context is kept during redirection

### DIFF
--- a/config/jenkinsisthewayio.yaml
+++ b/config/jenkinsisthewayio.yaml
@@ -1,3 +1,4 @@
-urlredirect: https://stories.jenkins.io/
 host: jenkinsistheway.io
 ingressClassName: public-nginx
+# https://nginx.org/en/docs/http/ngx_http_core_module.html#var_request_uri => contains both the uri and the query string. Implies smarter redirects.
+urlredirect: https://stories.jenkins.io$request_uri


### PR DESCRIPTION
With this change, the whole original URL context (URI and query string) is kept during redirection:

```console
curl --silent -verbose --output /dev/null -H 'Host: jenkinsistheway.io' "https://rating.jenkins.io/something?foo=bar"
# ...
> GET /something?foo=bar HTTP/2
> Host: jenkinsistheway.io
# ...
< HTTP/2 308 
# ...
< location: https://stories.jenkins.io/something?foo=bar
```

instead of being redirected straight to https://stories.jenkins.io/


**Implementation detail**

- Nginx provides a variables `$request_uri` documented at https://nginx.org/en/docs/http/ngx_http_core_module.html#var_request_uri
- The nginx ingress annotation `permanent-redirect` that we use documented at https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#permanent-redirect) generates an nginx configuration with `return` instruction (ref. https://github.com/kubernetes/ingress-nginx/blob/30809c066cd027079cbb32dccc8a101d6fbffdcb/test/e2e/annotations/redirect.go#L49 as example through tests).
- The Nginx `return` instruction (documented at https://nginx.org/en/docs/http/ngx_http_rewrite_module.html#return) accepts the variables such as `$ request_uri`: https://www.nginx.com/blog/creating-nginx-rewrite-rules/ 