### PR TITLE
chore: manually bump Windows 2019 EC2 agent template

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -235,7 +235,7 @@ controller:
                     value: "infra.ci.jenkins.io"
                   type: T4gMedium
                   useEphemeralDevices: true
-                - ami: "ami-0fd9f983884cd5f9a" # https://github.com/jenkins-infra/packer-images/ WINDOWSAMD64 (DO NOT DELETE OR EDIT THIS COMMENT, USED BY UPDATECLI: https://github.com/jenkins-infra/kubernetes-management/blob/cd7e4132eef4095ca287e8c17b284d3c04234cb4/updatecli/updatecli.d/charts/jenkins-agents-infra-release.yaml#L91)
+                - ami: "ami-0a2cc0502e057c183" # https://github.com/jenkins-infra/packer-images/ WINDOWSAMD64 (DO NOT DELETE OR EDIT THIS COMMENT, USED BY UPDATECLI: https://github.com/jenkins-infra/kubernetes-management/blob/cd7e4132eef4095ca287e8c17b284d3c04234cb4/updatecli/updatecli.d/charts/jenkins-agents-infra-release.yaml#L91)
                   amiOwners: "200564066411"
                   amiType:
                     unixData:

--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -235,7 +235,7 @@ controller:
                     value: "infra.ci.jenkins.io"
                   type: T4gMedium
                   useEphemeralDevices: true
-                - ami: "ami-0a2cc0502e057c183" # https://github.com/jenkins-infra/packer-images/ WINDOWSAMD64 (DO NOT DELETE OR EDIT THIS COMMENT, USED BY UPDATECLI: https://github.com/jenkins-infra/kubernetes-management/blob/cd7e4132eef4095ca287e8c17b284d3c04234cb4/updatecli/updatecli.d/charts/jenkins-agents-infra-release.yaml#L91)
+                - ami: "ami-06ba6f5c6bc6bb2d5" # https://github.com/jenkins-infra/packer-images/ WINDOWSAMD64 (DO NOT DELETE OR EDIT THIS COMMENT, USED BY UPDATECLI: https://github.com/jenkins-infra/kubernetes-management/blob/cd7e4132eef4095ca287e8c17b284d3c04234cb4/updatecli/updatecli.d/charts/jenkins-agents-infra-release.yaml#L91)
                   amiOwners: "200564066411"
                   amiType:
                     unixData:


### PR DESCRIPTION
Trying to make [this build](https://infra.ci.jenkins.io/job/docker-jobs/job/docker-inbound-agents/job/PR-24/10/console) pass, it seems hadolint isn't executed (?)

Retrieved the ami id from the last successfull build here: https://infra.ci.jenkins.io/job/infra-tools/job/packer-images/job/main/114/console