### PR TITLE
fix: revert jenkinsUrl

### DIFF
--- a/config/ext_jenkins-release.yaml
+++ b/config/ext_jenkins-release.yaml
@@ -191,7 +191,7 @@ controller:
           clouds:
             - kubernetes:
                 containerCapStr: "100"
-                jenkinsUrl: "http://default-release-jenkins.svc.cluster.local:8080"
+                jenkinsUrl: "http://default-release-jenkins:8080"
                 maxRequestsPerHostStr: "300"
                 webSocket: true
                 name: "kubernetes"


### PR DESCRIPTION
Revert the change introduced in https://github.com/jenkins-infra/kubernetes-management/pull/2468 which prevented agent to connect to the controller on release.ci.jenkins.io (cf https://release.ci.jenkins.io/job/core/job/weekly/job/release/job/master/135/console)