### PR TITLE
feat(oracle): add credentials secrets in jenkins for oracle terraform

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -286,41 +286,41 @@ jobsDefinition:
             description: "Terraform backend configuration for the production environment of jenkins-infra/fastly"
             secretBytes: "${base64:${PRODUCTION_TERRAFORM_FASTLY_BACKEND_CONFIG}}"
       oracle:
-        name: Terraform ORACLE
-        description: ORACLE resources managed by Terraform
+        name: Terraform Oracle
+        description: Oracle resources managed by Terraform
         credentials:
           staging_oracle_oci_cli_user:
             secret: "${STAGING_ORACLE_OCI_CLI_USER}"
-            description: "ORACLE access USER for the staging terraform account for jenkins-infra/oracle"
+            description: "Oracle access user for the staging terraform account for jenkins-infra/oracle"
           staging_oracle_oci_cli_fingerprint:
             secret: "${STAGING_ORACLE_OCI_CLI_FINGERPRINT}"
-            description: "ORACLE fingerkey for the staging terraform account for jenkins-infra/oracle"
+            description: "Oracle fingerkey for the staging terraform account for jenkins-infra/oracle"
           staging_oracle_oci_cli_key_content:
             secret: "${STAGING_ORACLE_OCI_CLI_KEY_CONTENT}"
-            description: "ORACLE secret key for the staging terraform account for jenkins-infra/oracle"
+            description: "Oracle secret key for the staging terraform account for jenkins-infra/oracle"
           staging_terraform_oracle_backend_config:
             fileName: backend-config
             description: "Terraform backend configuration for the staging environment of jenkins-infra/oracle"
             secretBytes: "${base64:${STAGING_TERRAFORM_ORACLE_BACKEND_CONFIG}}"
           production_oracle_oci_cli_user:
             secret: "${PRODUCTION_ORACLE_OCI_CLI_USER}"
-            description: "ORACLE access user for the staging terraform account for jenkins-infra/oracle"
+            description: "Oracle access user for the production terraform account for jenkins-infra/oracle"
           production_oracle_oci_cli_fingerprint:
             secret: "${PRODUCTION_ORACLE_OCI_CLI_FINGERPRINT}"
-            description: "ORACLE fingerkey for the staging terraform account for jenkins-infra/oracle"
+            description: "Oracle fingerkey for the production terraform account for jenkins-infra/oracle"
           production_oracle_oci_cli_key_content:
             secret: "${PRODUCTION_ORACLE_OCI_CLI_KEY_CONTENT}"
-            description: "ORACLE secret key for the staging terraform account for jenkins-infra/oracle"
+            description: "Oracle secret key for the production terraform account for jenkins-infra/oracle"
           production_terraform_oracle_backend_config:
             fileName: backend-config
-            description: "Terraform backend configuration for the staging environment of jenkins-infra/oracle"
+            description: "Terraform backend configuration for the production environment of jenkins-infra/oracle"
             secretBytes: "${base64:${PRODUCTION_TERRAFORM_ORACLE_BACKEND_CONFIG}}"
           oracle_oci_cli_tenancy:
             secret: "${ORACLE_OCI_CLI_TENANCY}"
-            description: "ORACLE tenant OCI for the terraform account for jenkins-infra/oracle"
+            description: "Oracle tenant OCI for the terraform account for jenkins-infra/oracle"
           oracle_oci_cli_region:
             secret: "${ORACLE_OCI_CLI_REGION}"
-            description: "ORACLE region OCI for the terraform account for jenkins-infra/oracle"
+            description: "Oracle region OCI for the terraform account for jenkins-infra/oracle"
   website-jobs:
     name: Website Jobs
     description: "Folder hosting all the Website jobs"


### PR DESCRIPTION
add jenkins credentials to use for oracle terraform project.
blocked by the merge of the secrets from sops

Related to https://github.com/jenkins-infra/helpdesk/issues/2973