### PR TITLE
hotfix(jenkinsisthewayio-redirect) bump httpredirector chart from 0.2.0 to 0.3.0

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -256,7 +256,7 @@ releases:
   - name: jenkinsisthewayio-redirect
     namespace: jenkinsisthewayio-redirector
     chart: jenkins-infra/httpredirector
-    version: 0.2.0
+    version: 0.3.0
     needs:
       - public-nginx-ingress/public-nginx-ingress # Required to expose both the UI and the webhooks endpoint
     values:


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/2943
