### PR TITLE
fix(weekly.ci): correct place to store the description

### DIFF
--- a/config/ext_jenkins-weekly.yaml
+++ b/config/ext_jenkins-weekly.yaml
@@ -17,10 +17,6 @@ networkPolicy:
     allowed: true
     namespaceLabels:
       name: "jenkins-weekly"
-primaryView:
-  all:
-    description: "<div style=\"width: 100%; display: flex;justify-content: center;\">\r\n    <div style=\"text-align: center;\">\r\n        <p>\r\n            <img alt=\"Design Library\" src=\"https://raw.githubusercontent.com/jenkinsci/design-library-plugin/master/logo.svg\" height=\"100\" width=\"280\" />\r\n        </p>\r\n    </div>\r\n    <p style=\"font-size: 18px;\"><a href=\"/design-library/\" rel=\"nofollow\">Design Library</a> makes it easy for developers to build complex and consistent interfaces using Jenkins UI components.</p>\r\n</div>\r\n"
-    name: "all"
 controller:
   image: jenkinsciinfra/jenkins-weekly
   tag: 0.63.0-2.356
@@ -129,6 +125,10 @@ controller:
           quietPeriod: 0 # No need to wait between build scheduling
           disabledAdministrativeMonitors:
             - "jenkins.security.QueueItemAuthenticatorMonitor"
+        views:
+          - all:
+            description: "<div style=\"width: 100%; display: flex;justify-content: center;\">\r\n    <div style=\"text-align: center;\">\r\n        <p>\r\n            <img alt=\"Design Library\" src=\"https://raw.githubusercontent.com/jenkinsci/design-library-plugin/master/logo.svg\" height=\"100\" width=\"280\" />\r\n        </p>\r\n    </div>\r\n    <p style=\"font-size: 18px;\"><a href=\"/design-library/\" rel=\"nofollow\">Design Library</a> makes it easy for developers to build complex and consistent interfaces using Jenkins UI components.</p>\r\n</div>\r\n"
+            name: "all"
   sidecars:
     configAutoReload:
       env:


### PR DESCRIPTION
Testing different combinations, we determined the `primaryView` wasn't in the correct section of the Jenkins helm chart values.yaml file (not in the `jcasc` section), but also its value wasn't sufficient to be taken in account.
Even more, it's the `views.-all` parameter (and only this one) which has to be set so the text could be displayed.
By setting this parameter, when we look at the resulting JCasc export, we can see the `primaryView` has been set too, with the same value:

Setting both values isn't working in the sense the `primaryView` submitted value will be overwritten by the `view.-all` one.
(I don't understand the goal of this, or why the `primaryView` isn't just a reference to the `views.-all`)

Fixes https://github.com/jenkins-infra/helpdesk/issues/2999