### PR TITLE
feat(infra.ci) add compartment ID for oracle terraform project

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -291,38 +291,44 @@ jobsDefinition:
         credentials:
           staging_oracle_oci_cli_user:
             secret: "${STAGING_ORACLE_OCI_CLI_USER}"
-            description: "Oracle access user for the staging terraform account for jenkins-infra/oracle"
+            description: "Oracle ID of terraform user account for the staging environment on jenkins-infra/oracle"
           staging_oracle_oci_cli_fingerprint:
             secret: "${STAGING_ORACLE_OCI_CLI_FINGERPRINT}"
-            description: "Oracle fingerkey for the staging terraform account for jenkins-infra/oracle"
+            description: "Oracle fingerkey of the API PEM key for the staging environment on jenkins-infra/oracle"
+          staging_oracle_oci_compartment_id:
+            secret: "${STAGING_ORACLE_OCI_COMPARTMENT_ID}"
+            description: "Oracle ID of the compartment for the staging environment on jenkins-infra/oracle"
           staging_oracle_oci_cli_key_content:
             username: "key"
             privateKey: "${STAGING_ORACLE_OCI_CLI_KEY_CONTENT}"
-            description: "Oracle secret key for the staging terraform account for jenkins-infra/oracle"
+            description: "Oracle secret API PEM key for the staging environment on jenkins-infra/oracle"
           staging_terraform_oracle_backend_config:
             fileName: backend-config
-            description: "Terraform backend configuration for the staging environment of jenkins-infra/oracle"
+            description: "Terraform backend configuration of the staging environment of jenkins-infra/oracle"
             secretBytes: "${base64:${STAGING_TERRAFORM_ORACLE_BACKEND_CONFIG}}"
           production_oracle_oci_cli_user:
             secret: "${PRODUCTION_ORACLE_OCI_CLI_USER}"
-            description: "Oracle access user for the production terraform account for jenkins-infra/oracle"
+            description: "Oracle ID of terraform user account for the production environment on jenkins-infra/oracle"
           production_oracle_oci_cli_fingerprint:
             secret: "${PRODUCTION_ORACLE_OCI_CLI_FINGERPRINT}"
-            description: "Oracle fingerkey for the production terraform account for jenkins-infra/oracle"
+            description: "Oracle fingerkey of the API PEM key for the production environment on jenkins-infra/oracle"
+          production_oracle_oci_compartment_id:
+            secret: "${PRODUCTION_ORACLE_OCI_COMPARTMENT_ID}"
+            description: "Oracle ID of the compartment for the production environment on jenkins-infra/oracle"
           production_oracle_oci_cli_key_content:
             username: "key"
             privateKey: "${PRODUCTION_ORACLE_OCI_CLI_KEY_CONTENT}"
-            description: "Oracle secret key for the production terraform account for jenkins-infra/oracle"
+            description: "Oracle secret API PEM key for the production environment on jenkins-infra/oracle"
           production_terraform_oracle_backend_config:
             fileName: backend-config
             description: "Terraform backend configuration for the production environment of jenkins-infra/oracle"
             secretBytes: "${base64:${PRODUCTION_TERRAFORM_ORACLE_BACKEND_CONFIG}}"
           oracle_oci_cli_tenancy:
             secret: "${ORACLE_OCI_CLI_TENANCY}"
-            description: "Oracle tenant OCI for the terraform account for jenkins-infra/oracle"
+            description: "Oracle ID of the tenant for jenkins-infra/oracle"
           oracle_oci_cli_region:
             secret: "${ORACLE_OCI_CLI_REGION}"
-            description: "Oracle region OCI for the terraform account for jenkins-infra/oracle"
+            description: "Oracle Region name for jenkins-infra/oracle"
   website-jobs:
     name: Website Jobs
     description: "Folder hosting all the Website jobs"


### PR DESCRIPTION
This PR adds 2 new credentials for the terraform oracle project, holding the Oracle ID for the 2 compartments.

Required to make https://github.com/jenkins-infra/oracle/pull/8 work as expected