### PR TITLE
feat(infra.ci) add a new job for jenkins-infra/jenkins-infra

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -58,6 +58,9 @@ jobsDefinition:
             description: "Azure Service Principal credential used by packer"
             subscriptionId: "${PACKER_AZURE_SUBSCRIPTION_ID}"
             tenant: "${PACKER_AZURE_TENANT_ID}"
+      jenkins-infra:
+        name: Puppet (jenkins-infra)
+        jenkinsfilePath: Jenkinsfile
       shared-tools:
         name: Shared Tools
   kubernetes-jobs:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/jenkins-infra/issues/2248

The reason to use infra.ci is that our checks are vital for the infra, but they are coliding with development jobs.