### PR TITLE
feat(infra.ci) defaults pipeline to use bash interpreter

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -339,10 +339,12 @@ controller:
                 - "GROUP:Overall/Administer:jenkins-admins"
                 - "GROUP:Overall/Read:authenticated"
                 - "GROUP:Overall/SystemRead:authenticated"
-      timestamper-settings: |
+      pipeline-settings: |
         unclassified:
           timestamper:
             allPipelines: true
+          shell:
+            shell: "/bin/bash"
       system-settings: |
         unclassified:
           defaultFolderConfiguration:


### PR DESCRIPTION
This PR allows infra.ci.jenkins.io to use `asdf` on the Linux nodes by default.

The default shell for the [`sh` pipeline instruction)(https://www.jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#sh-shell-script) is `/bin/sh` unless you [specify another shebang](https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/client-and-managed-masters/how-do-i-run-a-different-shell-interpreter-in-a-pipeline-script).

But this leads to many errors because of all possibilities that Groovy provides:

```groovy
/** Failures **/

sh '''
#!/bin/bash
asdf --version
'''

sh '#!/bin/bash asdf --version'

/** Successes **/
sh '''\
#!/bin/bash
asdf --version
'''

sh '''#!/bin/bash
asdf --version
'''
 // ... same with double quotes
```

As the infra team controls all agent images (VMs and containers) for infra.ci.jenkins.io, this PR defines `/bin/bash` as the default shell.
If we have a specific Alpine/busybox instance with no `bash` binary installed, then we'll adapt their pipeline (but that would be a edge case).