### PR TITLE
fix(infra.ci.jenkins.io): setup datadog agent on temp-privatek8s

### DIFF
--- a/clusters/cik8s.yaml
+++ b/clusters/cik8s.yaml
@@ -33,7 +33,7 @@ releases:
       - "../config/ext_datadog.yaml.gotmpl"
       - "../config/ext_cik8s-datadog.yaml"
     secrets:
-      - "../secrets/config/datadog/secrets.yaml"
+      - "../secrets/config/datadog/cik8s-secrets.yaml"
   - name: jenkins-agents
     needs:
       - default/docker-registry-secrets

--- a/clusters/doks.yaml
+++ b/clusters/doks.yaml
@@ -1,17 +1,3 @@
-templates:
-  default: &default
-    chart: stable/{{`{{ .Release.Name }}`}}
-    namespace: kube-system
-    # This prevents helmfile exiting when it encounters a missing file
-    # Valid values are "Error", "Warn", "Info", "Debug". The default is "Error"
-    # Use "Debug" to make missing files errors invisible at the default log level(--log-level=INFO)
-    missingFileHandler: Warn
-    values:
-    - config/{{`{{ .Release.Name }}`}}/values.yaml
-    - config/{{`{{ .Release.Name }}`}}/{{`{{ .Environment.Name }}`}}.yaml
-    secrets:
-    - config/{{`{{ .Release.Name }}`}}/secrets.yaml
-    - config/{{`{{ .Release.Name }}`}}/{{`{{ .Environment.Name }}`}}-secrets.yaml
 helmDefaults:
   atomic: true
   force: false
@@ -38,7 +24,7 @@ releases:
       - default/docker-registry-secrets
     namespace: datadog
     chart: datadog/datadog
-    version: 2.36.1
+    version: 2.36.4
     values:
       - "../config/ext_datadog.yaml.gotmpl"
       - "../config/ext_doks-datadog.yaml"

--- a/clusters/doks.yaml
+++ b/clusters/doks.yaml
@@ -1,3 +1,17 @@
+templates:
+  default: &default
+    chart: stable/{{`{{ .Release.Name }}`}}
+    namespace: kube-system
+    # This prevents helmfile exiting when it encounters a missing file
+    # Valid values are "Error", "Warn", "Info", "Debug". The default is "Error"
+    # Use "Debug" to make missing files errors invisible at the default log level(--log-level=INFO)
+    missingFileHandler: Warn
+    values:
+    - config/{{`{{ .Release.Name }}`}}/values.yaml
+    - config/{{`{{ .Release.Name }}`}}/{{`{{ .Environment.Name }}`}}.yaml
+    secrets:
+    - config/{{`{{ .Release.Name }}`}}/secrets.yaml
+    - config/{{`{{ .Release.Name }}`}}/{{`{{ .Environment.Name }}`}}-secrets.yaml
 helmDefaults:
   atomic: true
   force: false
@@ -24,12 +38,12 @@ releases:
       - default/docker-registry-secrets
     namespace: datadog
     chart: datadog/datadog
-    version: 2.36.4
+    version: 2.36.1
     values:
       - "../config/ext_datadog.yaml.gotmpl"
       - "../config/ext_doks-datadog.yaml"
     secrets:
-      - "../secrets/config/datadog/secrets.yaml"
+      - "../secrets/config/datadog/doks-secrets.yaml"
   - name: jenkins-agents
     needs:
       - default/docker-registry-secrets

--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -32,7 +32,7 @@ releases:
       - "../config/ext_datadog.yaml.gotmpl"
       - "../config/ext_publick8s-datadog.yaml"
     secrets:
-      - "../secrets/config/datadog/secrets.yaml"
+      - "../secrets/config/datadog/prodpublick8s-secrets.yaml"
   - name: public-nginx-ingress
     namespace: public-nginx-ingress
     chart: ingress-nginx/ingress-nginx

--- a/clusters/temp-privatek8s.yaml
+++ b/clusters/temp-privatek8s.yaml
@@ -4,22 +4,17 @@ helmDefaults:
   timeout: 300
   wait: true
 repositories:
+  - name: datadog
+    url: https://helm.datadoghq.com
+  - name: ingress-nginx
+    url: https://kubernetes.github.io/ingress-nginx
   - name: jenkins
     url: https://charts.jenkins.io
   - name: jenkins-infra
     url: https://jenkins-infra.github.io/helm-charts
-  - name: ingress-nginx
-    url: https://kubernetes.github.io/ingress-nginx
   - name: jetstack
     url: https://charts.jetstack.io
 releases:
-  - name: cert-manager
-    namespace: cert-manager
-    chart: jetstack/cert-manager
-    version: v1.8.2
-    set:
-      - name: installCRDs
-        value: true
   - name: acme
     namespace: cert-manager
     chart: jenkins-infra/acme
@@ -30,18 +25,23 @@ releases:
       - "../config/acme.yaml"
     secrets:
       - "../secrets/config/acme/secrets.yaml"
-  - name: public-nginx-ingress
-    namespace: public-nginx-ingress
-    chart: ingress-nginx/ingress-nginx
-    version: 4.1.4
+  - name: cert-manager
+    namespace: cert-manager
+    chart: jetstack/cert-manager
+    version: v1.8.2
+    set:
+      - name: installCRDs
+        value: true
+  - name: datadog
+    namespace: datadog
+    chart: datadog/datadog
+    version: 2.36.4
+    timeout: 840 # Should be <= 14 min (because the job runs every 15 min)
     values:
-      - "../config/temp-privatek8s/ext_public-nginx-ingress.yaml"
-  - name: private-nginx-ingress
-    namespace: private-nginx-ingress
-    chart: ingress-nginx/ingress-nginx
-    version: 4.1.4
-    values:
-      - "../config/temp-privatek8s/ext_private-nginx-ingress.yaml"
+      - "../config/ext_datadog.yaml.gotmpl"
+      - "../config/ext_temp-privatek8s-datadog.yaml"
+    secrets:
+      - "../secrets/config/datadog/temp-privatek8s-secrets.yaml"
   - name: jenkins-infra
     namespace: jenkins-infra
     chart: jenkins/jenkins
@@ -55,15 +55,27 @@ releases:
       - "../config/ext_jenkins-infra.yaml"
     secrets:
       - "../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml"
-  - name: jenkins-jobs
-    namespace: jenkins-infra
-    chart: jenkins-infra/jenkins-jobs
-    version: 0.4.0
-    values:
-      - "../config/ext_jenkins-infra-jobs.yaml"
   - name: jenkins-infra-additional
     namespace: jenkins-infra
     chart: jenkins-infra/jenkins-additional
     version: 0.0.3
     values:
       - ../config/jenkins-infra-additional.yaml
+  - name: jenkins-jobs
+    namespace: jenkins-infra
+    chart: jenkins-infra/jenkins-jobs
+    version: 0.4.0
+    values:
+      - "../config/ext_jenkins-infra-jobs.yaml"
+  - name: public-nginx-ingress
+    namespace: public-nginx-ingress
+    chart: ingress-nginx/ingress-nginx
+    version: 4.1.4
+    values:
+      - "../config/temp-privatek8s/ext_public-nginx-ingress.yaml"
+  - name: private-nginx-ingress
+    namespace: private-nginx-ingress
+    chart: ingress-nginx/ingress-nginx
+    version: 4.1.4
+    values:
+      - "../config/temp-privatek8s/ext_private-nginx-ingress.yaml"

--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -95,6 +95,11 @@ controller:
                     id: "ec2-agents-credentials"
                     scope: SYSTEM
                     secretKey: "${EC2_AWS_SECRET_ACCESS_KEY}"
+                - string:
+                    description: "Datadog API key for infra.ci.jenkins.io"
+                    id: "datadog-api-key-infra-ci-jenkins-io"
+                    secret: "${DATADOG_API_KEY_INFRA_CI_JENKINS_IO}"
+                    scope: GLOBAL
       agent-settings: |
         jenkins:
           numExecutors: 0
@@ -354,6 +359,24 @@ controller:
           quietPeriod: 0 # No need to wait between build scheduling
           disabledAdministrativeMonitors:
             - "jenkins.security.QueueItemAuthenticatorMonitor"
+      datadog: |
+        unclassified:
+          datadogGlobalConfiguration:
+            ciInstanceName: "infra-ci-jenkins-io"
+            collectBuildLogs: false
+            emitConfigChangeEvents: false
+            emitSecurityEvents: true
+            emitSystemEvents: true
+            enableCiVisibility: false
+            refreshDogstatsdClient: false
+            reportWith: "HTTP"
+            retryLogs: true
+            targetApiURL: "https://api.datadoghq.com/api/"
+            targetHost: "localhost"
+            targetLogIntakeURL: "https://http-intake.logs.datadoghq.com/v1/input/"
+            targetPort: 8125
+            targetCredentialsApiKey: "datadog-api-key-infra-ci-jenkins-io"
+
   sidecars:
     configAutoReload:
       env:

--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -95,11 +95,6 @@ controller:
                     id: "ec2-agents-credentials"
                     scope: SYSTEM
                     secretKey: "${EC2_AWS_SECRET_ACCESS_KEY}"
-                - string:
-                    description: "Datadog API key for infra.ci.jenkins.io"
-                    id: "datadog-api-key-infra-ci-jenkins-io"
-                    secret: "${DATADOG_API_KEY_INFRA_CI_JENKINS_IO}"
-                    scope: GLOBAL
       agent-settings: |
         jenkins:
           numExecutors: 0

--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -369,13 +369,10 @@ controller:
             emitSystemEvents: true
             enableCiVisibility: false
             refreshDogstatsdClient: false
-            reportWith: "HTTP"
+            reportWith: "DSD"
             retryLogs: true
-            targetApiURL: "https://api.datadoghq.com/api/"
-            targetHost: "localhost"
-            targetLogIntakeURL: "https://http-intake.logs.datadoghq.com/v1/input/"
+            targetHost: "datadog.datadog.svc.cluster.local"
             targetPort: 8125
-            targetCredentialsApiKey: "datadog-api-key-infra-ci-jenkins-io"
 
   sidecars:
     configAutoReload:

--- a/config/ext_temp-privatek8s-datadog.yaml
+++ b/config/ext_temp-privatek8s-datadog.yaml
@@ -1,0 +1,8 @@
+datadog:
+  clusterName: 'temp-privatek8s'
+  kubelet:
+    host:
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    hostCAPath: /etc/kubernetes/certs/kubeletserver.crt

--- a/updatecli/updatecli.d/charts/datadog.yaml
+++ b/updatecli/updatecli.d/charts/datadog.yaml
@@ -29,6 +29,7 @@ targets:
         - clusters/cik8s.yaml
         - clusters/doks.yaml
         - clusters/prodpublick8s.yaml
+        - clusters/temp-privatek8s.yaml
       matchpattern: 'chart: datadog\/datadog((\r\n|\r|\n)(\s+))version: .*'
       replacepattern: 'chart: datadog/datadog${1}version: {{ source "lastChartVersion" }}'
 


### PR DESCRIPTION
Supersedes #2625 by setting up a datadog agent with its own API key on temp-privatek8s and configure it in the corresponding datadog jcasc

Datadog API keys created for temp-privatek8s, cik8s and doks, then added in chart-secrets

Ref: jenkins-infra/helpdesk#2804