### PR TITLE
Revert "[updatecli] Bump datadog helm chart"

### DIFF
--- a/clusters/cik8s.yaml
+++ b/clusters/cik8s.yaml
@@ -28,7 +28,7 @@ releases:
       - default/docker-registry-secrets
     namespace: datadog
     chart: datadog/datadog
-    version: 2.36.7
+    version: 2.36.6
     values:
       - "../config/ext_datadog.yaml.gotmpl"
       - "../config/ext_cik8s-datadog.yaml"

--- a/clusters/doks.yaml
+++ b/clusters/doks.yaml
@@ -24,7 +24,7 @@ releases:
       - default/docker-registry-secrets
     namespace: datadog
     chart: datadog/datadog
-    version: 2.36.7
+    version: 2.36.6
     values:
       - "../config/ext_datadog.yaml.gotmpl"
       - "../config/ext_doks-datadog.yaml"

--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -28,7 +28,7 @@ releases:
   - name: datadog
     namespace: datadog
     chart: datadog/datadog
-    version: 2.36.7
+    version: 2.36.6
     timeout: 840 # Should be <= 14 min (because the job runs every 15 min)
     values:
       - "../config/ext_datadog.yaml.gotmpl"

--- a/clusters/temp-privatek8s.yaml
+++ b/clusters/temp-privatek8s.yaml
@@ -35,7 +35,7 @@ releases:
   - name: datadog
     namespace: datadog
     chart: datadog/datadog
-    version: 2.36.7
+    version: 2.36.6
     timeout: 840 # Should be <= 14 min (because the job runs every 15 min)
     values:
       - "../config/ext_datadog.yaml.gotmpl"


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#2647

```
FAILED RELEASES:
NAME
datadog
in clusters/temp-privatek8s.yaml: failed processing release datadog: command "/usr/local/bin/helm" exited with non-zero status:

PATH:
  /usr/local/bin/helm

ARGS:
  0: helm (4 bytes)
  1: upgrade (7 bytes)
  2: --install (9 bytes)
  3: --reset-values (14 bytes)
  4: datadog (7 bytes)
  5: datadog/datadog (15 bytes)
  6: --version (9 bytes)
  7: 2.36.6 (6 bytes)
  8: --wait (6 bytes)
  9: --timeout (9 bytes)
  10: 840s (4 bytes)
  11: --atomic (8 bytes)
  12: --create-namespace (18 bytes)
  13: --namespace (11 bytes)
  14: datadog (7 bytes)
  15: --values (8 bytes)
  16: /var/folders/z6/xykmq_m902n_7v4j8sxhzkdm0000gn/T/helmfile1657383346/datadog-datadog-values-7bc995f5b6 (101 bytes)
  17: --values (8 bytes)
  18: /var/folders/z6/xykmq_m902n_7v4j8sxhzkdm0000gn/T/helmfile2432776013/datadog-datadog-values-7fc567549d (101 bytes)
  19: --values (8 bytes)
  20: /var/folders/z6/xykmq_m902n_7v4j8sxhzkdm0000gn/T/helmfile1507995679/datadog-datadog-values-547797459d (101 bytes)
  21: --history-max (13 bytes)
  22: 10 (2 bytes)

ERROR:
  exit status 1

EXIT STATUS
  1

STDERR:
  Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress

COMBINED OUTPUT:
  Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress
```