### PR TITLE
Revert "Revert "[updatecli] Bump datadog helm chart""

### DIFF
--- a/clusters/cik8s.yaml
+++ b/clusters/cik8s.yaml
@@ -28,7 +28,7 @@ releases:
       - default/docker-registry-secrets
     namespace: datadog
     chart: datadog/datadog
-    version: 2.36.6
+    version: 2.36.7
     values:
       - "../config/ext_datadog.yaml.gotmpl"
       - "../config/ext_cik8s-datadog.yaml"

--- a/clusters/doks.yaml
+++ b/clusters/doks.yaml
@@ -24,7 +24,7 @@ releases:
       - default/docker-registry-secrets
     namespace: datadog
     chart: datadog/datadog
-    version: 2.36.6
+    version: 2.36.7
     values:
       - "../config/ext_datadog.yaml.gotmpl"
       - "../config/ext_doks-datadog.yaml"

--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -28,7 +28,7 @@ releases:
   - name: datadog
     namespace: datadog
     chart: datadog/datadog
-    version: 2.36.6
+    version: 2.36.7
     timeout: 840 # Should be <= 14 min (because the job runs every 15 min)
     values:
       - "../config/ext_datadog.yaml.gotmpl"

--- a/clusters/temp-privatek8s.yaml
+++ b/clusters/temp-privatek8s.yaml
@@ -35,7 +35,7 @@ releases:
   - name: datadog
     namespace: datadog
     chart: datadog/datadog
-    version: 2.36.6
+    version: 2.36.7
     timeout: 840 # Should be <= 14 min (because the job runs every 15 min)
     values:
       - "../config/ext_datadog.yaml.gotmpl"


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#2649

Manually applied this last datadog release on temp-privatek8s