### PR TITLE
fix(loki) ensure that a CSI disk is used instead of default (re-creates a new pod)

### DIFF
--- a/config/ext_loki.yaml
+++ b/config/ext_loki.yaml
@@ -1,4 +1,3 @@
-# https://github.com/grafana/loki/blob/master/production/helm/loki/values.yaml
 resources:
   limits:
     cpu: 200m
@@ -6,17 +5,9 @@ resources:
   requests:
     cpu: 200m
     memory: 1024Mi
-
-## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-## If you set enabled as "True", you need :
-## - create a pv which above 10Gi and has same namespace with loki
-## - keep storageClassName same with below setting
 persistence:
   enabled: true
   accessModes:
     - ReadWriteOnce
   size: 500Gi
-  storageClassName: default
-  annotations: {}
-  # subPath: ""
-  # existingClaim:
+  storageClassName: managed-csi


### PR DESCRIPTION
The latest loki upgrade is failing without any change.

The errors on the cluster are related to the volume unable to be mounted/unmounted which also causes timeouts.

First step to unblock: currently deleting the PV (with the data: we don't use loki for real) and re-creating it thanks to this change as a managed-csi disk.