### PR TITLE
fix(datadog) ensure log collection is enabled + feat(infra.ci.jenkins.io) enable datadog traces collection

### DIFF
--- a/config/ext_datadog.yaml.gotmpl
+++ b/config/ext_datadog.yaml.gotmpl
@@ -11,7 +11,7 @@ datadog:
     processCollection: true
   logs:
     enabled: true
-    configContainerCollectAll: true
+    containerCollectAll: true
   {{- if .Values }}
   {{- if hasKey .Values.datadog "kubelet" }}
   kubelet:

--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -395,17 +395,25 @@ controller:
       datadog: |
         unclassified:
           datadogGlobalConfiguration:
-            ciInstanceName: "infra-ci-jenkins-io"
+            ciInstanceName: "infra.ci.jenkins.io"
             collectBuildLogs: false
-            emitConfigChangeEvents: false
+            # Send events on configuration changes to jobs or changes to jenkins. These events include changes by the system which may be frequent and redundant.
+            emitConfigChangeEvents: true
             emitSecurityEvents: true
             emitSystemEvents: true
-            enableCiVisibility: false
-            refreshDogstatsdClient: false
+            enableCiVisibility: true
+            hostname: "infra.ci.jenkins.io"
+            # A list of tags to apply globally to all submissions.
+            globalTags: "controller:infra.ci.jenkins.io"
+            # Refresh Dogstatsd Client when your agent IP changes
+            refreshDogstatsdClient: true
             reportWith: "DSD"
             retryLogs: true
+            targetApiURL: "https://api.datadoghq.com/api/"
             targetHost: "datadog.datadog.svc.cluster.local"
+            targetLogIntakeURL: "https://http-intake.logs.datadoghq.com/v1/input/"
             targetPort: 8125
+            targetTraceCollectionPort: 8126
   sidecars:
     configAutoReload:
       env:


### PR DESCRIPTION
Follow up of  https://github.com/jenkins-infra/helpdesk/issues/2804, this PR:

- Fix a typo in the datadog chart's value (all cluster) to ensure that logs collection is enabled on the datadog agents
- Enable traces collection in infra.ci.jenkins.io through datadog agent


(edited) N.B:

Log collection in the Jenkins datadog plugin was not enabled because it blocks all controller threads if logs cannot be collected.

Tried with https://plugins.jenkins.io/datadog/#plugin-content-log-collection-for-agents mentions a custom log source file to add to the datadog agent. That one might not be present in our current setup resulting in error messages on infra.ci.jenkins.io until we find the correct setup (by switching to official datadog image instead of ours)

=> we might want to fine tune this in the future if we want log collection (or not using datadog plugin for collecting build logs).