### PR TITLE
fix(release.ci, infra.ci) Set git SSH host key verification to manually provided list and add github.com SSH ed25519 host key

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -57,6 +57,10 @@ controller:
             approvedSignatures:
               - "method org.jenkinsci.plugins.workflow.steps.FlowInterruptedException getCauses"
               - "new java.lang.RuntimeException java.lang.Throwable"
+          gitHostKeyVerificationConfiguration:
+            sshHostKeyVerificationStrategy:
+              manuallyProvidedKeyVerificationStrategy:
+                approvedHostKeys: "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
       credentials: |
         credentials:
           system:

--- a/config/ext_jenkins-release.yaml
+++ b/config/ext_jenkins-release.yaml
@@ -627,6 +627,11 @@ controller:
           quietPeriod: 0 # No need to wait between build scheduling
           disabledAdministrativeMonitors:
             - "jenkins.security.QueueItemAuthenticatorMonitor"
+        security:
+          gitHostKeyVerificationConfiguration:
+            sshHostKeyVerificationStrategy:
+              manuallyProvidedKeyVerificationStrategy:
+                approvedHostKeys: "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
   sidecars:
     configAutoReload:
       env:


### PR DESCRIPTION
As per https://www.jenkins.io/security/advisory/2022-07-27/#SECURITY-1468, the `git-client` plugin is set by this PR to use a manual list of host key for SSH verification.

Only github.com host key is included.


Documentation of the plugin for this particular feature can be found at: https://github.com/jenkinsci/git-client-plugin#ssh-host-key-verification