### PR TITLE
fix(release.ci,infra.ci) set explicit agent java bin to ensure JDK11

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -127,6 +127,10 @@ controller:
                     containers:
                       - name: jnlp
                         image: "jenkins/inbound-agent:latest-jdk11"
+                        envVars:
+                        - envVar:
+                            key: "JENKINS_JAVA_BIN"
+                            value: "/opt/java/openjdk/bin/java"
                         resourceLimitCpu: "500m"
                         resourceLimitMemory: "512Mi"
                         resourceRequestCpu: "500m"
@@ -178,6 +182,13 @@ controller:
                     containers:
                       - name: jnlp
                         image: "jenkinsciinfra/inbound-agent:windowsservercore-1809"
+                        envVars:
+                        - envVar:
+                            key: "JENKINS_JAVA_BIN"
+                            value: "C:/openjdk-11"
+                        - envVar:
+                            key: "JAVA_HOME"
+                            value: "C:/openjdk-11"
                         command: "powershell"
                         args: "C:/ProgramData/Jenkins/jenkins-agent.ps1"
                         resourceLimitCpu: "1"
@@ -212,6 +223,7 @@ controller:
                   amiType:
                     unixData:
                       sshPort: "22"
+                      slaveCommandPrefix: "PATH=/opt/jdk-11/bin:^${PATH}"
                   associatePublicIp: true
                   connectBySSHProcess: false
                   connectionStrategy: PUBLIC_IP
@@ -247,6 +259,7 @@ controller:
                   amiOwners: "200564066411"
                   amiType:
                     unixData:
+                      slaveCommandPrefix: "PATH=/opt/jdk-11/bin:^${PATH}"
                       sshPort: "22"
                   associatePublicIp: true
                   connectBySSHProcess: false
@@ -283,6 +296,8 @@ controller:
                   amiOwners: "200564066411"
                   amiType:
                     unixData:
+                      # Windows VM agent are not supported yet: https://issues.jenkins.io/browse/JENKINS-69304
+                      # slaveCommandPrefix: "PATH=C:/tools/jdk-11/bin:^${PATH}"
                       sshPort: "22"
                   associatePublicIp: true
                   connectBySSHProcess: false

--- a/config/ext_jenkins-release.yaml
+++ b/config/ext_jenkins-release.yaml
@@ -207,6 +207,10 @@ controller:
                     containers:
                       - name: jnlp
                         image: "jenkins/inbound-agent:latest-jdk11"
+                        envVars:
+                        - envVar:
+                            key: "JENKINS_JAVA_BIN"
+                            value: "/opt/java/openjdk/bin/java"
                         resourceLimitCpu: "500m"
                         resourceLimitMemory: "512Mi"
                         resourceRequestCpu: "500m"
@@ -220,6 +224,13 @@ controller:
                     containers:
                       - name: jnlp
                         image: "jenkinsciinfra/inbound-agent:windowsservercore-1809"
+                        envVars:
+                        - envVar:
+                            key: "JENKINS_JAVA_BIN"
+                            value: "C:/openjdk-11"
+                        - envVar:
+                            key: "JAVA_HOME"
+                            value: "C:/openjdk-11"
                         command: "powershell"
                         args: "C:/ProgramData/Jenkins/jenkins-agent.ps1"
                         resourceLimitCpu: "1"
@@ -253,6 +264,7 @@ controller:
                   amiType:
                     unixData:
                       sshPort: "22"
+                      slaveCommandPrefix: "PATH=/opt/jdk-11/bin:^${PATH}"
                   associatePublicIp: true
                   connectBySSHProcess: false
                   connectionStrategy: PUBLIC_IP
@@ -289,6 +301,7 @@ controller:
                   amiType:
                     unixData:
                       sshPort: "22"
+                      slaveCommandPrefix: "PATH=/opt/jdk-11/bin:^${PATH}"
                   associatePublicIp: true
                   connectBySSHProcess: false
                   connectionStrategy: PUBLIC_IP
@@ -325,6 +338,8 @@ controller:
                   amiType:
                     unixData:
                       sshPort: "22"
+                      # Windows VM agent are not supported yet: https://issues.jenkins.io/browse/JENKINS-69304
+                      # slaveCommandPrefix: "PATH=C:/tools/jdk-11/bin:^${PATH}"
                   associatePublicIp: true
                   connectBySSHProcess: false
                   connectionStrategy: PUBLIC_IP


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3090.

All these agents are *already* using JDK11, but making it explicit will help when switching to JDK17