### PR TITLE
Bump account-app image to 0.0.1 (new tag scheme)

### DIFF
--- a/config/accountapp.yaml
+++ b/config/accountapp.yaml
@@ -1,6 +1,5 @@
 image:
-  # https://github.com/jenkins-infra/kubernetes-management/issues/1668
-  tag: 169-buildca55e3
+  tag: 0.0.1
   pullPolicy: IfNotPresent
 
 ingress:


### PR DESCRIPTION
The goal is to deploy the change https://github.com/jenkins-infra/account-app/pull/136#event-7205302072 to production.

We haven't deployed this app since ages so let's keep an eye.

Note: it benefits from https://github.com/jenkins-infra/kubernetes-management/issues/1668

cc @daniel-beck @wadeck 