### PR TITLE
fix: use antislash for the tempDir on Windows EC2 (`mkdir` fails otherwise)

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -328,7 +328,7 @@ controller:
                   - name: "jenkins"
                     value: "infra.ci.jenkins.io"
                   tenancy: Default
-                  tmpDir: "C:/Temp"                          # Mandatory because EC2 plugins assumes SSH = Unix and searches for /tmp
+                  tmpDir: "C:\\\\Temp"                          # Mandatory because EC2 plugins assumes SSH = Unix and searches for /tmp
                   type: T3Medium
                   useEphemeralDevices: true
       ldap-settings: |


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/kubernetes-management/pull/2721