### PR TITLE
feat(infra.ci) add job definition to build the jenkinsci ATH Docker image

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -35,7 +35,6 @@ jobsDefinition:
       docker-packaging:
       docker-plugin-site-issues:
       docker-plugins-self-service:
-      docker-repo-proxy:
       docker-rsyncd:
       rating:
   infra-tools:

--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -18,6 +18,16 @@ jobsDefinition:
         username: infracijenkinsio
         password: "${DOCKER_HUB_TOKEN_PULL}"
     children:
+      acceptance-test-harness:
+        name: "Jenkins CI Acceptance Test Harness (ATH) Docker Image"
+        jenkinsfilePath: Jenkinsfile.infra.ci.jenkins.io
+        owner: "jenkinsci"
+        credentials:
+          jenkinsci-ath-ghapp:
+            description: "Github App installed on jenkinsci org for https://github.com/jenkinsci/acceptance-test-harness Docker Image build"
+            appId: "${GITHUB_APP_JENKINSCI_ID}"
+            owner: "jenkinsci"
+            privateKey: "${GITHUB_APP_JENKINSCI_PRIVATE_KEY}"
       account-app:
       docker-404:
       docker-builder:


### PR DESCRIPTION
Ref jenkins-infra/helpdesk#3084 

- Job definition added
- A GitHub App is specified to scan/checkout/report checks to the repo but the secrets values are empty for now
- Default configuration applied for now (untrusted contributor cannot change the Jenkinsfile or trigger build)
