### PR TITLE
chore: bump nginx-proxy

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -268,7 +268,7 @@ releases:
   - name: nginx-proxy-azure
     namespace: nginx-proxy-azure
     chart: jenkins-infra/nginx-proxy
-    version: 0.2.1
+    version: 0.2.2
     values:
       - "../config/nginx-proxy-common.yaml"
       - "../config/nginx-proxy-azure.yaml"


### PR DESCRIPTION
Should fix:
> Error: release nginx-proxy-azure failed, and has been uninstalled due to atomic being set: PersistentVolume 'nginx-proxy-azure-pv' is invalid: spec: Required value: must specify a volume type