### PR TITLE
fixup: fix grep instruction

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -95,7 +95,7 @@ pipeline {
                 changeset "config/**"
                 expression {
                     sh(returnStatus: true, script: '''
-                      git status -s | grep --quiet "^${K8S_CLUSTER}/.*"
+                      git status -s | grep "^clusters/${K8S_CLUSTER}.yaml"
                       '''
                     ) == 0
                 }
@@ -116,7 +116,7 @@ pipeline {
                 changeset "config/**"
                 expression {
                     sh(returnStatus: true, script: '''
-                      git status -s | grep --quiet "^${K8S_CLUSTER}/.*"
+                      git status -s | grep "^clusters/${K8S_CLUSTER}.yaml"
                       '''
                     ) == 0
                 }
@@ -134,7 +134,7 @@ pipeline {
                   changeset "config/**"
                   expression {
                       sh(returnStatus: true, script: '''
-                        git status -s | grep --quiet "^${K8S_CLUSTER}/.*"
+                        git status -s | grep "^clusters/${K8S_CLUSTER}.yaml"
                         '''
                       ) == 0
                   }
@@ -160,7 +160,7 @@ pipeline {
                   changeset "config/**"
                   expression {
                       sh(returnStatus: true, script: '''
-                        git status -s | grep --quiet "^${K8S_CLUSTER}/.*"
+                        git status -s | grep "^clusters/${K8S_CLUSTER}.yaml"
                         '''
                       ) == 0
                   }


### PR DESCRIPTION
```
+ grep --quiet '^prodpublick8s/.*'
 + git status -s
 grep: unrecognized option: quiet
 BusyBox v1.35.0 (2022-05-09 17:27:12 UTC) multi-call binary.
```
(And fix the path requested)