### PR TITLE
chore: test another artifact-caching-proxy on another subdomain

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -274,3 +274,12 @@ releases:
       - "../config/artifact-caching-proxy-azure.yaml"
     secrets:
       - "../secrets/config/artifact-caching-proxy/secrets.yaml"
+  - name: artifact-caching-proxy-test
+    namespace: artifact-caching-test
+    chart: jenkins-infra/artifact-caching-proxy
+    version: 0.0.10
+    values:
+      - "../config/artifact-caching-proxy-common.yaml"
+      - "../config/artifact-caching-proxy-test.yaml"
+    secrets:
+      - "../secrets/config/artifact-caching-proxy/secrets.yaml"

--- a/config/artifact-caching-proxy-test.yaml
+++ b/config/artifact-caching-proxy-test.yaml
@@ -9,14 +9,14 @@ ingress:
     nginx.ingress.kubernetes.io/cors-allow-origin: "*"
     nginx.ingress.kubernetes.io/whitelist-source-range: "88.172.134.5/32"
   hosts:
-    - host: repo.azure.jenkins.io
+    - host: repo.test.jenkins.io
       paths:
         - path: /
           pathType: Prefix
   tls:
     - secretName: tls-secret
       hosts:
-        - repo.azure.jenkins.io
+        - repo.test.jenkins.io
 
 persistence:
   storageClass: managed-csi-premium


### PR DESCRIPTION
> too many certificates (5) already issued for this exact set of domains in the last 168 hours: repo.azure.jenkins.io, retry after 2022-09-02T16:52:55Z: see https://letsencrypt.org/docs/duplicate-certificate-limit/'