### PR TITLE
fix: remove datadog release specific timeout

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -29,7 +29,6 @@ releases:
     namespace: datadog
     chart: datadog/datadog
     version: 2.37.9
-    timeout: 840 # Should be <= 14 min (because the job runs every 15 min)
     values:
       - "../config/ext_datadog.yaml.gotmpl"
       - "../config/ext_datadog_publick8s.yaml"

--- a/clusters/temp-privatek8s.yaml
+++ b/clusters/temp-privatek8s.yaml
@@ -36,7 +36,6 @@ releases:
     namespace: datadog
     chart: datadog/datadog
     version: 2.37.9
-    timeout: 840 # Should be <= 14 min (because the job runs every 15 min)
     values:
       - "../config/ext_datadog.yaml.gotmpl"
       - "../config/ext_datadog_temp-privatek8s.yaml"


### PR DESCRIPTION
Was put in place for a previous problem. This timeout causes troubles now as datadog release is frenquently in a bad state:
'Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress'