### PR TITLE
chore(updatecli) fixup of #2828 to correct error messages about the nginx default 404 image manifest

### DIFF
--- a/updatecli/updatecli.d/docker-images/404.yaml
+++ b/updatecli/updatecli.d/docker-images/404.yaml
@@ -60,7 +60,7 @@ targets:
       file: "config/ext_public-nginx-ingress_temp-privatek8s.yaml"
       key: "defaultBackend.image.tag"
     scmid: default
-  updatePublicNginxIngress404DOKS:
+  updatePublicNginxIngress404Doks:
     name: "Update 404 docker image tag"
     kind: yaml
     spec:
@@ -77,6 +77,7 @@ pullrequests:
       - updatePublicNginxIngress404ProdPublicK8s
       - updatePrivateNginxIngress404TempPrivateK8s
       - updatePublicNginxIngress404TempPrivateK8s
+      - updatePublicNginxIngress404Doks
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/docker-images/404.yaml
+++ b/updatecli/updatecli.d/docker-images/404.yaml
@@ -32,32 +32,39 @@ conditions:
       architecture: amd64
 
 targets:
-  updatePrivateNginxIngress404Public:
+  updatePrivateNginxIngress404ProdPublicK8s:
     name: "Update 404 docker image tag"
     kind: yaml
     spec:
-      file: "config/ext_private-nginx-ingress.yaml"
+      file: "config/ext_private-nginx-ingress_prodpublick8s.yaml"
       key: "defaultBackend.image.tag"
     scmid: default
-  updatePublicNginxIngress404Public:
+  updatePublicNginxIngress404ProdPublicK8s:
     name: "Update 404 docker image tag"
     kind: yaml
     spec:
-      file: "config/ext_public-nginx-ingress.yaml"
+      file: "config/ext_public-nginx-ingress_prodpublick8s.yaml"
       key: "defaultBackend.image.tag"
     scmid: default
-  updatePrivateNginxIngress404Private:
+  updatePrivateNginxIngress404TempPrivateK8s:
     name: "Update 404 docker image tag"
     kind: yaml
     spec:
-      file: "config/temp-privatek8s/ext_private-nginx-ingress.yaml"
+      file: "config/ext_private-nginx-ingress_temp-privatek8s.yaml"
       key: "defaultBackend.image.tag"
     scmid: default
-  updatePublicNginxIngress404Private:
+  updatePublicNginxIngress404TempPrivateK8s:
     name: "Update 404 docker image tag"
     kind: yaml
     spec:
-      file: "config/temp-privatek8s/ext_public-nginx-ingress.yaml"
+      file: "config/ext_public-nginx-ingress_temp-privatek8s.yaml"
+      key: "defaultBackend.image.tag"
+    scmid: default
+  updatePublicNginxIngress404DOKS:
+    name: "Update 404 docker image tag"
+    kind: yaml
+    spec:
+      file: "config/ext_public-nginx-ingress_doks.yaml"
       key: "defaultBackend.image.tag"
     scmid: default
 
@@ -66,10 +73,10 @@ pullrequests:
     kind: github
     scmid: default
     targets:
-      - updatePrivateNginxIngress404Public
-      - updatePublicNginxIngress404Public
-      - updatePrivateNginxIngress404Private
-      - updatePublicNginxIngress404Private
+      - updatePrivateNginxIngress404ProdPublicK8s
+      - updatePublicNginxIngress404ProdPublicK8s
+      - updatePrivateNginxIngress404TempPrivateK8s
+      - updatePublicNginxIngress404TempPrivateK8s
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
In #2828 , the nginx ingress configuration files were renamed (and a new one added for the public Doks ingress controller).

This PR fixes the updatecli manifest with these 5 files.