### PR TITLE
feat(datadog) enable HA mode for cluster agent + enable network monitoring

### DIFF
--- a/config/ext_datadog.yaml.gotmpl
+++ b/config/ext_datadog.yaml.gotmpl
@@ -38,9 +38,10 @@ agents:
     rollingUpdate:
       maxUnavailable: "33%"
     type: RollingUpdate
-clusterAgents:
-  enabled: true
+clusterAgent:
   metricsProvider:
     enabled: true
   rbac:
     create: true
+  # Run the clusterAgent in HA mode
+  replicas: 2

--- a/config/ext_datadog.yaml.gotmpl
+++ b/config/ext_datadog.yaml.gotmpl
@@ -12,6 +12,8 @@ datadog:
   logs:
     enabled: true
     containerCollectAll: true
+  networkMonitoring:
+    enabled: true
   {{- if .Values }}
   {{- if hasKey .Values.datadog "kubelet" }}
   kubelet:
@@ -34,6 +36,7 @@ agents:
     # we must skip version test while we use the docker image digest
     doNotCheckTag: true
     pullPolicy: IfNotPresent
+  # The updateStrategy ensures that there are no rollback, even when auto-scalingup/down the clusters (as the agent is deployed as DaemonSet by default)
   updateStrategy:
     rollingUpdate:
       maxUnavailable: "33%"


### PR DESCRIPTION
The logs of the cluster-agent components recommens to run in HA (High Availability) mode. This PR enable the HA mode by setting the amount of replicas to `2` as per https://github.com/DataDog/helm-charts/tree/main/charts/datadog.

It's also the opportunity to enable the network advanced monitoring by datadog (https://github.com/DataDog/helm-charts/tree/main/charts/datadog#enabling-npm-collection).

Please note that we used to set up an incorrect value for the cluster agent: it must be singular form. It was "partially" working because the default value is to have it enabled since months. By fixing this "syntax" error, it means that more datadog components will be created in the helmfile diff.

