### PR TITLE
fixup of 539a517 to ensure full HA mode for datadog cluster-agent

### DIFF
--- a/config/ext_datadog.yaml.gotmpl
+++ b/config/ext_datadog.yaml.gotmpl
@@ -48,3 +48,4 @@ clusterAgent:
     create: true
   # Run the clusterAgent in HA mode
   replicas: 2
+  createPodDisruptionBudget: true


### PR DESCRIPTION
Fixup of #2843 as per the deployment logs of datadog:

```console
[2022-09-08T15:30:24.484Z] 
[2022-09-08T15:30:24.484Z] ###################################################################################
[2022-09-08T15:30:24.484Z] ####   WARNING: Cluster-Agent should be deployed in high availability mode     ####
[2022-09-08T15:30:24.484Z] ###################################################################################
[2022-09-08T15:30:24.484Z] 
[2022-09-08T15:30:24.484Z] The Cluster-Agent should be in high availability mode because the following features
[2022-09-08T15:30:24.484Z] are enabled:
[2022-09-08T15:30:24.484Z] * Admission Controller
[2022-09-08T15:30:24.484Z] 
[2022-09-08T15:30:24.484Z] To run in high availability mode, our recommandation is to update the chart
[2022-09-08T15:30:24.484Z] configuration with:
[2022-09-08T15:30:24.484Z] * set `clusterAgent.replicas` value to `2` replicas .
[2022-09-08T15:30:24.484Z] * set `clusterAgent.createPodDisruptionBudget` to `true`.
```