### PR TITLE
fixup(artifact-caching-proxy): typo in resources.limits.memory

### DIFF
--- a/config/artifact-caching-proxy-common.yaml
+++ b/config/artifact-caching-proxy-common.yaml
@@ -2,7 +2,7 @@
 resources:
   limits:
     cpu: 2
-    memory: 1024MGi
+    memory: 1024Mi
   requests:
     cpu: 2
     memory: 1024Mi


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/kubernetes-management/pull/2842