### PR TITLE
Revert "Bump jenkins-infra helmfile docker image to 2.4.68"

### DIFF
--- a/PodTemplates.yaml
+++ b/PodTemplates.yaml
@@ -32,7 +32,7 @@ spec:
                 values:
                   - highmemlinux
   containers:
-    - image: "jenkinsciinfra/helmfile:2.4.70"
+    - image: "jenkinsciinfra/helmfile:2.4.66"
       imagePullPolicy: "IfNotPresent"
       name: "jnlp"
       resources:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#2879 because it fails during the `helmfile lint` step with:

```console
 ARGS:
[2022-09-14T17:21:06.510Z]   0: helm (4 bytes)
[2022-09-14T17:21:06.510Z]   1: secrets (7 bytes)
[2022-09-14T17:21:06.510Z]   2: view (4 bytes)
[2022-09-14T17:21:06.510Z]   3: /home/jenkins/agent/workspace/_jobs_kubernetes-management_main/secrets/config/docker-registry-secrets/secrets.yaml (114 bytes)
[2022-09-14T17:21:06.510Z] 
[2022-09-14T17:21:06.510Z] ERROR:
[2022-09-14T17:21:06.510Z]   exit status 1
[2022-09-14T17:21:06.510Z] 
[2022-09-14T17:21:06.510Z] EXIT STATUS
[2022-09-14T17:21:06.510Z]   1
[2022-09-14T17:21:06.510Z] 
[2022-09-14T17:21:06.510Z] STDERR:
[2022-09-14T17:21:06.510Z]   Error: unknown command "view" for "helm"
[2022-09-14T17:21:06.510Z]   Run 'helm --help' for usage.
[2022-09-14T17:21:06.510Z]   Error: plugin "secrets" exited with error
[2022-09-14T17:21:06.510Z] 
[2022-09-14T17:21:06.510Z] COMBINED OUTPUT:
[2022-09-14T17:21:06.510Z]   Error: unknown command "view" for "helm"
[2022-09-14T17:21:06.510Z]   Run 'helm --help' for usage.
[2022-09-14T17:21:06.510Z]   Error: plugin "secrets" exited with error
[2022-09-14T17:21:06.510Z] err 1: command "/usr/local/bin/helm" exited with non-zero status:
```