### PR TITLE
fixup: correct Jenkinsfile path for plugin-health-scoring

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -48,6 +48,7 @@ jobsDefinition:
       docker-plugins-self-service:
       docker-rsyncd:
       plugin-health-scoring:
+        jenkinsfilePath: Jenkinsfile
       rating:
   infra-tools:
     name: Infrastructure Tooling Jobs


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/kubernetes-management/pull/2889
Ref: https://github.com/jenkins-infra/helpdesk/issues/3114