### PR TITLE
Revert "fixup: correct Jenkinsfile path for plugin-health-scoring"

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -48,7 +48,6 @@ jobsDefinition:
       docker-plugins-self-service:
       docker-rsyncd:
       plugin-health-scoring:
-        jenkinsfilePath: Jenkinsfile
       rating:
   infra-tools:
     name: Infrastructure Tooling Jobs


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#2899 (not working, still looking for `Jenkinsfile_k8s`)