### PR TITLE
chore: remove artifact-caching-proxy from cik8s

### DIFF
--- a/clusters/cik8s.yaml
+++ b/clusters/cik8s.yaml
@@ -10,8 +10,6 @@ repositories:
     url: https://helm.datadoghq.com
   - name: eks
     url: https://aws.github.io/eks-charts
-  - name: ingress-nginx
-    url: https://kubernetes.github.io/ingress-nginx
   - name: jenkins-infra
     url: https://jenkins-infra.github.io/helm-charts
 releases:
@@ -56,20 +54,3 @@ releases:
     version: 0.19.3
     values:
       - "../config/ext_aws-node-termination-handler.yaml"
-  - name: public-nginx-ingress
-    namespace: public-nginx-ingress
-    chart: ingress-nginx/ingress-nginx
-    version: 4.2.5
-    values:
-      - "../config/ext_public-nginx-ingress_doks.yaml"
-  - name: artifact-caching-proxy-aws
-    namespace: artifact-caching-proxy-aws
-    chart: jenkins-infra/artifact-caching-proxy
-    version: 0.0.13
-    needs:
-      - public-nginx-ingress/public-nginx-ingress # Required to expose the proxy
-    values:
-      - "../config/artifact-caching-proxy__common.yaml"
-      - "../config/artifact-caching-proxy_aws.yaml"
-    secrets:
-      - "../secrets/config/artifact-caching-proxy/secrets.yaml"


### PR DESCRIPTION
Will be deployed on a future public EKS