### PR TITLE
fix: override docker-registry-secrets values to use `datadog` namespace only on doks-public

### DIFF
--- a/clusters/doks-public.yaml
+++ b/clusters/doks-public.yaml
@@ -13,16 +13,6 @@ repositories:
   - name: jetstack
     url: https://charts.jetstack.io
 releases:
-  - name: docker-registry-secrets
-    #this helmchart doesn't create any resources within the namespace specified below.
-    #specifying a namespace is required by the "needs" feature of helmfile (to allow referencing to this release from others)
-    namespace: default
-    chart: jenkins-infra/docker-registry-secrets
-    version: 0.1.0
-    values:
-      - "../config/docker-registry-secrets.yaml"
-    secrets:
-      - "../secrets/config/docker-registry-secrets/secrets.yaml"
   - name: cert-manager
     namespace: cert-manager
     chart: jetstack/cert-manager
@@ -39,8 +29,6 @@ releases:
     values:
       - "../config/acme_doks-public.yaml"
   - name: datadog
-    needs:
-      - default/docker-registry-secrets
     namespace: datadog
     chart: datadog/datadog
     version: 3.1.2

--- a/clusters/doks-public.yaml
+++ b/clusters/doks-public.yaml
@@ -13,6 +13,19 @@ repositories:
   - name: jetstack
     url: https://charts.jetstack.io
 releases:
+  - name: docker-registry-secrets
+    #this helmchart doesn't create any resources within the namespace specified below.
+    #specifying a namespace is required by the "needs" feature of helmfile (to allow referencing to this release from others)
+    namespace: default
+    chart: jenkins-infra/docker-registry-secrets
+    version: 0.1.0
+    values:
+      - imageCredentials:
+          enabled: true
+          namespaces:
+            - datadog
+    secrets:
+      - "../secrets/config/docker-registry-secrets/secrets.yaml"
   - name: cert-manager
     namespace: cert-manager
     chart: jetstack/cert-manager
@@ -32,6 +45,8 @@ releases:
     namespace: datadog
     chart: datadog/datadog
     version: 3.1.2
+    needs:
+      - default/docker-registry-secrets
     values:
       - "../config/ext_datadog.yaml.gotmpl"
       - "../config/ext_datadog_doks-public.yaml"


### PR DESCRIPTION
Not used, and release failed as there isn't any `jenkins-agents` namespace on this cluster.