### PR TITLE
chore(artifact-caching-proxy): increase resources

### DIFF
--- a/config/artifact-caching-proxy__common.yaml
+++ b/config/artifact-caching-proxy__common.yaml
@@ -1,11 +1,11 @@
 # Common values for all nginx-proxies
 resources:
   limits:
-    cpu: 2
-    memory: 1024Mi
+    cpu: 3
+    memory: 6146Mi
   requests:
-    cpu: 2
-    memory: 1024Mi
+    cpu: 3
+    memory: 6146Mi
 
 persistence:
   enabled: true


### PR DESCRIPTION
Node capacity on
- prodpublick8s: Standard_D8s_v3, 8 vCPU 32Go mem
- doks-public: s-4vcpu-8gb, 4 vCPU 8Go mem
- eks-public: t4g.xlarge, 4 vCPU 16Go mem