### PR TITLE
chore: use own datadog `doks-public-secrets`

### DIFF
--- a/clusters/doks-public.yaml
+++ b/clusters/doks-public.yaml
@@ -51,7 +51,7 @@ releases:
       - "../config/ext_datadog.yaml.gotmpl"
       - "../config/ext_datadog_doks-public.yaml"
     secrets:
-      - "../secrets/config/datadog/doks-secrets.yaml"
+      - "../secrets/config/datadog/doks-public-secrets.yaml"
   - name: public-nginx-ingress
     namespace: public-nginx-ingress
     chart: ingress-nginx/ingress-nginx


### PR DESCRIPTION
It's the same credentials in all these datadog secrets, this PR is to be consistent between all clusters.