### PR TITLE
fix: cleanup of all updatecli manifests

### DIFF
--- a/updatecli/updatecli.d/charts/accountapp.yaml
+++ b/updatecli/updatecli.d/charts/accountapp.yaml
@@ -1,4 +1,4 @@
-title: "Bump Account App Helm Chart Version"
+name: "Bump Account App Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: accountapp
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `accountapp` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/acme.yaml
+++ b/updatecli/updatecli.d/charts/acme.yaml
@@ -1,4 +1,4 @@
-title: "Bump Acme Helm Chart Version"
+name: "Bump Acme Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: acme
@@ -36,8 +37,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `acme` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/artifact-caching-proxy.yaml
+++ b/updatecli/updatecli.d/charts/artifact-caching-proxy.yaml
@@ -1,4 +1,4 @@
-title: "Bump `artifact-caching-proxy` helm chart version"
+name: "Bump `artifact-caching-proxy` helm chart version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: artifact-caching-proxy
@@ -36,8 +37,6 @@ pullrequests:
     kind: github
     scmid: default
     title: Bump `artifact-caching-proxy` helm chart version to {{ source `lastChartVersion` }}
-    targets:
-      - updateChartVersion
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/autoscaler.yaml
+++ b/updatecli/updatecli.d/charts/autoscaler.yaml
@@ -1,4 +1,4 @@
-title: Bump autoscaler helm chart version
+name: Bump autoscaler helm chart version
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://kubernetes.github.io/autoscaler
       name: cluster-autoscaler
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `autoscaler` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/aws-node-termination-handler.yaml
+++ b/updatecli/updatecli.d/charts/aws-node-termination-handler.yaml
@@ -1,4 +1,4 @@
-title: Bump aws-node-termination-handler helm chart version
+name: Bump aws-node-termination-handler helm chart version
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://aws.github.io/eks-charts
       name: aws-node-termination-handler
@@ -33,9 +34,8 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `aws-node-termination-handler` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies
-        - aws-node-termination
+        - aws-node-termination-handler

--- a/updatecli/updatecli.d/charts/cert-manager.yaml
+++ b/updatecli/updatecli.d/charts/cert-manager.yaml
@@ -1,4 +1,4 @@
-title: Bump cert-manager helm chart version
+name: Bump cert-manager helm chart version
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://charts.jetstack.io
       name: cert-manager
@@ -35,8 +36,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `cert-manager` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/codecentric-keycloak.yaml
+++ b/updatecli/updatecli.d/charts/codecentric-keycloak.yaml
@@ -1,4 +1,4 @@
-title: Bump keycloak helm chart version
+name: Bump keycloak helm chart version
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://codecentric.github.io/helm-charts
       name: keycloak
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `keycloak` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/datadog.yaml
+++ b/updatecli/updatecli.d/charts/datadog.yaml
@@ -1,4 +1,4 @@
-title: Bump datadog helm chart
+name: Bump datadog helm chart
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://helm.datadoghq.com
       name: datadog
@@ -37,8 +38,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateClusters
+    title: Bump `datadog` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/env-jenkins-release.yaml
+++ b/updatecli/updatecli.d/charts/env-jenkins-release.yaml
@@ -1,4 +1,4 @@
-title: "Bump env-jenkins-release Helm Chart Version"
+name: "Bump env-jenkins-release Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: env-jenkins-release
@@ -33,9 +34,8 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `env-jenkins-release` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies
-        - env-jenkins
+        - env-jenkins-release

--- a/updatecli/updatecli.d/charts/falco.yaml
+++ b/updatecli/updatecli.d/charts/falco.yaml
@@ -1,4 +1,4 @@
-title: Bump falco helm chart version
+name: Bump falco helm chart version
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://falcosecurity.github.io/charts
       name: falco
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `falco` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/github-comment-ops.yaml
+++ b/updatecli/updatecli.d/charts/github-comment-ops.yaml
@@ -1,4 +1,4 @@
-title: "Bump github-comment-ops Helm Chart Version"
+name: "Bump github-comment-ops Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://timja.github.io/github-comment-ops
       name: github-comment-ops
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `github-comment-ops` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/grafana-loki.yaml
+++ b/updatecli/updatecli.d/charts/grafana-loki.yaml
@@ -1,4 +1,4 @@
-title: Bump loki helm chart version
+name: Bump loki helm chart version
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://grafana.github.io/helm-charts
       name: loki
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `loki` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/grafana-promtail.yaml
+++ b/updatecli/updatecli.d/charts/grafana-promtail.yaml
@@ -1,4 +1,4 @@
-title: Bump promtail helm chart version
+name: Bump promtail helm chart version
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://grafana.github.io/helm-charts
       name: promtail
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `promtail` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/grafana.yaml
+++ b/updatecli/updatecli.d/charts/grafana.yaml
@@ -1,4 +1,4 @@
-title: Bump grafana helm chart version
+name: Bump grafana helm chart version
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://grafana.github.io/helm-charts
       name: grafana
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `grafana` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/incrementals-publisher.yaml
+++ b/updatecli/updatecli.d/charts/incrementals-publisher.yaml
@@ -1,4 +1,4 @@
-title: "Bump incrementals-publisher Helm Chart Version"
+name: "Bump incrementals-publisher Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: incrementals-publisher
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `incremental-publisher` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/ircbot.yaml
+++ b/updatecli/updatecli.d/charts/ircbot.yaml
@@ -1,4 +1,4 @@
-title: "Bump `ircbot` helm chart version"
+name: "Bump `ircbot` helm chart version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: ircbot
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `ircbot` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/javadoc.yaml
+++ b/updatecli/updatecli.d/charts/javadoc.yaml
@@ -1,4 +1,4 @@
-title: "Bump javadoc Helm Chart Version"
+name: "Bump javadoc Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: javadoc
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `javadoc` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/jenkins-additional.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-additional.yaml
@@ -1,4 +1,4 @@
-title: "Bump jenkins-additional Helm Chart Version"
+name: "Bump jenkins-additional Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: jenkins-additional
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersionPrivate
+    title: Bump `jenkins-additional` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/jenkins-agents-infra.ci.jenkins.io.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-agents-infra.ci.jenkins.io.yaml
@@ -1,4 +1,5 @@
-title: Bump agent templates version for infra.ci.jenkins.io
+name: Bump agent templates version for infra.ci.jenkins.io
+
 scms:
   default:
     kind: github
@@ -14,6 +15,7 @@ scms:
 sources:
   packerImageVersion:
     kind: githubrelease
+    name: get last packer-image release
     spec:
       owner: "jenkins-infra"
       repository: "packer-images"
@@ -21,7 +23,8 @@ sources:
       username: "{{ .github.username }}"
   getLatestUbuntuAgentAMIAmd64:
     kind: aws/ami
-    depends_on:
+    name: get latest Ubuntu amd64 agent AMI
+    dependson:
       - packerImageVersion
     spec:
       region: us-east-2
@@ -35,7 +38,8 @@ sources:
           values: '{{ source "packerImageVersion" }}'
   getLatestWindowsAgentAMIAmd64:
     kind: aws/ami
-    depends_on:
+    name: get latest Windows amd64 agent AMI
+    dependson:
       - packerImageVersion
     spec:
       region: us-east-2
@@ -49,7 +53,8 @@ sources:
           values: '{{ source "packerImageVersion" }}'
   getLatestUbuntuAgentAMIArm64:
     kind: aws/ami
-    depends_on:
+    name: get latest Ubuntu arm64 agent AMI
+    dependson:
       - packerImageVersion
     spec:
       region: us-east-2
@@ -96,7 +101,7 @@ pullrequests:
     kind: github
     scmid: default
     title: Bump agent templates for infra.ci.jenkins.io (packer-image {{ source `packerImageVersion` }})
-    targets:
-      - setUbuntuAgentAMIAmd64
-      - setUbuntuAgentAMIArm64
-      - setWindowsAgentAMIamd64
+    spec:
+      labels:
+        - dependencies
+        - agent-templates

--- a/updatecli/updatecli.d/charts/jenkins-infra-and-release-securitygroups.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-infra-and-release-securitygroups.yaml
@@ -1,4 +1,4 @@
-title: Bump Security Groups on jenkins-infra AND release
+name: Bump Security Groups on jenkins-infra AND release
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   getNewJenkinsInfraSecurityGroup:
     kind: file
+    name: get new Jenkins Infra Security Group
     spec:
       file: https://raw.githubusercontent.com/jenkins-infra/aws/main/locals.tf
       matchpattern: 'aws_security_group.*\["(.*?):'
@@ -25,6 +26,7 @@ sources:
       - addprefix: "ec2_agents_"
   getNewJenkinsReleaseSecurityGroup:
     kind: file
+    name: get new Jenkins Release Security Group
     spec:
       file: https://raw.githubusercontent.com/jenkins-infra/aws/main/locals.tf
       matchpattern: 'aws_security_group.*\[".*", "(.*?):'
@@ -58,6 +60,10 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - setJenkinsInfraSecurityGroup
-      - setJenkinsReleaseSecurityGroup
+    title: Bump Security Groups on Jenkins Infra and Release
+    spec:
+      labels:
+        - dependencies
+        - security-groups
+        - infra.ci.jenkins.io
+        - release.ci.jenkins.io

--- a/updatecli/updatecli.d/charts/jenkins-infra-keycloak.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-infra-keycloak.yaml
@@ -1,4 +1,4 @@
-title: "Bump jenkins-infra-keycloak Helm Chart Version"
+name: "Bump jenkins-infra-keycloak Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: keycloak
@@ -33,9 +34,8 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `jenkins-infra-keycloak` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies
-        - keycloak
+        - jenkins-infra-keycloak

--- a/updatecli/updatecli.d/charts/jenkins-jobs.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-jobs.yaml
@@ -1,4 +1,4 @@
-title: "Bump jenkins-infra/jenkins-jobs Helm Chart Version"
+name: "Bump jenkins-infra/jenkins-jobs Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: jenkins-jobs
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersionPrivate
+    title: Bump `jenkins-jobs` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
@@ -1,4 +1,4 @@
-title: "Bump jenkins-kubernetes-agents Helm Chart Version"
+name: "Bump jenkins-kubernetes-agents Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: jenkins-kubernetes-agents
@@ -35,8 +36,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `jenkins-kubernetes-agents` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/jenkinsio.yaml
+++ b/updatecli/updatecli.d/charts/jenkinsio.yaml
@@ -1,4 +1,4 @@
-title: "Bump jenkinsio Helm Chart Version"
+name: "Bump jenkinsio Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: jenkinsio
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `jenkinsio` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/jenkinsisthewayio.yaml
+++ b/updatecli/updatecli.d/charts/jenkinsisthewayio.yaml
@@ -1,4 +1,4 @@
-title: "Bump jenkinsistheway.io redirection Helm Chart Version"
+name: "Bump jenkinsistheway.io redirection Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: httpredirector
@@ -33,9 +34,9 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump jenkinsistheway.io redirection helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies
         - jenkinsisthewayio-redirection
+        - httpredirector

--- a/updatecli/updatecli.d/charts/ldap.yaml
+++ b/updatecli/updatecli.d/charts/ldap.yaml
@@ -1,4 +1,4 @@
-title: "Bump LDAP Helm Chart Version"
+name: "Bump LDAP Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: ldap
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `ldap` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/mirrorbits.yaml
+++ b/updatecli/updatecli.d/charts/mirrorbits.yaml
@@ -1,4 +1,4 @@
-title: "Bump mirrorbits Helm Chart Version"
+name: "Bump mirrorbits Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: mirrorbits
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `mirrorbits` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/nginx-ingress.yaml
+++ b/updatecli/updatecli.d/charts/nginx-ingress.yaml
@@ -1,4 +1,4 @@
-title: Bump nginx-ingress helm chart
+name: Bump nginx-ingress helm chart
 
 scms:
   default:
@@ -16,6 +16,7 @@ sources:
   lastChartVersion:
     name: "Retrieve latest version of the chart ingress-nginx"
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://kubernetes.github.io/ingress-nginx
       name: ingress-nginx
@@ -37,8 +38,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `nginx-ingress` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/nginx-ingress.yaml
+++ b/updatecli/updatecli.d/charts/nginx-ingress.yaml
@@ -16,7 +16,6 @@ sources:
   lastChartVersion:
     name: "Retrieve latest version of the chart ingress-nginx"
     kind: helmchart
-    name: get last chart version
     spec:
       url: https://kubernetes.github.io/ingress-nginx
       name: ingress-nginx

--- a/updatecli/updatecli.d/charts/plugin-health-scoring.yaml
+++ b/updatecli/updatecli.d/charts/plugin-health-scoring.yaml
@@ -1,4 +1,4 @@
-title: "Bump plugin-health-scoring Helm Chart Version"
+name: "Bump plugin-health-scoring Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: plugin-health-scoring
@@ -33,7 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    title: "Bump plugin-health-scoring helm chart version to {{ source `lastChartVersion` }}"
+    title: Bump `plugin-health-scoring` helm chart version to {{ source `lastChartVersion` }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/plugin-site-issues.yaml
+++ b/updatecli/updatecli.d/charts/plugin-site-issues.yaml
@@ -1,4 +1,4 @@
-title: "Bump plugin-site-issues Helm Chart Version"
+name: "Bump plugin-site-issues Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: plugin-site-issues
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `plugin-site-issues` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/plugin-site.yaml
+++ b/updatecli/updatecli.d/charts/plugin-site.yaml
@@ -1,4 +1,4 @@
-title: "Bump plugin-site Helm Chart Version"
+name: "Bump plugin-site Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: plugin-site
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `plugin-site` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/prometheus.yaml
+++ b/updatecli/updatecli.d/charts/prometheus.yaml
@@ -1,4 +1,4 @@
-title: Bump prometheus helm chart version
+name: Bump prometheus helm chart version
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://prometheus-community.github.io/helm-charts
       name: prometheus
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `prometheus` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/rating.yaml
+++ b/updatecli/updatecli.d/charts/rating.yaml
@@ -1,4 +1,4 @@
-name: Bump Jenkins Upstream Helm Charts
+title: "Bump rating Helm Chart Version"
 
 scms:
   default:
@@ -17,30 +17,25 @@ sources:
     kind: helmchart
     name: get last chart version
     spec:
-      url: https://charts.jenkins.io
-      name: jenkins
+      url: https://jenkins-infra.github.io/helm-charts
+      name: rating
 
 targets:
   updateChartVersion:
-    name: "jenkinsci/jenkins Helm Chart"
+    name: "Update the chart version for rating"
     kind: file
     spec:
-      files:
-        - clusters/prodpublick8s.yaml
-        - clusters/temp-privatek8s.yaml
-      matchpattern: 'chart: jenkins\/jenkins((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins/jenkins${1}version: {{ source "lastChartVersion" }}'
+      file: clusters/prodpublick8s.yaml
+      matchpattern: 'chart: jenkins-infra\/rating((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/rating${1}version: {{ source "lastChartVersion" }}'
     scmid: default
 
 pullrequests:
   default:
     kind: github
     scmid: default
-    title: Bump `jenkins` helm chart version to {{ source "lastChartVersion" }}
+    title: Bump `rating` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies
-        - infra.ci.jenkins.io
-        - release.ci.jenkins.io
-        - weekly.ci.jenkins.io
-        - jenkins
+        - rating

--- a/updatecli/updatecli.d/charts/reports.yaml
+++ b/updatecli/updatecli.d/charts/reports.yaml
@@ -1,4 +1,4 @@
-title: "Bump reports Helm Chart Version"
+name: "Bump reports Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: reports
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `reports` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/uplink.yaml
+++ b/updatecli/updatecli.d/charts/uplink.yaml
@@ -1,4 +1,4 @@
-title: "Bump uplink Helm Chart Version"
+name: "Bump uplink Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: uplink
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `uplink` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/charts/wiki.yaml
+++ b/updatecli/updatecli.d/charts/wiki.yaml
@@ -1,4 +1,4 @@
-title: "Bump wiki Helm Chart Version"
+name: "Bump wiki Helm Chart Version"
 
 scms:
   default:
@@ -15,6 +15,7 @@ scms:
 sources:
   lastChartVersion:
     kind: helmchart
+    name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
       name: wiki
@@ -33,8 +34,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateChartVersion
+    title: Bump `wiki` helm chart version to {{ source "lastChartVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/docker-images/404.yaml
+++ b/updatecli/updatecli.d/docker-images/404.yaml
@@ -1,4 +1,4 @@
-title: Bump 404 docker image version
+name: Bump `404` docker image version
 
 scms:
   default:
@@ -79,13 +79,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updatePrivateNginxIngress404ProdPublicK8s
-      - updatePublicNginxIngress404ProdPublicK8s
-      - updatePrivateNginxIngress404TempPrivateK8s
-      - updatePublicNginxIngress404TempPrivateK8s
-      - updatePublicNginxIngress404Doks
-      - updatePublicNginxIngress404Cik8s
+    title: Bump `404` docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/docker-images/datadog.yaml
+++ b/updatecli/updatecli.d/docker-images/datadog.yaml
@@ -38,7 +38,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    title: Bump `datadog`` docker image version to {{ source "latestRelease" }}
+    title: Bump `datadog` docker image version to {{ source "latestDigest" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/docker-images/datadog.yaml
+++ b/updatecli/updatecli.d/docker-images/datadog.yaml
@@ -1,4 +1,4 @@
-title: Bump datadog docker image digest
+name: Bump `datadog` docker image digest
 
 scms:
   default:
@@ -38,8 +38,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateDigestInConfig
+    title: Bump `datadog`` docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/docker-images/jenkins-lts.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-lts.yaml
@@ -1,4 +1,4 @@
-title: "Bump Jenkins LTS docker image version"
+name: "Bump Jenkins LTS docker image version"
 
 scms:
   default:
@@ -44,8 +44,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateReleaseInConfig
+    title: Bump Jenkins LTS docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/docker-images/jenkins-weekly.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-weekly.yaml
@@ -1,4 +1,4 @@
-title: "Bump Jenkins weekly docker image version"
+name: "Bump Jenkins Weekly docker image version"
 
 scms:
   default:
@@ -51,9 +51,7 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateReleaseInConfig
-      - updateReleaseInWeeklyConfig
+    title: Bump Jenkins Weekly docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/docker-images/keycloak-theme.yaml
+++ b/updatecli/updatecli.d/docker-images/keycloak-theme.yaml
@@ -1,4 +1,4 @@
-title: Bump keycloak-theme docker image version
+name: Bump `keycloak-theme` docker image version
 
 scms:
   default:
@@ -45,9 +45,8 @@ pullrequests:
   default:
     kind: github
     scmid: default
-    targets:
-      - updateReleaseInConfig
+    title: Bump `keycloak-theme` docker image version to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies
-        - certmanager
+        - keycloak-theme

--- a/updatecli/updatecli.d/pod-templates/helmfile.yaml
+++ b/updatecli/updatecli.d/pod-templates/helmfile.yaml
@@ -1,4 +1,4 @@
-title: Bump jenkins-infra helmfile docker image
+name: Bump jenkins-infra helmfile docker image
 
 scms:
   default:
@@ -56,9 +56,6 @@ pullrequests:
     kind: github
     scmid: default
     title: Bump jenkins-infra helmfile docker image to {{ source `lastRelease` }}
-    targets:
-      - updatePodImage
-      - updatePipelineImage
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
- Replaced deprecated main `title` by `name`
- Added missing `name` field in all `sources` blocks
- Replaced deprecated `depends_on` by `dependson`
- Replaced deprecated and now useless `targets` by `title` in all `pullrequest` blocks
- Completed and fixed labels in all `pullrequests` blocks