### PR TITLE
feat: add `kubeconfig-eks-public` credentials

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -111,6 +111,10 @@ jobsDefinition:
             fileName: "kubeconfig"
             description: "Kubeconfig file for cik8s"
             secretBytes: "${base64:${KUBECONFIG_CIK8S}}"
+          kubeconfig-eks-public:
+            fileName: "kubeconfig"
+            description: "Kubeconfig file for eks-public"
+            secretBytes: "${base64:${KUBECONFIG_EKS_PUBLIC}}"
           kubeconfig-doks:
             fileName: "kubeconfig"
             description: "Kubeconfig file for doks"


### PR DESCRIPTION
Extracted from and needed for https://github.com/jenkins-infra/kubernetes-management/pull/2944

Corresponding secret added by https://github.com/jenkins-infra/charts-secrets/commit/b251cd22b7e3e3f1e4fcfc67350173c0528f0ff3
(obtained with `aws eks update-kubeconfig --name jenkins-infra-public-ENRZrfwf --region us-east-2`)