### PR TITLE
hotfix: remove image.tag from `plugin-health-scoring` values

### DIFF
--- a/config/plugin-health-scoring.yaml
+++ b/config/plugin-health-scoring.yaml
@@ -13,6 +13,3 @@ ingress:
     - secretName: plugin-health-scoring-tls
       hosts:
         - plugin-health.jenkins.io
-
-image:
-  tag: 0.0.1 # maintained with updatecli


### PR DESCRIPTION
Excerpt of https://github.com/jenkins-infra/kubernetes-management/pull/2999 to unblock @alecharp