### PR TITLE
chore: align cluster name value declaration between cik8s & eks-public

### DIFF
--- a/clusters/cik8s.yaml
+++ b/clusters/cik8s.yaml
@@ -51,6 +51,9 @@ releases:
     version: 9.21.0
     values:
       - "../config/ext_autoscaler_cik8s.yaml"
+    set:
+      - name: autoDiscovery.clusterName
+        value: jenkins-infra-eks-ENRZrfwf
   - name: aws-node-termination-handler
     namespace: eks
     chart: eks/aws-node-termination-handler

--- a/config/ext_autoscaler_cik8s.yaml
+++ b/config/ext_autoscaler_cik8s.yaml
@@ -15,5 +15,4 @@ rbac:
       eks.amazonaws.com/role-arn: "arn:aws:iam::200564066411:role/cluster-autoscaler"
 
 autoDiscovery:
-  clusterName: jenkins-infra-eks-ENRZrfwf
   enabled: true


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/kubernetes-management/pull/2944