### PR TITLE
fix(eks-public): restore nginx-ingress default backend

### DIFF
--- a/config/ext_public-nginx-ingress_eks-public.yaml
+++ b/config/ext_public-nginx-ingress_eks-public.yaml
@@ -1,6 +1,26 @@
 defaultBackend:
-  # disabled as not compatible with arm64/aarch64
-  enabled: false
+  enabled: true
+  image:
+    repository: jenkinsciinfra/404
+    tag: 0.3.58
+    pullPolicy: IfNotPresent
+  ## Unprivileged port as non root user and no escalation allowed
+  port: 8080
+  ## Volumes are required because rootfs is readonly
+  extraVolumeMounts:
+    - name: nginx-cache
+      mountPath: /var/cache/nginx
+    - name: nginx-rundir
+      mountPath: /var/run/nginx
+    - name: nginx-logs
+      mountPath: /var/logs/nginx
+  extraVolumes:
+    - name: nginx-cache
+      emptyDir: {}
+    - name: nginx-rundir
+      emptyDir: {}
+    - name: nginx-logs
+      emptyDir: {}
 controller:
   publishService:
     enabled: true

--- a/updatecli/updatecli.d/docker-images/404.yaml
+++ b/updatecli/updatecli.d/docker-images/404.yaml
@@ -74,6 +74,13 @@ targets:
       file: "config/ext_public-nginx-ingress_cik8s.yaml"
       key: "defaultBackend.image.tag"
     scmid: default
+  updatePublicNginxIngress404EksPublic:
+    name: "Update 404 docker image tag"
+    kind: yaml
+    spec:
+      file: "config/ext_public-nginx-ingress_eks-public.yaml"
+      key: "defaultBackend.image.tag"
+    scmid: default
 
 pullrequests:
   default:


### PR DESCRIPTION
Now that we've switched from an incompatible ARM CPU architecture to a compatible amd64 one in https://github.com/jenkins-infra/aws/pull/250

Related restoration, same effect: #3024 