### PR TITLE
fix(eks-public): correct instance type for the autoscaler node selector

### DIFF
--- a/config/ext_autoscaler_eks-public.yaml
+++ b/config/ext_autoscaler_eks-public.yaml
@@ -3,7 +3,7 @@ awsRegion: us-east-2
 
 nodeSelector:
   eks.amazonaws.com/capacityType: ON_DEMAND
-  node.kubernetes.io/instance-type: t4g.xlarge
+  node.kubernetes.io/instance-type: t3a.xlarge
 
 rbac:
   create: true


### PR DESCRIPTION
As the instance type has changed from 't4g.xlarge' to 't3a.xlarge' since https://github.com/jenkins-infra/aws/pull/250, the autoscaler pod stayed in 'pending' with the following warning:
> Warning  FailedScheduling  14s (x2 over 104s)  default-scheduler  0/2 nodes are available: 2 node(s) didn’t match Pod’s node affinity/selector.