### PR TITLE
feat(infra.ci) add a job for the Docker image of ircbot

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -47,6 +47,8 @@ jobsDefinition:
       docker-plugin-site-issues:
       docker-plugins-self-service:
       docker-rsyncd:
+      ircbot:
+        jenkinsfilePath: Jenkinsfile
       plugin-health-scoring:
         jenkinsfilePath: Jenkinsfile
       rating:


### PR DESCRIPTION
Cc @NotMyFault 

(edit for context)

- Related to https://github.com/jenkins-infra/ircbot/issues/104
- Allows to deploy the new versions of the ircbot image (v1.5.0 is from 2019 😱)