### PR TITLE
fix(ircbot): no image.tag and bump chart version

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -115,7 +115,7 @@ releases:
   - name: ircbot
     namespace: ircbot
     chart: jenkins-infra/ircbot
-    version: 0.1.0
+    version: 0.1.1
     values:
       - "../config/ircbot.yaml"
     secrets:
@@ -267,7 +267,7 @@ releases:
   - name: artifact-caching-proxy
     namespace: artifact-caching-proxy
     chart: jenkins-infra/artifact-caching-proxy
-    version: 0.1.1
+    version: 0.1.2
     needs:
       - public-nginx-ingress/public-nginx-ingress # Required to expose the proxy
     values:

--- a/config/ircbot.yaml
+++ b/config/ircbot.yaml
@@ -1,5 +1,4 @@
 image:
-  tag: 165-buildbc1736
   pullPolicy: IfNotPresent
 
 resources:


### PR DESCRIPTION
Closes https://github.com/jenkins-infra/kubernetes-management/pull/3036

cc @slide @halkeye 