### PR TITLE
chore: temporary disable kubernetes-management job on `eks-public` cluster

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -29,7 +29,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'prodpublick8s', 'cik8s', 'eks-public', 'temp-privatek8s', 'doks', 'doks-public'
+            values 'prodpublick8s', 'cik8s', 'temp-privatek8s', 'doks', 'doks-public'
           }
         } // axes
         agent {


### PR DESCRIPTION
While working on the artifact-caching-proxy