### PR TITLE
chore(infra.ci) remove a deprecated (and ignored) directive for the jobs configuration

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -225,7 +225,6 @@ jobsDefinition:
         name: "Plugin Migration Status Report"
         repository: "infra-reports"
         jenkinsfilePath: "plugin-migration/Jenkinsfile"
-        disableGitHubChecks: true ## Only build status, no more
         credentials:
           githubapp-jenkins-infra-reports-private-key-b64:
             description: "Base64 encoded private key of the Github App installed on jenkinsci org for https://github.com/jenkins-infra/infra-reports scripts"


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/3157, I realized this line was doing nothing, since https://github.com/jenkins-infra/helm-charts/pull/120