### PR TITLE
chore(updatecli) fix manifests with dockerdigest in 0.36.x

### DIFF
--- a/updatecli/updatecli.d/docker-images/datadog.yaml
+++ b/updatecli/updatecli.d/docker-images/datadog.yaml
@@ -20,6 +20,8 @@ sources:
       image: "jenkinsciinfra/datadog"
       tag: "latest"
       architecture: amd64
+    transformers:
+      - trimprefix: 'sha256:'
 
 # no condition to test docker image availability as we're using a digest from docker hub
 


### PR DESCRIPTION
Same thing as https://github.com/jenkins-infra/jenkins-infra/pull/2439.

The goal of this PR is to avoid duplication of the `sha256:` prefix due to updatecli v0.36.0