### PR TITLE
Revert "Bump `accountapp` helm chart version to 0.1.5"

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -148,7 +148,7 @@ releases:
   - name: accountapp
     namespace: accountapp
     chart: jenkins-infra/accountapp
-    version: 0.1.5
+    version: 0.1.4
     values:
       - "../config/accountapp.yaml"
     secrets:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#3076

The new version does not start (issue incoming in jenkins-infra/account-app with error logs) but we have to stop trying to deploy it.