### PR TITLE
feat(infra.ci) add tools `jdk8`, `jdk11`, `jdk17` and `mvn` adapted from ci.jenkins.io export

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -511,6 +511,67 @@ controller:
             targetLogIntakeURL: "https://http-intake.logs.datadoghq.com/v1/input/"
             targetPort: 8125
             targetTraceCollectionPort: 8126
+      tools-config: |
+        tool:
+          jdk:
+            installations:
+            - name: "jdk8"
+              properties:
+              - installSource:
+                  installers:
+                  - zip:
+                      label: "linux && amd64"
+                      subdir: "jdk8u345-b01"
+                      url: "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_x64_linux_hotspot_8u345b01.tar.gz"
+                  - zip:
+                      label: "windows"
+                      subdir: "jdk8u345-b01"
+                      url: "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_x64_windows_hotspot_8u345b01.zip"
+                  - zip:
+                      label: "linux && arm64"
+                      subdir: "jdk8u345-b01"
+                      url: "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_aarch64_linux_hotspot_8u345b01.tar.gz"
+            - name: "jdk11"
+              properties:
+              - installSource:
+                  installers:
+                  - zip:
+                      label: "linux && amd64"
+                      subdir: "jdk-11.0.16.1+1"
+                      url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1+1/OpenJDK11U-jdk_x64_linux_hotspot_11.0.16.1_1.tar.gz"
+                  - zip:
+                      label: "windows"
+                      subdir: "jdk-11.0.16.1+1"
+                      url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1+1/OpenJDK11U-jdk_x64_windows_hotspot_11.0.16.1_1.zip"
+                  - zip:
+                      label: "linux && arm64"
+                      subdir: "jdk-11.0.16.1+1"
+                      url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1+1/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.16.1_1.tar.gz"
+            - name: "jdk17"
+              properties:
+              - installSource:
+                  installers:
+                  - zip:
+                      label: "linux && amd64"
+                      subdir: "jdk-17.0.4.1+1"
+                      url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1+1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.4.1_1.tar.gz"
+                  - zip:
+                      label: "windows"
+                      subdir: "jdk-17.0.4.1+1"
+                      url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1+1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.4.1_1.zip"
+                  - zip:
+                      label: "linux && arm64"
+                      subdir: "jdk-17.0.4.1+1"
+                      url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1+1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.4.1_1.tar.gz"
+          maven:
+            installations:
+            - name: "mvn"
+              properties:
+              - installSource:
+                  installers:
+                  - maven:
+                      id: "3.8.6"
+
   sidecars:
     configAutoReload:
       env:


### PR DESCRIPTION
- Removed ppc64 and s390x CPU architecture
- Bumped JDK11 to 11.0.16.1+1
- Bumped JDK17 to 17.0.4.1+1

This PR is related to https://github.com/jenkins-infra/helpdesk/issues/3087. It ensures a partial feature parity between ci.jenkins.io and infra.ci.jenkins.io to handle jobs migrated (or spread) between these 2 controllers.

Please note that:

- There is no updatecli tracking (yet)
- After a discussion with @lemeurherve , we though on a way to generate a common definition for both Puppet and helm chart, to be continued.