### PR TITLE
fix(artifact-caching-proxi/AWS): use new storage class

### DIFF
--- a/config/artifact-caching-proxy_aws.yaml
+++ b/config/artifact-caching-proxy_aws.yaml
@@ -10,4 +10,4 @@ ingress:
         - repo.aws.jenkins.io
 
 persistence:
-  storageClass: gp2
+  storageClass: ebs-gp3


### PR DESCRIPTION
```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  annotations:
    storageclass.kubernetes.io/is-default-class: "true"
  name: ebs-gp3
parameters:
  fsType: ext4
  type: gp3
provisioner: ebs.csi.aws.com
reclaimPolicy: Delete
volumeBindingMode: WaitForFirstConsumer
```

Ref: https://github.com/jenkins-infra/helpdesk/issues/3053