### PR TITLE
fix(cik8s,eks-public) use new IAM ARNs + fix ACP storageclass to use 1.23 CSI

### DIFF
--- a/config/artifact-caching-proxy_aws.yaml
+++ b/config/artifact-caching-proxy_aws.yaml
@@ -10,4 +10,15 @@ ingress:
         - repo.aws.jenkins.io
 
 persistence:
-  storageClass: ebs-gp3
+  storageClass: ebs-sc
+  ## TODO: find a way to helmfile apply this YAML storageclass definition
+  ##########
+  # apiVersion: storage.k8s.io/v1
+  # kind: StorageClass
+  # metadata:
+  #   name: ebs-sc
+  #   annotations:
+  #     storageclass.kubernetes.io/is-default-class: "true" # Don't forget to edit the "gp2" to set this annotation to "false"
+  # provisioner: ebs.csi.aws.com
+  # volumeBindingMode: WaitForFirstConsumer
+  ##########

--- a/config/ext_autoscaler_cik8s.yaml
+++ b/config/ext_autoscaler_cik8s.yaml
@@ -12,7 +12,7 @@ rbac:
     name: cluster-autoscaler-aws-cluster-autoscaler-chart
     annotations:
       # This value should match the ARN of the role created by module.iam_assumable_role_admin
-      eks.amazonaws.com/role-arn: "arn:aws:iam::200564066411:role/cluster-autoscaler"
+      eks.amazonaws.com/role-arn: "arn:aws:iam::200564066411:role/cluster-autoscaler-aws-cluster-autoscaler-chart-eks"
 
 autoDiscovery:
   enabled: true

--- a/config/ext_autoscaler_eks-public.yaml
+++ b/config/ext_autoscaler_eks-public.yaml
@@ -12,7 +12,7 @@ rbac:
     name: cluster-autoscaler-aws-cluster-autoscaler-chart
     annotations:
       # This value should match the ARN of the role created by module.iam_assumable_role_admin
-      eks.amazonaws.com/role-arn: "arn:aws:iam::200564066411:role/cluster-autoscaler-eks-public"
+      eks.amazonaws.com/role-arn: "arn:aws:iam::200564066411:role/cluster-autoscaler-aws-cluster-autoscaler-chart-eks-public"
 
 autoDiscovery:
   enabled: true


### PR DESCRIPTION
This PR follows up the following AWS EKS changes on cik8s ("eks") and eks-public:

- https://github.com/jenkins-infra/aws/pull/272
- https://github.com/jenkins-infra/aws/pull/273
- https://github.com/jenkins-infra/aws/pull/274
- https://github.com/jenkins-infra/aws/pull/275
- https://github.com/jenkins-infra/aws/pull/276
- https://github.com/jenkins-infra/aws/pull/277



It uses the new IAM ARN roles for CSI storage provisioning on both clusters and it corrects the ACP storageClass.
PS: the current storage class is provided in comment in ACP values, until we find are able to "helmfile" apply it properly.