### PR TITLE
hotfix(eks public) Correct LB system

### DIFF
--- a/config/ext_aws-load-balancer-controller.yaml
+++ b/config/ext_aws-load-balancer-controller.yaml
@@ -4,4 +4,4 @@ serviceAccount:
   name: aws-load-balancer-controller
   annotations:
     # This value should match the ARN of the role created by module.iam_assumable_role_admin in iam-role-nlb.tf
-    eks.amazonaws.com/role-arn: "arn:aws:iam::200564066411:role/aws-load-balancer-controller"
+    eks.amazonaws.com/role-arn: "arn:aws:iam::200564066411:role/aws-load-balancer-controller-eks-public"

--- a/config/ext_public-nginx-ingress_eks-public.yaml
+++ b/config/ext_public-nginx-ingress_eks-public.yaml
@@ -2,7 +2,9 @@ controller:
   service:
     annotations:
       # NLB is balancing at Layer 4 (no need for an ALB-layer 7)
-      service.beta.kubernetes.io/aws-load-balancer-type: nlb
+      # Using `nlb-ip` instead of `nlb` ensures the AWS LoadBalancer Controller is used to provision (instead of the Legacy Cloud Controller)
+      #   as per https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/annotations/#legacy-cloud-provider
+      service.beta.kubernetes.io/aws-load-balancer-type: nlb-ip
       service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
       # Using "ip" instead of instance ensures that balancing is NOT handled
       # by the cluster iptables, but by the external LB itself through CNI


### PR DESCRIPTION
After https://github.com/jenkins-infra/helpdesk/issues/3053, the EKS managed SG was updated with the tag `kubernetes.io/cluster/<cluster name>` which caused mayhem with the Loadbalancer (no more backends...) because subnet discoverability was expecting only 1 tagged SG while they were 2 (the [EKS managed SG](https://github.com/jenkins-infra/aws/blob/d783760bdd8df46d4f79719c4be88e32c8c9fb62/eks-public-cluster.tf#L73-L75) and the [Terraform EKS module managed Node SG (`node_security_group_id`)](https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest?tab=outputs).

Hard to diagnose because eks-public used the Legacy Cloud Load Balancer Controller (no logs) despite the new Controller being installed (logs but no mentions of the loadbalancer because delegated to the Legacy Controller). 
Error message could be found in the service description:

```console
$ kubectl --namespace=public-nginx-ingress describe svc <svc name>
# ...
Events
----------
# ...
Error syncing load balancer: failed to ensure load balancer: Multiple tagged security groups found for instance i-0850526a4ec2a17af; ensure only the k8s security group is tagged; the tagged groups were sg-03029dd273150c206(eks-cluster-sg-public-mint-ape-1630374159) sg-03735a81840336f76(public-mint-ape-node-20221013174103536200000004)  
```

Once switched to the AWS LB Controller, same error with more details in the controller logs:

```console
$ kubectl -n aws-load-balancer logs -l 'app.kubernetes.io/name'=aws-load-balancer-controller -f
# ...
expect exactly one securityGroup tagged with kubernetes.io/cluster/public-mint-ape for eni eni-0b66cbd6118848186, got: [sg-03029dd273150c206 sg-03735a81840336f76] (clusterName: public-mint-ape)"}
```

=> Automatic discovery of the subnets allows selecting a network interface (`eni-xxxx`) and then select security groups transitively, with a final selection per tags on security groups.
This is how we diagnosed the tag added by EKS itself outside our Terraform management (issue https://github.com/jenkins-infra/helpdesk/issues/3053 updated for next kubernetes updates).

Finally, the IRSA ARN in the AWS LB Controller was changed by https://github.com/jenkins-infra/aws/pull/276 but not reported to the helm chart values.

This PR fixes the LB management in eks-public with the following changes:

- Set the Nginx LB service annotation to avoid using the Legacy Cloud LB Controller as per https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/annotations/#legacy-cloud-provider
- Use the correct ARN for the AWS LB Controller