### PR TITLE
feat: activate `rss2twitter` service by disabling dry mode

### DIFF
--- a/config/rss2twitter.yaml
+++ b/config/rss2twitter.yaml
@@ -5,4 +5,4 @@ env:
     {{.Title}}
     {{.Link}}?utm_source=rss2twitter&utm_medium=twitter"
   # disables publishing to twitter and sends updates to logger only
-  dryMode: true
+  dryMode: false


### PR DESCRIPTION
As the service is deployed on prodpublick8s and its logs in dry mode are OK, this PR is activating the publication of the https://www.jenkins.io/releases.rss RSS feed on the [`Jenkins releases` Twitter account](https://twitter.com/jenkins_release).

Ref: https://github.com/jenkins-infra/helpdesk/issues/3085