### PR TITLE
feat(infra.ci) add a new agent VM template 'linux-big' for higher memory use cases

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -257,7 +257,41 @@ controller:
                     value: "linux"
                   - name: "jenkins"
                     value: "infra.ci.jenkins.io"
-                  type: T3Medium
+                  type: T3Medium # 2 vCPUs / 4 Gb
+                  useEphemeralDevices: true
+                - ami: "ami-082ee8cbf0342f2c6" # https://github.com/jenkins-infra/packer-images/ LINUXAMD64 (DO NOT DELETE OR EDIT THIS COMMENT, USED BY UPDATECLI: https://github.com/jenkins-infra/kubernetes-management/blob/cd7e4132eef4095ca287e8c17b284d3c04234cb4/updatecli/updatecli.d/charts/jenkins-agents-infra-release.yaml#L73)
+                  amiOwners: "200564066411"
+                  associatePublicIp: true
+                  connectBySSHProcess: false
+                  connectionStrategy: PUBLIC_IP
+                  deleteRootOnTermination: true
+                  description: "AMD64 Ubuntu 20.04 Big"
+                  ebsOptimized: false
+                  hostKeyVerificationStrategy: ACCEPT_NEW           # Secure: more flexible to save some time at startup
+                  idleTerminationMinutes: "5"
+                  instanceCapStr: "50"
+                  javaPath: "/opt/jdk-11/bin/java"
+                  labelString: "linux-amd64-big linux-amd64-docker-big"
+                  launchTimeoutStr: "180"
+                  maxTotalUses: 1
+                  minimumNumberOfInstances: 0
+                  minimumNumberOfSpareInstances: 0
+                  mode: EXCLUSIVE
+                  monitoring: true
+                  numExecutors: 1
+                  remoteAdmin: "jenkins"
+                  remoteFS: "/home/jenkins"
+                  securityGroups: "ec2_agents_infraci"
+                  stopOnTerminate: false
+                  t2Unlimited: false
+                  tags:
+                  - name: "architecture"
+                    value: "amd64"
+                  - name: "os"
+                    value: "linux"
+                  - name: "jenkins"
+                    value: "infra.ci.jenkins.io"
+                  type: T3Xlarge # 4 vCPUs / 16 Gb
                   useEphemeralDevices: true
                 - ami: "ami-055b20099f9cedc5f" # https://github.com/jenkins-infra/packer-images/ LINUXARM64 (DO NOT DELETE OR EDIT THIS COMMENT, USED BY UPDATECLI: https://github.com/jenkins-infra/kubernetes-management/blob/cd7e4132eef4095ca287e8c17b284d3c04234cb4/updatecli/updatecli.d/charts/jenkins-agents-infra-release.yaml#L82)
                   amiOwners: "200564066411"
@@ -291,7 +325,7 @@ controller:
                     value: "linux"
                   - name: "jenkins"
                     value: "infra.ci.jenkins.io"
-                  type: T4gMedium
+                  type: T4gMedium # 2 vCPUs ARM64 Graviton / 4 Gb
                   useEphemeralDevices: true
                 - ami: "ami-017468623be03f9af" # https://github.com/jenkins-infra/packer-images/ WINDOWSAMD64 (DO NOT DELETE OR EDIT THIS COMMENT, USED BY UPDATECLI: https://github.com/jenkins-infra/kubernetes-management/blob/cd7e4132eef4095ca287e8c17b284d3c04234cb4/updatecli/updatecli.d/charts/jenkins-agents-infra-release.yaml#L91)
                   amiOwners: "200564066411"
@@ -327,7 +361,7 @@ controller:
                     value: "infra.ci.jenkins.io"
                   tenancy: Default
                   tmpDir: "C:\\\\Temp"                          # Mandatory because EC2 plugins assumes SSH = Unix and searches for /tmp
-                  type: T3Medium
+                  type: T3Medium # 2 vCPUs / 4 Gb
                   useEphemeralDevices: true
       ldap-settings: |
         jenkins:


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/3087, it appeared  that https://github.com/jenkins-infra/pipeline-steps-doc-generator requires at least 8 Gb of memory.

The PR https://github.com/jenkins-infra/pipeline-steps-doc-generator/pull/222 was failing the checks with a "Java heap" error.

The default `linux-amd64` machine on infra.ci is a T3Medium which is 2 vCPUs and 4 Gb: too small for this case.


The build `#8` of the PR The PR https://github.com/jenkins-infra/pipeline-steps-doc-generator/pull/222 succeeded with a T3Large (2 vCPUs and 8 Gb), but I chose a `T3XLarge` (4 vCPU / 16 Gb) for the following reasons:

- Same size as the default "Linux" ci.jenkins.io: https://github.com/jenkins-infra/jenkins-infra/blob/7222278ec24b8888ce28d80d7b6b6a9e53f45395/hieradata/clients/azure.ci.jenkins.io.yaml#L320
- Adding more vCPUs helps for parallelizing