### PR TITLE
fix(rss2twitter): remove double quote at the end of the tweet

### DIFF
--- a/config/rss2twitter.yaml
+++ b/config/rss2twitter.yaml
@@ -3,6 +3,6 @@ env:
   rssRefreshRate: 1m
   template: |
     {{.Title}}
-    {{.Link}}?utm_source=rss2twitter&utm_medium=twitter"
+    {{.Link}}?utm_source=rss2twitter&utm_medium=twitter
   # disables publishing to twitter and sends updates to logger only
   dryMode: false


### PR DESCRIPTION
This (typo) quote has for consequence for the link to be displayed while it shouldn't:

<img width="683" alt="image" src="https://user-images.githubusercontent.com/91831478/198856958-cdc5ae2f-5a90-459e-891e-96f37ea28bdd.png">

Ref: https://github.com/jenkins-infra/helpdesk/issues/3085