### PR TITLE
chore(artifact-caching-proxy): 2 replicas for the Azure provider

### DIFF
--- a/config/artifact-caching-proxy_azure.yaml
+++ b/config/artifact-caching-proxy_azure.yaml
@@ -11,3 +11,5 @@ ingress:
 
 persistence:
   storageClass: managed-csi-premium
+
+replicaCount: 2


### PR DESCRIPTION
It should help with the 504 errors we're seeing on Azure like https://github.com/jenkins-infra/helpdesk/issues/3221