### PR TITLE
feat(infra.ci): exclude pr from libraries caching

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -430,7 +430,10 @@ controller:
             url: "https://infra.ci.jenkins.io"
           globalLibraries:
             libraries:
-            - defaultVersion: "master"
+            - cachingConfiguration:
+                excludedVersionsStr: "pull/"
+                refreshTimeMinutes: 180
+              defaultVersion: "master"
               implicit: true
               name: "pipeline-library"
               includeInChangesets: false


### PR DESCRIPTION
to avoid caching of libraries on PR, allowing to work on pipeline library without having to empty the cache