### PR TITLE
feat(infra.ci.jenkins.io) update Linux pod templates configuration (cleanup + tolerations)

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -144,6 +144,19 @@ controller:
                         resourceRequestMemory: "512Mi"
                         alwaysPullImage: true
                     yamlMergeStrategy: "merge"
+                    yaml: |-
+                      apiVersion: v1
+                      kind: Pod
+                      spec:
+                        tolerations:
+                        - key: "jenkins"
+                          operator: "Equal"
+                          value: "infra.ci.jenkins.io"
+                          effect: "NoSchedule"
+                        - key: "kubernetes.azure.com/scalesetpriority"
+                          operator: "Equal"
+                          value: "spot"
+                          effect: "NoSchedule"
                   - name: jnlp-windows
                     nodeSelector: "kubernetes.io/os=windows"
                     instanceCap: 5 # Usual sizing is 2 pods per Windows node, and max 3 windows nodes
@@ -180,6 +193,19 @@ controller:
                                   - windows
                   - name: "jnlp-webbuilder"
                     nodeSelector: "kubernetes.io/os=linux"
+                    yaml: |-
+                      apiVersion: v1
+                      kind: Pod
+                      spec:
+                        tolerations:
+                        - key: "jenkins"
+                          operator: "Equal"
+                          value: "infra.ci.jenkins.io"
+                          effect: "NoSchedule"
+                        - key: "kubernetes.azure.com/scalesetpriority"
+                          operator: "Equal"
+                          value: "spot"
+                          effect: "NoSchedule"
                     containers:
                       - name: "jnlp"
                         image: "jenkinsciinfra/builder@sha256:230919e6a856373c43ed01c4f967cab6274599f6457cd1ea49850ea759e67aa4"

--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -144,44 +144,6 @@ controller:
                         resourceRequestMemory: "512Mi"
                         alwaysPullImage: true
                     yamlMergeStrategy: "merge"
-                  - name: jnlp-beta-11
-                    nodeSelector: "kubernetes.io/os=linux"
-                    containers:
-                      - name: jnlp-beta
-                        image: "jenkinsciinfra/jenkins-agent-ubuntu-20.04"
-                        envVars:
-                        - envVar:
-                            key: "JENKINS_JAVA_BIN"
-                            value: "/opt/jdk11/bin/java"
-                        - envVar:
-                            key: "JAVA_HOME"
-                            value: "/opt/jdk-11"
-                        resourceLimitCpu: "500m"
-                        resourceLimitMemory: "512Mi"
-                        resourceRequestCpu: "500m"
-                        resourceRequestMemory: "512Mi"
-                        alwaysPullImage: true
-                    yamlMergeStrategy: "merge"
-                    label: "ubuntu-20-04-beta-11"
-                  - name: jnlp-beta-17
-                    nodeSelector: "kubernetes.io/os=linux"
-                    containers:
-                      - name: jnlp-beta
-                        image: "jenkinsciinfra/jenkins-agent-ubuntu-20.04"
-                        envVars:
-                        - envVar:
-                            key: "JENKINS_JAVA_BIN"
-                            value: "/opt/jdk11/bin/java"
-                        - envVar:
-                            key: "JAVA_HOME"
-                            value: "/opt/jdk-17"
-                        resourceLimitCpu: "500m"
-                        resourceLimitMemory: "512Mi"
-                        resourceRequestCpu: "500m"
-                        resourceRequestMemory: "512Mi"
-                        alwaysPullImage: true
-                    yamlMergeStrategy: "merge"
-                    label: "ubuntu-20-04-beta-17"
                   - name: jnlp-windows
                     nodeSelector: "kubernetes.io/os=windows"
                     instanceCap: 5 # Usual sizing is 2 pods per Windows node, and max 3 windows nodes


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3157.

The goal is to ensure that the (big) pods generating the stories.jenkins.io website (for both preview and production deployment) are scheduled.

The node pool `infracinodepool` had been created with a bigger machine size (8vCPUS/32 Gb) to ensure pods can be scheduled.

This PR makes sure that we only have Linux pods templates that are:
- used (other are emoved)
- schedulable (toleration applied to ensure that the correct node pool is used)