### PR TITLE
bump plugin-health-scoring to 1.4.0

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -279,7 +279,7 @@ releases:
   - name: plugin-health-scoring
     namespace: plugin-health-scoring
     chart: jenkins-infra/plugin-health-scoring
-    version: 1.3.3
+    version: 1.4.0
     needs:
       - public-nginx-ingress/public-nginx-ingress # Required to expose the service
     values:


### PR DESCRIPTION
Note: already applied to ensure no exposure (as per https://github.com/jenkins-infra/helm-charts/pull/349)