### PR TITLE
feat(ldap) allow IPs for `private.vpn.jenkins.io` and JFrog AWS `us-east-1`

### DIFF
--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -2,21 +2,26 @@ service:
   type: LoadBalancer
   whitelisted_sources:
     - '10.0.32.0/19' # Kubernetes publick8s internal IPs
-    - '35.196.175.89/32' # 2021-06-08 Allow new IP repo.jenkins-ci.org. The hosted Artifactory by JFrog
-    - '34.75.131.248/32' # 2021-06-08 Allow new IP repo.jenkins-ci.org. The hosted Artifactory by JFrog
+    - '35.196.175.89/32' # 2021-06-08 Allow new IP repo.jenkins-ci.org. The hosted Artifactory by JFrog # TODO: remove when https://github.com/jenkins-infra/helpdesk/issues/3288 is completed
+    - '34.75.131.248/32' # 2021-06-08 Allow new IP repo.jenkins-ci.org. The hosted Artifactory by JFrog # TODO: remove when https://github.com/jenkins-infra/helpdesk/issues/3288 is completed
     - '73.71.177.172/32' # 106 accept inbound LDAPS request from spambot
-    - '140.211.15.101/32' # 107 accept inbound LDAPS request from accounts app
-    - '140.211.9.94/32' # 107 accept inbound LDAPS request from puppet.jenkins.io puppet.jenkins.io
+    - '140.211.15.101/32' # 107 accept inbound LDAPS request from accounts.jenkins.io
+    - '140.211.9.94/32' # 107 accept inbound LDAPS request from puppet.jenkins.io
     - '3.209.43.20/32' # 107 accept inbound LDAPS from trusted-ci
-    - '52.71.231.250/32' # 107 accept inbound LDAPS from ci
+    - '52.71.231.250/32' # 107 accept inbound LDAPS from (AWS) ci.jenkins.io # TODO: sounds like we can remove this one
     - '104.209.251.202/32' # accept inbound LDAPS from vpn.jenkins.io
-    - '104.210.5.242/32' # accept inbound LDAPS from cert-ci
+    - '172.176.126.194/32' # accept inbound LDAPS from private.vpn.jenkins.io
+    - '104.210.5.242/32' # accept inbound LDAPS from cert.ci.jenkins.io
     - '104.208.238.39/32' # Accept inbound LDAPS from azure.ci.jenkins.io
     - '52.167.253.43/32' # Accept inbound LDAPS from public.aks.jenkins.io
     - '34.211.101.61/32' # Accept inbound connections from Linux Foundation test machine
     - '44.240.22.235/32' # Accept inbound connections from Linux Foundation prod machine
     - '20.75.10.224/29' # Accept inbound connections from publick8s public IPs
     - '20.72.105.159/32' # Accept inbound connections from temp-privatek8s
+    - '18.214.241.149/32' # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
+    - '34.201.191.93/32' # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
+    - '34.233.58.83/32' # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
+    - '54.236.124.56/32' # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
 image:
   slapd:
     # repo & '@sha256' suffix here as we're retrieving a docker digest from updatecli


### PR DESCRIPTION
This PR is related to both:

- https://github.com/jenkins-infra/helpdesk/issues/3257 to allow the new `private.vpn.jenkins.io` machine to reach the LDAP (tested manually)
- https://github.com/jenkins-infra/helpdesk/issues/3288 to allow the new JFrog platform to reach the LDAP