### PR TITLE
feat(privatek8s): add Jenkins controller

### DIFF
--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -10,6 +10,9 @@ repositories:
   # https://github.com/kubernetes/ingress-nginx/
   - name: ingress-nginx
     url: https://kubernetes.github.io/ingress-nginx
+  # https://github.com/jenkinsci/helm-charts/
+  - name: jenkins
+    url: https://charts.jenkins.io
   # https://github.com/jenkins-infra/helm-charts/
   - name: jenkins-infra
     url: https://jenkins-infra.github.io/helm-charts

--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -43,6 +43,34 @@ releases:
       - "../config/ext_datadog_privatek8s.yaml"
     secrets:
       - "../secrets/config/datadog/privatek8s-secrets.yaml"
+  - name: jenkins-infra
+    namespace: jenkins-infra
+    chart: jenkins/jenkins
+    version: 4.2.17
+    needs:
+      - jenkins-infra-additional # Required to allow the Jenkins controller to spawn kubernetes pods in the current cluster
+      ## TODO: uncomment the following line when switching from temp-privatek8s to privatek8s
+      # - jenkins-jobs # Required to generate the job definition in a configmap
+      - public-nginx-ingress/public-nginx-ingress # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
+      - private-nginx-ingress/private-nginx-ingress # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
+    values:
+      - "../config/ext_jenkins-infra__common.yaml"
+      - "../config/ext_jenkins-infra_privatek8s.yaml"
+    secrets:
+      - "../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml"
+  - name: jenkins-infra-additional
+    namespace: jenkins-infra
+    chart: jenkins-infra/jenkins-additional
+    version: 0.0.3
+    values:
+      - ../config/jenkins-infra-additional.yaml
+  ## TODO: uncomment the following line when switching from temp-privatek8s to privatek8s
+  # - name: jenkins-jobs
+  #   namespace: jenkins-infra
+  #   chart: jenkins-infra/jenkins-jobs
+  #   version: 0.4.0
+  #   values:
+  #     - "../config/ext_jenkins-infra-jobs.yaml"
   - name: public-nginx-ingress
     namespace: public-nginx-ingress
     chart: ingress-nginx/ingress-nginx

--- a/clusters/temp-privatek8s.yaml
+++ b/clusters/temp-privatek8s.yaml
@@ -56,7 +56,8 @@ releases:
       - public-nginx-ingress/public-nginx-ingress # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
       - private-nginx-ingress/private-nginx-ingress # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
     values:
-      - "../config/ext_jenkins-infra.yaml"
+      - "../config/ext_jenkins-infra__common.yaml"
+      - "../config/ext_jenkins-infra_temp-privatek8s.yaml"
     secrets:
       - "../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml"
   - name: jenkins-infra-additional

--- a/config/ext_jenkins-infra__common.yaml
+++ b/config/ext_jenkins-infra__common.yaml
@@ -58,44 +58,6 @@ controller:
             sshHostKeyVerificationStrategy:
               manuallyProvidedKeyVerificationStrategy:
                 approvedHostKeys: "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
-      credentials: |
-        credentials:
-          system:
-            domainCredentials:
-              - credentials:
-                - gitHubApp:
-                    appID: "${GITHUB_APP_ID}"
-                    description: "GitHub App for infra.ci.jenkins.io"
-                    id: "github-app-infra"
-                    privateKey: "${GITHUB_APP_PRIVATE_KEY}"
-                    scope: GLOBAL
-                - gitHubApp:
-                    appID: "${GITHUB_APP_JENKINS_INFRA_UPDATECLI_ID}"
-                    description: "GitHub App for updatecli tasks on jenkins-infra org"
-                    id: "github-app-updatecli-on-jenkins-infra"
-                    privateKey: "${GITHUB_APP_JENKINS_INFRA_UPDATECLI_PRIVATE_KEY}"
-                    owner: "jenkins-infra"
-                    scope: GLOBAL
-                - usernamePassword:
-                    description: "Credentials to access an artifact caching proxy"
-                    id: "artifact-caching-proxy-credentials"
-                    password: "${ARTIFACT_CACHING_PROXY_PASSWORD}"
-                    scope: GLOBAL
-                    username: "MY-USERNAME"
-                - basicSSHUserPrivateKey:
-                    scope: SYSTEM
-                    id: "ec2-agents-privkey"
-                    username: "key"
-                    description: "SSH privkey used to connect to EC2 agents"
-                    privateKeySource:
-                      directEntry:
-                        privateKey: "${EC2_AGENTS_PRIVKEY}"
-                - aws:
-                    accessKey: "${EC2_AWS_ACCESS_KEY_ID}"
-                    description: "This credential is used to provision dynamic agents on AWS EC2"
-                    id: "ec2-agents-credentials"
-                    scope: SYSTEM
-                    secretKey: "${EC2_AWS_SECRET_ACCESS_KEY}"
       agent-settings: |
         jenkins:
           numExecutors: 0

--- a/config/ext_jenkins-infra__common.yaml
+++ b/config/ext_jenkins-infra__common.yaml
@@ -40,10 +40,6 @@ controller:
     readinessProbe:
       initialDelaySeconds: 120
   testEnabled: false
-  podSecurityContextOverride:
-    runAsNonRoot: true
-    runAsUser: 1000
-    supplementalGroups: [1000]
   overwritePlugins: true
   serviceType: "ClusterIP"
   javaOpts: >-
@@ -86,12 +82,6 @@ controller:
                     password: "${ARTIFACT_CACHING_PROXY_PASSWORD}"
                     scope: GLOBAL
                     username: "MY-USERNAME"
-                - file:
-                    fileName: "kubeconfig"
-                    id: "kubeconfig-controller-temp-privatek8s"
-                    description: "Kubeconfig file for temp-privatek8s"
-                    scope: SYSTEM
-                    secretBytes: "${base64:${KUBECONFIG_TEMP_PRIVATEK8S}}"
                 - basicSSHUserPrivateKey:
                     scope: SYSTEM
                     id: "ec2-agents-privkey"
@@ -111,6 +101,7 @@ controller:
           numExecutors: 0
           clouds:
             - kubernetes:
+                credentialsId: "kubeconfig-controller"
                 containerCapStr: "100"
                 # Kubernetes internal URL to stay within private networks
                 jenkinsUrl: "http://jenkins-infra.jenkins-infra.svc.cluster.local:8080"
@@ -120,7 +111,6 @@ controller:
                 namespace: "jenkins-agents"
                 podRetention: "Never"
                 serverUrl: ${AGENTS_KUBERNETES_CLUSTER_URL}
-                credentialsId: "kubeconfig-controller-temp-privatek8s"
                 serverCertificate: |
                   ${AGENTS_KUBERNETES_CLUSTER_CERT}
                 podLabels:

--- a/config/ext_jenkins-infra_privatek8s.yaml
+++ b/config/ext_jenkins-infra_privatek8s.yaml
@@ -6,6 +6,44 @@ controller:
           system:
             domainCredentials:
               - credentials:
+      credentials: |
+        credentials:
+          system:
+            domainCredentials:
+              - credentials:
+                - gitHubApp:
+                    appID: "${GITHUB_APP_ID}"
+                    description: "GitHub App for infra.ci.jenkins.io"
+                    id: "github-app-infra"
+                    privateKey: "${GITHUB_APP_PRIVATE_KEY}"
+                    scope: GLOBAL
+                - gitHubApp:
+                    appID: "${GITHUB_APP_JENKINS_INFRA_UPDATECLI_ID}"
+                    description: "GitHub App for updatecli tasks on jenkins-infra org"
+                    id: "github-app-updatecli-on-jenkins-infra"
+                    privateKey: "${GITHUB_APP_JENKINS_INFRA_UPDATECLI_PRIVATE_KEY}"
+                    owner: "jenkins-infra"
+                    scope: GLOBAL
+                - usernamePassword:
+                    description: "Credentials to access an artifact caching proxy"
+                    id: "artifact-caching-proxy-credentials"
+                    password: "${ARTIFACT_CACHING_PROXY_PASSWORD}"
+                    scope: GLOBAL
+                    username: "MY-USERNAME"
+                - basicSSHUserPrivateKey:
+                    scope: SYSTEM
+                    id: "ec2-agents-privkey"
+                    username: "key"
+                    description: "SSH privkey used to connect to EC2 agents"
+                    privateKeySource:
+                      directEntry:
+                        privateKey: "${EC2_AGENTS_PRIVKEY}"
+                - aws:
+                    accessKey: "${EC2_AWS_ACCESS_KEY_ID}"
+                    description: "This credential is used to provision dynamic agents on AWS EC2"
+                    id: "ec2-agents-credentials"
+                    scope: SYSTEM
+                    secretKey: "${EC2_AWS_SECRET_ACCESS_KEY}"
                 - file:
                     fileName: "kubeconfig"
                     id: "kubeconfig-controller"

--- a/config/ext_jenkins-infra_privatek8s.yaml
+++ b/config/ext_jenkins-infra_privatek8s.yaml
@@ -1,0 +1,14 @@
+controller:
+  JCasC:
+    configScripts:
+      cluster-credentials: |
+        credentials:
+          system:
+            domainCredentials:
+              - credentials:
+                - file:
+                    fileName: "kubeconfig"
+                    id: "kubeconfig-controller"
+                    description: "Kubeconfig file for privatek8s"
+                    scope: SYSTEM
+                    secretBytes: "${base64:${KUBECONFIG_PRIVATEK8S}}"

--- a/config/ext_jenkins-infra_temp-privatek8s.yaml
+++ b/config/ext_jenkins-infra_temp-privatek8s.yaml
@@ -6,6 +6,39 @@ controller:
           system:
             domainCredentials:
               - credentials:
+                - gitHubApp:
+                    appID: "${GITHUB_APP_ID}"
+                    description: "GitHub App for infra.ci.jenkins.io"
+                    id: "github-app-infra"
+                    privateKey: "${GITHUB_APP_PRIVATE_KEY}"
+                    scope: GLOBAL
+                - gitHubApp:
+                    appID: "${GITHUB_APP_JENKINS_INFRA_UPDATECLI_ID}"
+                    description: "GitHub App for updatecli tasks on jenkins-infra org"
+                    id: "github-app-updatecli-on-jenkins-infra"
+                    privateKey: "${GITHUB_APP_JENKINS_INFRA_UPDATECLI_PRIVATE_KEY}"
+                    owner: "jenkins-infra"
+                    scope: GLOBAL
+                - usernamePassword:
+                    description: "Credentials to access an artifact caching proxy"
+                    id: "artifact-caching-proxy-credentials"
+                    password: "${ARTIFACT_CACHING_PROXY_PASSWORD}"
+                    scope: GLOBAL
+                    username: "MY-USERNAME"
+                - basicSSHUserPrivateKey:
+                    scope: SYSTEM
+                    id: "ec2-agents-privkey"
+                    username: "key"
+                    description: "SSH privkey used to connect to EC2 agents"
+                    privateKeySource:
+                      directEntry:
+                        privateKey: "${EC2_AGENTS_PRIVKEY}"
+                - aws:
+                    accessKey: "${EC2_AWS_ACCESS_KEY_ID}"
+                    description: "This credential is used to provision dynamic agents on AWS EC2"
+                    id: "ec2-agents-credentials"
+                    scope: SYSTEM
+                    secretKey: "${EC2_AWS_SECRET_ACCESS_KEY}"
                 - file:
                     fileName: "kubeconfig"
                     id: "kubeconfig-controller"

--- a/config/ext_jenkins-infra_temp-privatek8s.yaml
+++ b/config/ext_jenkins-infra_temp-privatek8s.yaml
@@ -1,0 +1,14 @@
+controller:
+  JCasC:
+    configScripts:
+      credentials: |
+        credentials:
+          system:
+            domainCredentials:
+              - credentials:
+                - file:
+                    fileName: "kubeconfig"
+                    id: "kubeconfig-controller"
+                    description: "Kubeconfig file for temp-privatek8s"
+                    scope: SYSTEM
+                    secretBytes: "${base64:${KUBECONFIG_TEMP_PRIVATEK8S}}"

--- a/config/ext_jenkins-infra_temp-privatek8s.yaml
+++ b/config/ext_jenkins-infra_temp-privatek8s.yaml
@@ -12,3 +12,8 @@ controller:
                     description: "Kubeconfig file for temp-privatek8s"
                     scope: SYSTEM
                     secretBytes: "${base64:${KUBECONFIG_TEMP_PRIVATEK8S}}"
+  # Can be omitted, here to avoid modifying temp-privatek8s config
+  podSecurityContextOverride:
+    runAsNonRoot: true
+    runAsUser: 1000
+    supplementalGroups: [1000]

--- a/updatecli/updatecli.d/charts/jenkins-additional.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-additional.yaml
@@ -25,7 +25,9 @@ targets:
     name: "Update the chart version for jenkins-additional"
     kind: file
     spec:
-      file: clusters/temp-privatek8s.yaml
+      files:
+        - clusters/privatek8s.yaml
+        - clusters/temp-privatek8s.yaml
       matchpattern: 'chart: jenkins-infra\/jenkins-additional((\r\n|\r|\n)(\s+))version: .*'
       replacepattern: 'chart: jenkins-infra/jenkins-additional${1}version: {{ source "lastChartVersion" }}'
     scmid: default

--- a/updatecli/updatecli.d/charts/jenkins-jobs.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-jobs.yaml
@@ -25,7 +25,9 @@ targets:
     name: "Update the chart version for jenkins-jobs"
     kind: file
     spec:
-      file: clusters/temp-privatek8s.yaml
+      files:
+        - clusters/privatek8s.yaml
+        - clusters/temp-privatek8s.yaml
       matchpattern: 'chart: jenkins-infra\/jenkins-jobs((\r\n|\r|\n)(\s+))version: .*'
       replacepattern: 'chart: jenkins-infra/jenkins-jobs${1}version: {{ source "lastChartVersion" }}'
     scmid: default

--- a/updatecli/updatecli.d/charts/jenkins.yaml
+++ b/updatecli/updatecli.d/charts/jenkins.yaml
@@ -26,6 +26,7 @@ targets:
     kind: file
     spec:
       files:
+        - clusters/privatek8s.yaml
         - clusters/prodpublick8s.yaml
         - clusters/temp-privatek8s.yaml
       matchpattern: 'chart: jenkins\/jenkins((\r\n|\r|\n)(\s+))version: .*'

--- a/updatecli/updatecli.d/docker-images/jenkins-weekly.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-weekly.yaml
@@ -36,7 +36,7 @@ targets:
     name: "Update jenkinsciinfra/jenkins-weekly docker image tag"
     kind: yaml
     spec:
-      file: "config/ext_jenkins-infra.yaml"
+      file: "config/ext_jenkins-infra__common.yaml"
       key: "controller.tag"
     scmid: default
   updateReleaseInWeeklyConfig:


### PR DESCRIPTION
This PR add the Jenkins controller intended for infra.ci.jenkins.io, without the corresponding jobs definitions (for another PR)

Follow-up of https://github.com/jenkins-infra/kubernetes-management/pull/3247
Remaining changes of https://github.com/jenkins-infra/kubernetes-management/pull/3194
Ref: https://github.com/jenkins-infra/helpdesk/issues/2844