### PR TITLE
chore: correct comment spacing to avoid yamllint warnings

### DIFF
--- a/config/ext_datadog_privatek8s.yaml
+++ b/config/ext_datadog_privatek8s.yaml
@@ -6,4 +6,5 @@ datadog:
         fieldRef:
           fieldPath: spec.nodeName
     hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
-    tlsVerify: false # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
+    # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
+    tlsVerify: false

--- a/config/ext_datadog_publick8s.yaml
+++ b/config/ext_datadog_publick8s.yaml
@@ -6,4 +6,5 @@ datadog:
         fieldRef:
           fieldPath: spec.nodeName
     hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
-    tlsVerify: false # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
+    # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
+    tlsVerify: false

--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -1,25 +1,25 @@
 service:
   type: LoadBalancer
   whitelisted_sources:
-    - '10.0.32.0/19' # Kubernetes publick8s internal IPs
-    - '73.71.177.172/32' # 106 accept inbound LDAPS request from spambot
-    - '140.211.15.101/32' # 107 accept inbound LDAPS request from accounts.jenkins.io
-    - '140.211.9.94/32' # 107 accept inbound LDAPS request from puppet.jenkins.io
-    - '3.209.43.20/32' # 107 accept inbound LDAPS from trusted-ci
-    - '52.71.231.250/32' # 107 accept inbound LDAPS from (AWS) ci.jenkins.io # TODO: sounds like we can remove this one
-    - '104.209.251.202/32' # accept inbound LDAPS from vpn.jenkins.io
-    - '172.176.126.194/32' # accept inbound LDAPS from private.vpn.jenkins.io
-    - '104.210.5.242/32' # accept inbound LDAPS from cert.ci.jenkins.io
-    - '104.208.238.39/32' # Accept inbound LDAPS from azure.ci.jenkins.io
-    - '52.167.253.43/32' # Accept inbound LDAPS from public.aks.jenkins.io
-    - '34.211.101.61/32' # Accept inbound connections from Linux Foundation test machine
-    - '44.240.22.235/32' # Accept inbound connections from Linux Foundation prod machine
-    - '20.75.10.224/29' # Accept inbound connections from publick8s public IPs
-    - '20.96.66.246/32' # Accept inbound connections from privatek8s # TODO: find out how to retrieve this IP from terraform
-    - '18.214.241.149/32' # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
-    - '34.201.191.93/32' # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
-    - '34.233.58.83/32' # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
-    - '54.236.124.56/32' # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
+    - '10.0.32.0/19'  # Kubernetes publick8s internal IPs
+    - '73.71.177.172/32'  # 106 accept inbound LDAPS request from spambot
+    - '140.211.15.101/32'  # 107 accept inbound LDAPS request from accounts.jenkins.io
+    - '140.211.9.94/32'  # 107 accept inbound LDAPS request from puppet.jenkins.io
+    - '3.209.43.20/32'  # 107 accept inbound LDAPS from trusted-ci
+    - '52.71.231.250/32'  # 107 accept inbound LDAPS from (AWS) ci.jenkins.io # TODO: sounds like we can remove this one
+    - '104.209.251.202/32'  # accept inbound LDAPS from vpn.jenkins.io
+    - '172.176.126.194/32'  # accept inbound LDAPS from private.vpn.jenkins.io
+    - '104.210.5.242/32'  # accept inbound LDAPS from cert.ci.jenkins.io
+    - '104.208.238.39/32'  # Accept inbound LDAPS from azure.ci.jenkins.io
+    - '52.167.253.43/32'  # Accept inbound LDAPS from public.aks.jenkins.io
+    - '34.211.101.61/32'  # Accept inbound connections from Linux Foundation test machine
+    - '44.240.22.235/32'  # Accept inbound connections from Linux Foundation prod machine
+    - '20.75.10.224/29'  # Accept inbound connections from publick8s public IPs
+    - '20.96.66.246/32'  # Accept inbound connections from privatek8s # TODO: find out how to retrieve this IP from terraform
+    - '18.214.241.149/32'  # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
+    - '34.201.191.93/32'  # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
+    - '34.233.58.83/32'  # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
+    - '54.236.124.56/32'  # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
 image:
   slapd:
     # repo & '@sha256' suffix here as we're retrieving a docker digest from updatecli


### PR DESCRIPTION
```console
$ yamllint --config-file yamllint.config config
config/ldap.yaml
  4:22      warning  too few spaces before comment  (comments)
  5:26      warning  too few spaces before comment  (comments)
  6:27      warning  too few spaces before comment  (comments)
  7:25      warning  too few spaces before comment  (comments)
  8:24      warning  too few spaces before comment  (comments)
  9:26      warning  too few spaces before comment  (comments)
  10:28     warning  too few spaces before comment  (comments)
  11:28     warning  too few spaces before comment  (comments)
  12:26     warning  too few spaces before comment  (comments)
  13:27     warning  too few spaces before comment  (comments)
  14:26     warning  too few spaces before comment  (comments)
  15:26     warning  too few spaces before comment  (comments)
  16:26     warning  too few spaces before comment  (comments)
  17:25     warning  too few spaces before comment  (comments)
  18:25     warning  too few spaces before comment  (comments)
  19:27     warning  too few spaces before comment  (comments)
  20:26     warning  too few spaces before comment  (comments)
  21:25     warning  too few spaces before comment  (comments)
  22:26     warning  too few spaces before comment  (comments)

config/ext_datadog_publick8s.yaml
  9:22      warning  too few spaces before comment  (comments)

config/ext_datadog_privatek8s.yaml
  9:22      warning  too few spaces before comment  (comments)
```