### PR TITLE
fix(eks-public/doks-public): upgrade cert-manager version to v1.11.0

### DIFF
--- a/clusters/doks-public.yaml
+++ b/clusters/doks-public.yaml
@@ -30,7 +30,7 @@ releases:
   - name: cert-manager
     namespace: cert-manager
     chart: jetstack/cert-manager
-    version: v1.9.1
+    version: v1.11.0
     set:
       - name: installCRDs
         value: true

--- a/clusters/eks-public.yaml
+++ b/clusters/eks-public.yaml
@@ -66,7 +66,7 @@ releases:
   - name: cert-manager
     namespace: cert-manager
     chart: jetstack/cert-manager
-    version: v1.9.1
+    version: v1.11.0
     set:
       - name: installCRDs
         value: true

--- a/updatecli/updatecli.d/charts/cert-manager.yaml
+++ b/updatecli/updatecli.d/charts/cert-manager.yaml
@@ -26,11 +26,11 @@ targets:
     kind: file
     spec:
       files:
+        - clusters/doks-public.yaml
+        - clusters/eks-public.yaml
         - clusters/privatek8s.yaml
         - clusters/prodpublick8s.yaml
         - clusters/publick8s.yaml
-        - clusters/eks-public.yaml
-        - clusters/doks-public.yaml
       matchpattern: 'chart: jetstack\/cert-manager((\r\n|\r|\n)(\s+))version: .*'
       replacepattern: 'chart: jetstack/cert-manager${1}version: {{ source "lastChartVersion" }}'
     scmid: default

--- a/updatecli/updatecli.d/charts/cert-manager.yaml
+++ b/updatecli/updatecli.d/charts/cert-manager.yaml
@@ -29,6 +29,8 @@ targets:
         - clusters/privatek8s.yaml
         - clusters/prodpublick8s.yaml
         - clusters/publick8s.yaml
+        - clusters/eks-public.yaml
+        - clusters/doks-public.yaml
       matchpattern: 'chart: jetstack\/cert-manager((\r\n|\r|\n)(\s+))version: .*'
       replacepattern: 'chart: jetstack/cert-manager${1}version: {{ source "lastChartVersion" }}'
     scmid: default


### PR DESCRIPTION
updatecli was not tracking cert-manager versions for eks-public and doks-public. 