### PR TITLE
chore: migrate `ircbot` from `prodpublick8s` to `privatek8s`

### DIFF
--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -87,3 +87,11 @@ releases:
     values:
       - "../config/ext_private-nginx-ingress__common.yaml"
       - "../config/ext_private-nginx-ingress_privatek8s.yaml"
+  - name: ircbot
+    namespace: ircbot
+    chart: jenkins-infra/ircbot
+    version: 0.2.8
+    values:
+      - "../config/ircbot.yaml"
+    secrets:
+      - "../secrets/config/ircbot/secrets.yaml"


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/2844