### PR TITLE
fix(artifact-caching-proxy): distinct health check path

### DIFF
--- a/config/artifact-caching-proxy__common.yaml
+++ b/config/artifact-caching-proxy__common.yaml
@@ -14,6 +14,7 @@ persistence:
 ingress:
   enabled: true
   className: public-nginx
+  healthPath: /health
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"


### PR DESCRIPTION
As the `/healthz` path is the default health check path of the nginx ingress, this PR is specifying a distinct path to ensure the artifact-caching-proxy health is tested and not the nginx ingress.

Note: [the default chart value](https://github.com/jenkins-infra/helm-charts/blob/4173bbb9d8238ab89be27085f09234459a1298a2/charts/artifact-caching-proxy/values.yaml#L43) could also be changed.