### PR TITLE
fix(eks-public) correct ACP and public-ingress configuration to follow cert-manager recommendations

### DIFF
--- a/config/artifact-caching-proxy_aws.yaml
+++ b/config/artifact-caching-proxy_aws.yaml
@@ -1,4 +1,7 @@
 ingress:
+  enabled: true
+  annotations:
+    acme.cert-manager.io/http01-edit-in-place: "true"
   hosts:
     - host: repo.aws.jenkins.io
       paths:

--- a/config/artifact-caching-proxy_aws.yaml
+++ b/config/artifact-caching-proxy_aws.yaml
@@ -1,5 +1,4 @@
 ingress:
-  enabled: true
   annotations:
     acme.cert-manager.io/http01-edit-in-place: "true"
   hosts:

--- a/config/ext_public-nginx-ingress_eks-public.yaml
+++ b/config/ext_public-nginx-ingress_eks-public.yaml
@@ -13,3 +13,7 @@ controller:
       service.beta.kubernetes.io/aws-load-balancer-subnets: subnet-03f3f5c43b4e312df, subnet-0439f1b3505a86064, subnet-08d5d75484ad0b7c1
       # Defined in https://github.com/jenkins-infra/aws/blob/main/eks-public-cluster.tf
       service.beta.kubernetes.io/aws-load-balancer-eip-allocations: eipalloc-03bcda5de8989b2a7, eipalloc-02112eaece33364b5, eipalloc-040e011509996d859
+  ingressClassResource:
+    default: true
+  ingressClassByName: true
+  ingressClass: public-nginx


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3305, this PR persists the manual changes that were done to allow Cert Manager to validate the HTTP-01 Let's Encrypt challenge in eks-public, for the ACP service.

- Setting the ingress class `public-nginx`as the default (to pick and implement any ingress rule without a `spec.ingressClass` attribute set to the value `public-nginx`
- Enabling the class by name mode to ensure that all cases of ingress rule specification are covered
- Set up ACP ingress rule to reuse its Ingress rule "in place" (instead of creating/deleting another ingress rule each time a challenge happens)

References:
- https://github.com/cert-manager/cert-manager/issues/4821
- https://cert-manager.io/docs/installation/upgrading/ingress-class-compatibility/