### PR TITLE
Revert "Bump `grafana` helm chart version to 6.50.6"

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -91,7 +91,7 @@ releases:
   - name: grafana
     namespace: grafana
     chart: grafana/grafana
-    version: 6.50.6
+    version: 6.50.5
     values:
       - "../config/ext_grafana.yaml"
     secrets:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#3535

Every following deployment on prodpublick8s failed.