### PR TITLE
fix(eks-public) correct ACP by using single AZ node pool, EBS PVC with custom SC and autoscaler topology awareness

### DIFF
--- a/clusters/eks-public.yaml
+++ b/clusters/eks-public.yaml
@@ -94,3 +94,14 @@ releases:
     values:
       - "../config/ext_public-nginx-ingress__common.yaml"
       - "../config/ext_public-nginx-ingress_eks-public.yaml"
+  - name: artifact-caching-proxy
+    namespace: artifact-caching-proxy
+    chart: jenkins-infra/artifact-caching-proxy
+    version: 0.10.3
+    needs:
+      - public-nginx-ingress/public-nginx-ingress # Required to expose the proxy
+    values:
+      - "../config/artifact-caching-proxy__common.yaml"
+      - "../config/artifact-caching-proxy_aws.yaml"
+    secrets:
+      - "../secrets/config/artifact-caching-proxy/secrets.yaml"

--- a/config/artifact-caching-proxy_aws.yaml
+++ b/config/artifact-caching-proxy_aws.yaml
@@ -12,7 +12,7 @@ ingress:
         - repo.aws.jenkins.io
 
 persistence:
-  storageClass: ebs-sc
+  storageClass: ebs-sc-az1-retain
   ## TODO: find a way to helmfile apply this YAML storageclass definition
   ##########
   # apiVersion: storage.k8s.io/v1

--- a/config/ext_autoscaler_cik8s.yaml
+++ b/config/ext_autoscaler_cik8s.yaml
@@ -5,6 +5,10 @@ nodeSelector:
   eks.amazonaws.com/capacityType: ON_DEMAND
   node.kubernetes.io/instance-type: t3a.xlarge
 
+extraArgs:
+  balance-similar-node-groups: true
+replicaCount: 2
+
 rbac:
   create: true
   serviceAccount:

--- a/config/ext_autoscaler_eks-public.yaml
+++ b/config/ext_autoscaler_eks-public.yaml
@@ -5,6 +5,10 @@ nodeSelector:
   eks.amazonaws.com/capacityType: ON_DEMAND
   node.kubernetes.io/instance-type: t3a.xlarge
 
+extraArgs:
+  balance-similar-node-groups: true
+replicaCount: 2
+
 rbac:
   create: true
   serviceAccount:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3305, follows up https://github.com/jenkins-infra/aws/pull/335.

This PR introduces the following changes (already applied on production to validate):

- Revert https://github.com/dduportal/kubernetes-management/commit/0288bb0748a85242f4bf1c126d121817d2cd1c1d
- Use the storage class `ebs-sc-az1-retain` (bound to `us-east-2a` AZ)
- Enable HA for AWS autoscalers
- Enable topology awareness for AWS autoscalers