### PR TITLE
fix(infra.ci.jenkins.io): force Jenkins controller to use IPv4

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -43,7 +43,7 @@ controller:
   overwritePlugins: true
   serviceType: "ClusterIP"
   javaOpts: >-
-    -XshowSettings:vm -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:MaxRAM=4g -XX:+AlwaysPreTouch -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/ -XX:+UseG1GC -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.websocketConnectionTimeout=60
+    -XshowSettings:vm -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:MaxRAM=4g -XX:+AlwaysPreTouch -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/ -XX:+UseG1GC -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.websocketConnectionTimeout=60 -Djava.net.preferIPv4Stack=true
   JCasC:
     enabled: true
     defaultConfig: false


### PR DESCRIPTION
Fix https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/best-practices/stuck-thread-looking-up-ipv6-hostname

Ref: https://github.com/jenkins-infra/helpdesk/issues/2844