### PR TITLE
fix(infra.ci): add Docker hub credentials for incrementals-publisher

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -155,6 +155,8 @@ jobsDefinition:
     name: Other Jobs
     description: Folder hosting all the jobs not fitting any category
     kind: folder
+    credentials:
+      jenkinsinfraadmin-dockerhub-push: *jenkinsinfraadmin-dockerhub-push-def
     children:
       incrementals-publisher:
         name: Incrementals Publisher


### PR DESCRIPTION
Missing credentials noticed in https://github.com/jenkins-infra/incrementals-publisher/pull/23