### PR TITLE
fix(infra.ci): add Docker hub credentials for incrementals-publisher (#3609

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -13,7 +13,7 @@ jobsDefinition:
         description: Docker hub credential for jenkinsinfra organisation PUSH
         username: jenkinsinfraadmin
         password: "${DOCKER_HUB_TOKEN_PUSH}"
-      infracijenkinsio-dockerhub-pull:
+      infracijenkinsio-dockerhub-pull: &jenkinsinfraadmin-dockerhub-pull-def
         description: Docker hub credential for jenkinsinfra organisation PULL
         username: infracijenkinsio
         password: "${DOCKER_HUB_TOKEN_PULL}"
@@ -157,6 +157,7 @@ jobsDefinition:
     kind: folder
     credentials:
       jenkinsinfraadmin-dockerhub-push: *jenkinsinfraadmin-dockerhub-push-def
+      jenkinsinfraadmin-dockerhub-pull: *jenkinsinfraadmin-dockerhub-pull-def
     children:
       incrementals-publisher:
         name: Incrementals Publisher

--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -155,6 +155,8 @@ jobsDefinition:
     name: Other Jobs
     description: Folder hosting all the jobs not fitting any category
     kind: folder
+    credentials:
+      jenkinsinfraadmin-dockerhub-push: *jenkinsinfraadmin-dockerhub-push-def
     children:
       incrementals-publisher:
         name: Incrementals Publisher


### PR DESCRIPTION
The incrementals-publisher job also needs to pull images from jenkinsciinfra Docker hub organisation.

Follow-up of #3608 