### PR TITLE
fix(infra.ci): correct Docker pull credentials name for incrementals-publisher

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -157,7 +157,7 @@ jobsDefinition:
     kind: folder
     credentials:
       jenkinsinfraadmin-dockerhub-push: *jenkinsinfraadmin-dockerhub-push-def
-      jenkinsinfraadmin-dockerhub-pull: *jenkinsinfraadmin-dockerhub-pull-def
+      infracijenkinsio-dockerhub-pull: *jenkinsinfraadmin-dockerhub-pull-def
     children:
       incrementals-publisher:
         name: Incrementals Publisher


### PR DESCRIPTION
Fixup of #3609 