### PR TITLE
fix(infra.ci,release.ci, weekly.ci) improve memory management for JVMs + cleanup JVM options

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -28,10 +28,10 @@ controller:
     resources:
         limits:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
         requests:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
     probes:
         startupProbe:
             initialDelaySeconds: 120
@@ -43,7 +43,7 @@ controller:
     overwritePlugins: true
     serviceType: "ClusterIP"
     javaOpts: >-
-        -XshowSettings:vm -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:MaxRAM=4g -XX:+AlwaysPreTouch -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/ -XX:+UseG1GC -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.websocketConnectionTimeout=60 -Djava.net.preferIPv4Stack=true
+        -XshowSettings:vm -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/ -XX:+UseG1GC -Djava.net.preferIPv4Stack=true
     JCasC:
         enabled: true
         defaultConfig: false

--- a/config/ext_jenkins-release.yaml
+++ b/config/ext_jenkins-release.yaml
@@ -31,10 +31,10 @@ controller:
     resources:
         limits:
             cpu: "2"
-            memory: "8Gi"
+            memory: "4Gi"
         requests:
             cpu: "2"
-            memory: "8Gi"
+            memory: "4Gi"
     probes:
         startupProbe:
             initialDelaySeconds: 120

--- a/config/ext_jenkins-release.yaml
+++ b/config/ext_jenkins-release.yaml
@@ -31,10 +31,10 @@ controller:
     resources:
         limits:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
         requests:
             cpu: "2"
-            memory: "4Gi"
+            memory: "8Gi"
     probes:
         startupProbe:
             initialDelaySeconds: 120
@@ -50,7 +50,7 @@ controller:
     overwritePlugins: true
     serviceType: "ClusterIP"
     javaOpts: >
-        -XshowSettings:vm -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:MaxRAM=4g -XX:+AlwaysPreTouch -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/ -XX:+UseG1GC -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.websocketConnectionTimeout=60
+        -XshowSettings:vm -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/ -XX:+UseG1GC -Djava.net.preferIPv4Stack=true
 
     JCasC:
         enabled: true

--- a/config/ext_jenkins-weekly.yaml
+++ b/config/ext_jenkins-weekly.yaml
@@ -43,7 +43,7 @@ controller:
     overwritePlugins: true
     serviceType: "ClusterIP"
     javaOpts: >-
-        -XshowSettings:vm -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:MaxRAM=4g -XX:+AlwaysPreTouch -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/ -XX:+UseG1GC -Dorg.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.websocketConnectionTimeout=60
+        -XshowSettings:vm -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/ -XX:+UseG1GC -Djava.net.preferIPv4Stack=true
     JCasC:
         enabled: true
         defaultConfig: false


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3378

This PR introduces the following changes:

- Increase the memory for infra.ci from 4 to 8 Gigabyte (nodes have 4 vCPUS and 16 GB: it fits) to had more space to the controller to deal with running pipelines
- Remove the JVM option `MaxRAM` to let the JVM deal with its container memory limits (we are in 2023 and both JDK11 and JDK17 are ok with that, even with cgroups v2)
- Remove the JVM option `org.csanchez.jenkins.plugins.kubernetes.pipeline.ContainerExecDecorator.websocketConnectionTimeout` (impact: the value will be back to its default which is 30s AFAIR)
- Ensure that both release.ci and weekly.ci JVMs are using IPv4 (`-Djava.net.preferIPv4Stack=true`)