### PR TITLE
chore(public-nginx/AKS): replace `spec.loadBalancerIP` by `annotations.service.beta.kubernetes.io/azure-load-balancer-ipv4`

### DIFF
--- a/config/ext_public-nginx-ingress_privatek8s.yaml
+++ b/config/ext_public-nginx-ingress_privatek8s.yaml
@@ -5,6 +5,6 @@ controller:
   service:
     annotations:
       service.beta.kubernetes.io/azure-load-balancer-internal: false
-    # azurerm_public_ip.public_privatek8s.ip_address in https://github.com/jenkins-infra/azure/blob/main/privatek8s.tf
-    loadBalancerIP: 20.15.118.70
+      # azurerm_public_ip.public_privatek8s.ip_address in https://github.com/jenkins-infra/azure/blob/main/privatek8s.tf
+      service.beta.kubernetes.io/azure-load-balancer-ipv4: 20.15.118.70
     externalTrafficPolicy: Local

--- a/config/ext_public-nginx-ingress_prodpublick8s.yaml
+++ b/config/ext_public-nginx-ingress_prodpublick8s.yaml
@@ -3,7 +3,7 @@ controller:
   service:
     annotations:
       service.beta.kubernetes.io/azure-load-balancer-internal: false
+      service.beta.kubernetes.io/azure-load-balancer-ipv4: 52.167.253.43
       prometheus.io/scrape: "true"
       prometheus.io/port: "10254"
-    loadBalancerIP: 52.167.253.43
     externalTrafficPolicy: Local

--- a/config/ext_public-nginx-ingress_publick8s.yaml
+++ b/config/ext_public-nginx-ingress_publick8s.yaml
@@ -3,7 +3,7 @@ controller:
   service:
     annotations:
       service.beta.kubernetes.io/azure-load-balancer-internal: false
-    # azurerm_public_ip.publick8s_ipv4.ip_address in https://github.com/jenkins-infra/azure/blob/main/privatek8s.tf
-    loadBalancerIP: 20.119.232.75
+      # azurerm_public_ip.publick8s_ipv4.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
+      service.beta.kubernetes.io/azure-load-balancer-ipv4: 20.119.232.75
     externalTrafficPolicy: Local
     ipFamilyPolicy: PreferDualStack


### PR DESCRIPTION
Address the deprecation of `spec.loadBalancerIP` introduced with the version 1.24 of Kubernetes, see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#deprecation

This new annotation is available for Kubernetes version 1.21 and later.

See https://github.com/Azure/AKS/issues/3122 & the new AKS load balancer doc: https://cloud-provider-azure.sigs.k8s.io/topics/loadbalancer/

Ref: https://github.com/jenkins-infra/helpdesk/issues/3387