### PR TITLE
fixup(publick8s/public-nginx): complete `spec.ipFamilies` with IPv4 and IPv6

### DIFF
--- a/config/ext_public-nginx-ingress_publick8s.yaml
+++ b/config/ext_public-nginx-ingress_publick8s.yaml
@@ -8,5 +8,5 @@ controller:
       # azurerm_public_ip.publick8s_ipv6.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
       service.beta.kubernetes.io/azure-load-balancer-ipv6: 2603:1030:408:7::44
     externalTrafficPolicy: Local
-    ipFamilies: ["IPv4","IPv6"]
+    ipFamilies: ["IPv4", "IPv6"]
     ipFamilyPolicy: PreferDualStack

--- a/config/ext_public-nginx-ingress_publick8s.yaml
+++ b/config/ext_public-nginx-ingress_publick8s.yaml
@@ -8,5 +8,7 @@ controller:
       # azurerm_public_ip.publick8s_ipv6.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
       service.beta.kubernetes.io/azure-load-balancer-ipv6: 2603:1030:408:7::44
     externalTrafficPolicy: Local
-    ipFamilies: ["IPv4", "IPv6"]
+    ipFamilies:
+      - IPv4
+      - IPv6
     ipFamilyPolicy: PreferDualStack

--- a/config/ext_public-nginx-ingress_publick8s.yaml
+++ b/config/ext_public-nginx-ingress_publick8s.yaml
@@ -5,5 +5,8 @@ controller:
       service.beta.kubernetes.io/azure-load-balancer-internal: false
       # azurerm_public_ip.publick8s_ipv4.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
       service.beta.kubernetes.io/azure-load-balancer-ipv4: 20.119.232.75
+      # azurerm_public_ip.publick8s_ipv6.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
+      service.beta.kubernetes.io/azure-load-balancer-ipv6: 2603:1030:408:7::44
     externalTrafficPolicy: Local
+    ipFamilies: ["IPv4","IPv6"]
     ipFamilyPolicy: PreferDualStack

--- a/config/ext_public-nginx-ingress_publick8s.yaml
+++ b/config/ext_public-nginx-ingress_publick8s.yaml
@@ -8,7 +8,5 @@ controller:
       # azurerm_public_ip.publick8s_ipv6.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
       service.beta.kubernetes.io/azure-load-balancer-ipv6: 2603:1030:408:7::44
     externalTrafficPolicy: Local
-    ipFamilies:
-      - IPv4
-      - IPv6
+    ipFamilies: ["IPv4", "IPv6"]
     ipFamilyPolicy: PreferDualStack


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/kubernetes-management/pull/3624

Fix the following error:
> Error: UPGRADE FAILED: an error occurred while rolling back the release. original upgrade error: cannot patch "public-nginx-ingress-ingress-nginx-controller" with kind Service: Service "public-nginx-ingress-ingress-nginx-controller" is invalid: spec.ipFamilyPolicy: Invalid value: "PreferDualStack": must be 'SingleStack' to release the secondary IP family: cannot patch "public-nginx-ingress-ingress-nginx-controller" with kind Service: Service "public-nginx-ingress-ingress-nginx-controller" is invalid: spec.ipFamilyPolicy: Invalid value: "PreferDualStack": must be 'SingleStack' to release the secondary IP family

Indeed, by default the `spec.ipFamilies` has only "IPv4" as value, adding "IPv6" to it allows the "PreferDualStack" value for `spec.ipFamilyPolicy`

Corresponding doc: https://kubernetes.io/docs/concepts/services-networking/dual-stack/

Ref: https://github.com/jenkins-infra/helpdesk/issues/3307 & https://github.com/jenkins-infra/helpdesk/issues/3387