### PR TITLE
chore: pin GitHub actions with their SHA-1 instead of their version number

### DIFF
--- a/.github/workflows/delete-unmerged-branch.yaml
+++ b/.github/workflows/delete-unmerged-branch.yaml
@@ -1,10 +1,8 @@
 name: Delete unmerged branch
-
 on:
   pull_request:
-    branches: [ main ]
-    types: [ closed ]
-
+    branches: [main]
+    types: [closed]
 jobs:
   worker:
     if: ${{ github.event.pull_request.merged_at == '' }}


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3402