### PR TITLE
feat(updatecli): add the jenkins-infra (puppet) entry to updatecli

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -151,6 +151,9 @@ jobsDefinition:
     children:
       kubernetes-management:
         jenkinsfilePath: Jenkinsfile_updatecli
+      jenkins-infra:
+        name: Puppet (jenkins-infra)
+        jenkinsfilePath: Jenkinsfile_updatecli
   other-jobs:
     name: Other Jobs
     description: Folder hosting all the jobs not fitting any category


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3419 
this PR add the repository jenkins-infra with the jenkins file `Jenkinsfile_updatecli` to the infra.ci.jenkins.io in order to replace the GHA.
The `Jenkinsfile_updatecli` is provided by the PR : https://github.com/jenkins-infra/jenkins-infra/pull/2673