### PR TITLE
chore(infra.ci): set Maven version to 3.9.0

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -613,7 +613,7 @@ controller:
                       - installSource:
                           installers:
                           - maven:
-                              id: "3.8.6"
+                              id: "3.9.0"
     sidecars:
         configAutoReload:
             env:


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3396