### PR TITLE
fix(artifact-caching-proxy): update mirrored repositories list to be the same on infra.ci and ci.jenkins.io

### DIFF
--- a/config/ext_jenkins-infra.yaml
+++ b/config/ext_jenkins-infra.yaml
@@ -435,7 +435,7 @@ controller:
                               <mirror>
                                   <id>aws-proxy</id>
                                   <url>https://repo.aws.jenkins.io/public/</url>
-                                  <mirrorOf>repo.jenkins-ci.org</mirrorOf>
+                                  <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots</mirrorOf>
                               </mirror>
                               <mirror>
                                   <id>aws-proxy-incrementals</id>
@@ -461,7 +461,7 @@ controller:
                               <mirror>
                                   <id>azure-proxy</id>
                                   <url>https://repo.azure.jenkins.io/public/</url>
-                                  <mirrorOf>repo.jenkins-ci.org</mirrorOf>
+                                  <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots</mirrorOf>
                               </mirror>
                               <mirror>
                                   <id>azure-proxy-incrementals</id>
@@ -487,7 +487,7 @@ controller:
                               <mirror>
                                   <id>do-proxy</id>
                                   <url>https://repo.do.jenkins.io/public/</url>
-                                  <mirrorOf>repo.jenkins-ci.org</mirrorOf>
+                                  <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots</mirrorOf>
                               </mirror>
                               <mirror>
                                   <id>do-proxy-incrementals</id>


### PR DESCRIPTION
Cf https://github.com/jenkins-infra/jenkins-infra/pull/2674#issuecomment-1452076960

Settings on ci.jenkins.io defined here: https://github.com/jenkins-infra/jenkins-infra/blob/production/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb

Ref: https://github.com/jenkins-infra/helpdesk/issues/2752