### PR TITLE
fix(infra.ci) ensure that the updatecli job for puppet (jenkins-infra) watches the correct branches (production, etc.)

### DIFF
--- a/config/ext_jenkins-infra-jobs.yaml
+++ b/config/ext_jenkins-infra-jobs.yaml
@@ -154,6 +154,7 @@ jobsDefinition:
       jenkins-infra:
         name: Puppet (jenkins-infra)
         jenkinsfilePath: Jenkinsfile_updatecli
+        branchIncludes: "production staging updatecli_* PR-* main"
   other-jobs:
     name: Other Jobs
     description: Folder hosting all the jobs not fitting any category


### PR DESCRIPTION
Fixup of #3648 