### PR TITLE
feat(cik8s,doks) increase the max. pod quotas for jenkins-agents namespaces

### DIFF
--- a/clusters/cik8s.yaml
+++ b/clusters/cik8s.yaml
@@ -51,7 +51,7 @@ releases:
       - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
     set:
       - name: "quotas.pods"
-        value: "120"
+        value: "150"
   - name: autoscaler
     namespace: autoscaler
     chart: autoscaler/cluster-autoscaler

--- a/clusters/doks.yaml
+++ b/clusters/doks.yaml
@@ -45,4 +45,4 @@ releases:
       - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
     set:
       - name: "quotas.pods"
-        value: "30"
+        value: "66"


### PR DESCRIPTION
- Reference for cik8s: https://github.com/jenkins-infra/jenkins-infra/blob/b2ed0ee76d2d362a51353fa511a86b6792c10cd8/hieradata/clients/azure.ci.jenkins.io.yaml#L148
- Reference for doks: https://github.com/jenkins-infra/jenkins-infra/blob/b2ed0ee76d2d362a51353fa511a86b6792c10cd8/hieradata/clients/azure.ci.jenkins.io.yaml#L247

(edit) this PR follows up https://github.com/jenkins-infra/jenkins-infra/pull/2655 which changed the quotas on the Jenkins Kuberenetes plugin side. I forgot to propagate the change manually on Kubernetes side.

PS: this change will be automated by an updatecli manifest soon (ref. jenkins-infra/helpdesk#3431)