### PR TITLE
feat(doks) increase the max. pod quotas for jenkins-agents namespaces

### DIFF
--- a/clusters/doks.yaml
+++ b/clusters/doks.yaml
@@ -45,4 +45,4 @@ releases:
       - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
     set:
       - name: "quotas.pods"
-        value: "66"
+        value: "150"


### PR DESCRIPTION
As the droplets limit on DigitalOcean account has been increased to 100, we can now increase this cluster capacity to be the same as the AWS one.

Follow-up of https://github.com/jenkins-infra/jenkins-infra/pull/2679 & #3660 