### PR TITLE
chore(updatecli) track the maven tool version for infra.ci.jenkins.io

### DIFF
--- a/updatecli/updatecli.d/charts/jenkins-infra-tools-maven.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-infra-tools-maven.yaml
@@ -1,0 +1,65 @@
+---
+name: Bump Maven version (Jenkins tools) on infra.ci.jenkins.io
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  packerImageVersion:
+    kind: githubrelease
+    name: get last packer-image release
+    spec:
+      owner: "jenkins-infra"
+      repository: "packer-images"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+  getMavenVersionFromPackerImages:
+    kind: file
+    name: Get the latest Maven version set in packer-images
+    dependson:
+      - packerImageVersion
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "packerImageVersion" }}/provisioning/tools-versions.yml
+      matchpattern: 'maven_version:\s"(.*)"'
+    transformers:
+      - findsubmatch:
+          pattern: 'maven_version:\s"(.*)"'
+          captureindex: 1
+
+conditions:
+  checkIfReleaseIsAvailable:
+    kind: shell
+    disablesourceinput: true
+    spec:
+      command: curl --connect-timeout 5 --location --head --fail --silent --show-error https://archive.apache.org/dist/maven/maven-3/{{ source `getMavenVersionFromPackerImages` }}/binaries/apache-maven-{{ source `getMavenVersionFromPackerImages` }}-bin.tar.gz
+
+targets:
+  setMavenToolVersion:
+    name: "Bump Maven tool version on infra.ci.jenkins.io"
+    kind: file
+    sourceid: getMavenVersionFromPackerImages
+    spec:
+      file: config/ext_jenkins-infra.yaml
+      matchpattern: '- maven:((\r\n|\r|\n)(\s+))id: .*'
+      replacepattern: '- maven:${1}id: "{{ source "getMavenVersionFromPackerImages" }}"'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump Maven version (Jenkins tools) on infra.ci.jenkins.io to {{ source "getMavenVersionFromPackerImages" }}
+    spec:
+      labels:
+        - dependencies
+        - maven
+        - infra.ci.jenkins.io


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3396#issuecomment-1451997725

This PR  ensures that updatecli track the Maven version to update the tool version in infra.ci.jenkins.io.