### PR TITLE
fix(privatek8s.yaml): put the core package PVCs in the same namespace as the release agents

### DIFF
--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -85,7 +85,7 @@ releases:
     secrets:
       - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
   - name: jenkins-release-core-package
-    namespace: jenkins-release
+    namespace: jenkins-release-agents
     chart: jenkins-infra/env-jenkins-release
     version: 0.2.0
     secrets:


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/2844