### PR TITLE
Added namespace creation to docker-registry-secrets Helm chart

### DIFF
--- a/clusters/doks.yaml
+++ b/clusters/doks.yaml
@@ -13,17 +13,21 @@ repositories:
 releases:
   - name: docker-registry-secrets
     # This helm chart doesn't create any resources within the namespace specified below.
-    # Specifying a namespace is required by the "needs" feature of helmfile (to allow referencing to this release from others)
-    namespace: default
-    chart: jenkins-infra/docker-registry-secrets
-    version: 0.1.0
-    values:
-      - "../config/docker-registry-secrets.yaml"
-    set:
-      - name: "imageCredentials.namespaces[1]"
-        value: jenkins-agents
-    secrets:
-      - "../secrets/config/docker-registry-secrets/secrets.yaml"
+    # Specifying a namespace is required by the "needs" feature of helmfile (to allow referencing to this release from others)                                                                                                                                                                                                                                                                                                                                        
+namespace:
+  create: true
+  name: jenkins-agents
+
+chart: jenkins-infra/docker-registry-secrets 
+version: 0.1.0 
+values: 
+  - "../config/docker-registry-secrets.yaml" 
+  - imageCredentials:
+      namespaces:
+        - default
+        - jenkins-agents  # add jenkins-agents as second namespace
+secrets: 
+  - "../secrets/config/docker-registry-secrets/secrets.yaml"
   - name: datadog
     needs:
       - default/docker-registry-secrets


### PR DESCRIPTION
Fixes issue where docker-registry-secrets Helm release fails to install
due to missing namespace. This commit adds a `namespace` field to the
`values.yaml` file with `create` set to `true` and `name` set to
`jenkins-agents` to create the namespace before installing the Helm chart.

Additionally, the `imageCredentials.namespaces[1]` value is updated to include the `jenkins-agents` namespace.

This resolves the issue and allows for successful installation of the docker-registry-secrets Helm chart.

Issue: #2278