### PR TITLE
chore(infra.ci/updatecli): add Azure version from packer image version in updatecli manifest

### DIFF
--- a/updatecli/updatecli.d/charts/jenkins-agents-infra.ci.jenkins.io.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-agents-infra.ci.jenkins.io.yaml
@@ -63,6 +63,15 @@ targets:
       matchpattern: '- ami: ".*"(.*)LINUXARM64'
       replacepattern: '- ami: "{{ source `getLatestUbuntuAgentAMIArm64` }}"${1}LINUXARM64'
     scmid: default
+  setAzureGalleryImageVersion:
+    sourceid: packerImageVersion
+    name: "Bump Azure Gallery Image Version for azureVM"
+    kind: file
+    spec:
+      file: config/ext_jenkins-infra.yaml
+      matchpattern: 'galleryImageVersion: ".*"'
+      replacepattern: 'galleryImageVersion: "{{ source `packerImageVersion` }}"'
+    scmid: default
 
 actions:
   default:


### PR DESCRIPTION
Still missing a condition that check the existence of the image within the azure gallery of packer-image with  
`az image list or show`