### PR TITLE
fix: force accountapp Docker image bump

### DIFF
--- a/config/accountapp.yaml
+++ b/config/accountapp.yaml
@@ -1,5 +1,7 @@
 image:
   pullPolicy: IfNotPresent
+  # TODO: remove as soon as a new version of the account-app is published
+  tag: 0.2.63
 ingress:
   enabled: true
   className: public-nginx


### PR DESCRIPTION
As the helm chart release GitHub Action hasn't been triggered by https://github.com/jenkins-infra/helm-charts/commit/771c1c2b00daabd697748a2c618745e757a41521 nor https://github.com/jenkins-infra/helm-charts/commit/b041e70256f653207f04c68fee6e33cb551a66f0, this PR is bumping the Docker image version directly in its values.

Include the hotfix to unblock accounts.jenkins.io content: https://github.com/jenkins-infra/account-app/pull/254
Cf https://github.com/jenkins-infra/account-app/issues/250