### PR TITLE
fix: force account-app docker image bump

### DIFF
--- a/config/accountapp.yaml
+++ b/config/accountapp.yaml
@@ -1,7 +1,7 @@
 image:
   pullPolicy: IfNotPresent
-  # TODO: remove as soon as a new version of the account-app is published
-  tag: 0.2.63
+  # TODO: remove as soon as a version above 0.2.56 of the account-app helm chart is published
+  tag: 0.2.64
 ingress:
   enabled: true
   className: public-nginx


### PR DESCRIPTION
Same as #3767 to include https://github.com/jenkins-infra/account-app/pull/251 as https://github.com/jenkins-infra/account-app/pull/254 didn't work