### PR TITLE
chore(updatecli) ensure that Maven version is retrieved from the production deployed image instead of the 'main' branch that may be unreleased

### DIFF
--- a/updatecli/updatecli.d/charts/jenkins-infra-tools-maven.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-infra-tools-maven.yaml
@@ -14,7 +14,7 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  getPackerImageDeployedVersion:
+  getDeployedPackerImageVersion:
     kind: file
     name: Retrieve the current version of the Packer images used in production
     spec:
@@ -27,9 +27,9 @@ sources:
     kind: file
     name: Get the latest Maven version set in packer-images
     dependson:
-      - getPackerImageDeployedVersion
+      - getDeployedPackerImageVersion
     spec:
-      file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getPackerImageDeployedVersion" }}/provisioning/tools-versions.yml
+      file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getDeployedPackerImageVersion" }}/provisioning/tools-versions.yml
       matchpattern: 'maven_version:\s"(.*)"'
     transformers:
       - findsubmatch:

--- a/updatecli/updatecli.d/charts/jenkins-infra-tools-maven.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-infra-tools-maven.yaml
@@ -14,21 +14,22 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  packerImageVersion:
-    kind: githubrelease
-    name: get last packer-image release
+  getPackerImageDeployedVersion:
+    kind: file
+    name: Retrieve the current version of the Packer images used in production
     spec:
-      owner: "jenkins-infra"
-      repository: "packer-images"
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
+      file: ./config/jenkins_infra.ci.jenkins.io.yaml
+    transformers:
+      - findsubmatch:
+          pattern: 'galleryImageVersion:\s"(.*)"'
+          captureindex: 1
   getMavenVersionFromPackerImages:
     kind: file
     name: Get the latest Maven version set in packer-images
     dependson:
-      - packerImageVersion
+      - getPackerImageDeployedVersion
     spec:
-      file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "packerImageVersion" }}/provisioning/tools-versions.yml
+      file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getPackerImageDeployedVersion" }}/provisioning/tools-versions.yml
       matchpattern: 'maven_version:\s"(.*)"'
     transformers:
       - findsubmatch:


### PR DESCRIPTION
Blocked by ~https://github.com/jenkins-infra/kubernetes-management/pull/3773~ https://github.com/jenkins-infra/kubernetes-management/pull/3798  (due to filename changes).

Since #3750 we now have (easy) access to the semantic version of the packer images used for agents in the configuration.

This PR ensures that updatecli uses this version to check the expected Maven version for tools.