### PR TITLE
chore: temporarily decrease doks capacity

### DIFF
--- a/config/jenkins-kubernetes-agents_ci-jenkins-io_doks.yaml
+++ b/config/jenkins-kubernetes-agents_ci-jenkins-io_doks.yaml
@@ -1,2 +1,2 @@
 quotas:
-  pods: 150
+  pods: 50


### PR DESCRIPTION
Decrease `doks` capacity until credits are renewed.

Related: https://github.com/jenkins-infra/jenkins-infra/pull/2745

Ref: https://github.com/jenkins-infra/helpdesk/issues/3487