### PR TITLE
feat(privatek8s) enable load balancer deny list for the public ingress, in full IPv4

### DIFF
--- a/config/public-nginx-ingress_privatek8s.yaml
+++ b/config/public-nginx-ingress_privatek8s.yaml
@@ -1,10 +1,11 @@
 controller:
   config:
     # Only allow GitHub's webhooks requests - https://api.github.com/meta ("hooks", tracked by updatecli)
-    whitelist-source-range: "140.82.112.0/20,143.55.64.0/20,185.199.108.0/22,192.30.252.0/22,2606:50c0::/32,2a0a:a440::/29"
+    whitelist-source-range: "140.82.112.0/20,143.55.64.0/20,185.199.108.0/22,192.30.252.0/22"
   service:
     annotations:
       service.beta.kubernetes.io/azure-load-balancer-internal: false
       # azurerm_public_ip.public_privatek8s.ip_address in https://github.com/jenkins-infra/azure/blob/main/privatek8s.tf
       service.beta.kubernetes.io/azure-load-balancer-ipv4: 20.15.118.70
     externalTrafficPolicy: Local
+    loadBalancerSourceRanges: ["140.82.112.0/20", "143.55.64.0/20", "185.199.108.0/22", "192.30.252.0/22"]

--- a/updatecli/updatecli.d/allowed-github-hooks-ips.yaml
+++ b/updatecli/updatecli.d/allowed-github-hooks-ips.yaml
@@ -13,20 +13,38 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  githubHooksIps:
+  githubHooksIpV4:
     kind: shell
-    name: get GitHub hooks IPs
+    name: get GitHub hooks IPv4s
     spec:
-      command: curl https://api.github.com/meta | jq -r '.hooks | sort | join(",")'
+      command: curl --silent --show-error https://api.github.com/meta | jq -r '.hooks | map(select(contains(":") | not)) | sort | join(",")'
+  githubHooksIpV4YamlArray:
+    kind: shell
+    dependson:
+      - githubHooksIpV4
+    name: Format the IP list
+    spec:
+      command: echo {{ source `githubHooksIpV4` }} | sed 's/,/", "/g'
 
 targets:
-  allowIPs:
+  allowIPsIngress:
     name: Update allowed IPs
     kind: yaml
+    sourceid: githubHooksIpV4
     scmid: default
     spec:
       file: config/public-nginx-ingress_privatek8s.yaml
       key: controller.config.whitelist-source-range
+  allowIPsLB:
+    name: Update allowed IPs
+    # It does not seem possible to split a string to a YAML array so using regexp in file mode instead
+    kind: file
+    sourceid: githubHooksIpV4YamlArray
+    scmid: default
+    spec:
+      file: config/public-nginx-ingress_privatek8s.yaml
+      matchpattern: 'loadBalancerSourceRanges(.*)'
+      replacepattern: 'loadBalancerSourceRanges: ["{{ source `githubHooksIpV4YamlArray` }}"]'
 
 actions:
   default:


### PR DESCRIPTION
While working on the migration https://github.com/jenkins-infra/helpdesk/issues/2844, @lemeurherve and I realized that the IP restriction of the public nginx ingress on the `privatek8s` cluster was only at the NBginx level.

It works as expected, but we can improve this with this PR, by ensuring that the IP denylist is also set at the Loadbalancer level.

The command 

```
curl --silent --verbose --insecure https://20.15.118.70 --output /dev/null 
```

should timeout once deployed, unless run from an authorized IP.

- The value `co,ntroller.service.loadBalancerSourceRanges` is documented in https://github.com/kubernetes/ingress-nginx/blob/26d83d1b2058cc9c23657b4e97b9e5a6d5fe9871/charts/ingress-nginx/README.md?plain=1#L292

- We already use it on the `prodpublick8s` cluster (for LDAP: https://github.com/jenkins-infra/helm-charts/blob/c1c01ce01a23d6c23861b3eebdfcf7b005376c08/charts/ldap/templates/service.yaml#L13): the AKS LoadBalancers are working properly with it

- This PR has been tested manually: the attribute `loadBalancerSourceRanges` was defined manually and the `curl` command timed out as expected. This manual change was rollbacked

- The updatecli manifest is failing in this PR but was tested locally without the `scmid/action`.
  - Note that only IPv4 is used, the IPv6 are filtered out: the network setup on `privatek8s` cluster does not allow for IPv6 at all.
  - I had to "cheat" by using a "file matchpattern" to define the YAMl list from the collection returned by updatecli. Ping @olblak if you have a better solution (my source is a string that can be split by `,`, my target is a YAML array)