### PR TITLE
feat(cik8s) add a new 'jenkins-agents-bom' namespace ready for handling 'bom' builds

### DIFF
--- a/clusters/cik8s.yaml
+++ b/clusters/cik8s.yaml
@@ -56,7 +56,7 @@ releases:
     chart: jenkins-infra/jenkins-kubernetes-agents
     version: 0.4.0
     values:
-      - "../config/jenkins-kubernetes-agents_ci.jenkins.io_cik8s.yaml"
+      - "../config/jenkins-kubernetes-agents_ci.jenkins.io_cik8s-bom.yaml"
     secrets:
       - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
   - name: autoscaler

--- a/clusters/cik8s.yaml
+++ b/clusters/cik8s.yaml
@@ -51,6 +51,14 @@ releases:
       - "../config/jenkins-kubernetes-agents_ci.jenkins.io_cik8s.yaml"
     secrets:
       - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
+  - name: jenkins-agents-bom
+    namespace: jenkins-agents-bom
+    chart: jenkins-infra/jenkins-kubernetes-agents
+    version: 0.4.0
+    values:
+      - "../config/jenkins-kubernetes-agents_ci.jenkins.io_cik8s.yaml"
+    secrets:
+      - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
   - name: autoscaler
     namespace: autoscaler
     chart: autoscaler/cluster-autoscaler

--- a/config/jenkins-kubernetes-agents_ci.jenkins.io_cik8s-bom.yaml
+++ b/config/jenkins-kubernetes-agents_ci.jenkins.io_cik8s-bom.yaml
@@ -1,0 +1,2 @@
+quotas:
+  pods: "345"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3521

This PR adds a new namespace `jenkins-agents-bom` in the cluster `cik8s` (AWS EKS) to ensure:

- Logical and clear separation (for metrics, logs, configuration)
- Ease the definition of pod limit


Note that the docker-registry-secrets are not set up: it should not be needed (as the images `jenkinsciinfra/*` are not rate limited)