### PR TITLE
fix(datadog in cik8s) ensure datadog agent runs on all node pools

### DIFF
--- a/config/datadog_cik8s.yaml
+++ b/config/datadog_cik8s.yaml
@@ -4,3 +4,10 @@ clusterAgent:
   image:
     pullSecrets:
       - name: "dockerhub-credential"
+agents:
+  tolerations:
+    # These tolerations are needed to run the agents on the bom node pool
+    - key: "ci.jenkins.io/bom"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3521.