### PR TITLE
chore(infra.ci): separated updatecli pipeline for `packer-images`

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -149,12 +149,14 @@ jobsDefinition:
       # Used by updatecli to retrieve AMIs
       packer-aws-secret-access-key: *packer-aws-secret-access-key-def
     children:
-      kubernetes-management:
-        jenkinsfilePath: Jenkinsfile_updatecli
       jenkins-infra:
         name: Puppet (jenkins-infra)
         jenkinsfilePath: Jenkinsfile_updatecli
         branchIncludes: "production staging updatecli_* PR-* main"
+      kubernetes-management:
+        jenkinsfilePath: Jenkinsfile_updatecli
+      packer-images:
+        jenkinsfilePath: Jenkinsfile_updatecli
   other-jobs:
     name: Other Jobs
     description: Folder hosting all the jobs not fitting any category


### PR DESCRIPTION
Needed for https://github.com/jenkins-infra/packer-images/pull/606

Ref: https://github.com/jenkins-infra/helpdesk/issues/2778