### PR TITLE
hotfix(prodpublick8s) migrate mirrorbits PV to native CSI, use a 1000 Gib size and fine-tune mountoptions

### DIFF
--- a/config/mirrorbits.yaml
+++ b/config/mirrorbits.yaml
@@ -56,29 +56,33 @@ repository:
     spec:
       accessModes:
         - ReadWriteMany
-      storageClassName: azurefile
+      storageClassName: azurefile-csi-premium
       resources:
         requests:
-          storage: 500Gi
-      selector:
-        matchLabels:
-          data: mirrorbits-binary
+          storage: 1000Gi
+      volumeName: mirrorbits-binary
   persistentVolume:
     enabled: true
     spec:
       capacity:
-        storage: 500Gi
-      storageClassName: azurefile
+        storage: 1000Gi
+      storageClassName: azurefile-csi-premium
       accessModes:
         - ReadWriteMany
-      azureFile:
-        secretName: mirrorbits-binary
-        secretNamespace: mirrorbits
-        shareName: mirrorbits
-        readOnly: true
+      persistentVolumeReclaimPolicy: Retain
+      csi:
+        driver: file.csi.azure.com
+        readOnly: false
+        volumeHandle: mirrorbits-binary  # make sure this volumeid is unique for every identical share in the cluster
+        volumeAttributes:
+          resourceGroup: prod-core-releases
+          shareName: mirrorbits
+        nodeStageSecretRef:
+          name: mirrorbits-binary
+          namespace: mirrorbits
       mountOptions:
-        - dir_mode=0777
-        - file_mode=0777
+        - dir_mode=0755
+        - file_mode=0644
         - uid=1000
         - gid=1000
         - mfsymlinks


### PR DESCRIPTION
- Current used disk space is 486 Gb which is over the 80% threshold with a 500 Gib volume => setting it to `1000 Gib`
- Switch to CSI-premium tier to ensure performances
- Use CSI native options to eavoid any kind of "autoamtic" migration
- Fine tuned the mount options: only the owner should be able to write