### PR TITLE
fix(prodpublick8s) tune mirrorbit to fit resource usage

### DIFF
--- a/config/mirrorbits.yaml
+++ b/config/mirrorbits.yaml
@@ -1,21 +1,21 @@
 replicaCount:
-  mirrorbits: 3
-  files: 3
+  mirrorbits: 2
+  files: 2
 resources:
   mirrorbits:
     limits:
-      cpu: 2000m
-      memory: 2048Mi
+      cpu: 500m
+      memory: 1024Mi
     requests:
-      cpu: 2000m
-      memory: 2048Mi
+      cpu: 500m
+      memory: 1024Mi
   files:
     limits:
-      cpu: 500m
-      memory: 256Mi
+      cpu: 2000m
+      memory: 2048Mi
     requests:
-      cpu: 500m
-      memory: 256Mi
+      cpu: 2000m
+      memory: 2048Mi
 ingress:
   enabled: true
   className: public-nginx


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3525 (incident on the service get.jenkins.io).

As per datadog metrics for the past week:

- The deployment `mirrorbit` does not use as much resources as its resources definitions states, let's decrease:

<img width="1773" alt="Capture d’écran 2023-04-19 à 14 29 42" src="https://user-images.githubusercontent.com/1522731/233075632-1bcf9f84-2091-4e8b-84cf-f37602eb7c1b.png">


<img width="1783" alt="Capture d’écran 2023-04-19 à 14 29 23" src="https://user-images.githubusercontent.com/1522731/233075615-504f8f78-7eb6-41b6-a350-4514cf28cff9.png">

- The deployment `mirrorbit-files` is constantly OOM killed: its resources definition is too low compared to what we observe on datadog:

<img width="1786" alt="Capture d’écran 2023-04-19 à 14 20 26" src="https://user-images.githubusercontent.com/1522731/233075817-9a0e34d3-aace-4997-a794-19185395fc46.png">
<img width="1775" alt="Capture d’écran 2023-04-19 à 14 27 06" src="https://user-images.githubusercontent.com/1522731/233075828-29bf8acf-f24e-4b9b-82e0-3dc1afd94515.png">


- Decrease the amount of replicas to `2` to reduce pressure on the persistent volume which seems really busy on Azure side:

<img width="1088" alt="Capture d’écran 2023-04-19 à 13 37 53" src="https://user-images.githubusercontent.com/1522731/233075931-e3c4a72e-fa59-4da3-82b6-bfbf3641f851.png">

