### PR TITLE
chore(accountapp): switch mail provider from Sendgrid to Mailgun

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -115,7 +115,7 @@ releases:
   - name: accountapp
     namespace: accountapp
     chart: jenkins-infra/accountapp
-    version: 0.3.3
+    version: 0.4.0
     values:
       - "../config/accountapp.yaml"
     secrets:

--- a/config/accountapp.yaml
+++ b/config/accountapp.yaml
@@ -30,3 +30,6 @@ resources:
   requests:
     cpu: 500m
     memory: 512Mi
+smtp:
+  server: smtp.mailgun.org
+  port: 587


### PR DESCRIPTION
Needs https://github.com/jenkins-infra/helm-charts/pull/495

The corresponding SMTP accounts credentials has been stored in accountapp secrets.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3534#issuecomment-1521371887