### PR TITLE
fix(eks-public,cik8s) use the latest AWS IAM credentials

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -46,7 +46,7 @@ pipeline {
         DIGITALOCEAN_ACCESS_TOKEN = credentials('production-terraform-digitalocean-pat')
         // Required for AWS-hosted clusters.
         // Variable name is constrained (ref. https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html)
-        AWS_SHARED_CREDENTIALS_FILE       = credentials('eks_charter_awsconfig')
+        AWS_SHARED_CREDENTIALS_FILE       =   "${K8S_CLUSTER == 'cik8s' || K8S_CLUSTER == 'eks-public' ? credentials("${K8S_CLUSTER}-charter-awsconfig") : ''}"
       }
         stages {
           stage('Prepare Environment'){

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -105,10 +105,14 @@ jobsDefinition:
           production-terraform-digitalocean-pat:
             secret: "${PRODUCTION_TERRAFORM_DIGITALOCEAN_PAT}"
             description: "Digital Ocean PAT for production"
-          # TODO: check if this credential is still required (as svc account is used for cik8s)
-          eks_charter_awsconfig:
+          # Used by AWS terraform and kubernetes-management
+          eks-public-charter-awsconfig:
             fileName: "credentials"
-            secretBytes: "${base64:${EKS_CHARTER_AWSCONFIG}}"
+            secretBytes: "${base64:${EKS_PUBLIC_CHARTER_AWSCONFIG}}"
+          # Used by AWS terraform and kubernetes-management
+          cik8s-charter-awsconfig:
+            fileName: "credentials"
+            secretBytes: "${base64:${CIK8S_CHARTER_AWSCONFIG}}"
           kubeconfig-cik8s:
             fileName: "kubeconfig"
             description: "Kubeconfig file for cik8s"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3542 

The checks for cik8s and eks-ublic are expected to fail as the PR contains both the pipeline change and the new secrets (need to be merged and applied).