### PR TITLE
fix(cik8s) update AWS environement values (ARNs, namespaces etc.)

### DIFF
--- a/clusters/cik8s.yaml
+++ b/clusters/cik8s.yaml
@@ -28,6 +28,8 @@ releases:
     set:
       - name: "imageCredentials.namespaces[1]"
         value: jenkins-agents
+      - name: "imageCredentials.namespaces[2]"
+        value: jenkins-agents-bom
     secrets:
       - "../secrets/config/docker-registry-secrets/secrets.yaml"
   - name: datadog
@@ -67,7 +69,7 @@ releases:
       - "../config/autoscaler_cik8s.yaml"
     set:
       - name: autoDiscovery.clusterName
-        value: jenkins-infra-eks-ENRZrfwf
+        value: cik8s-ENRZrfwf
   - name: aws-node-termination-handler
     namespace: eks
     chart: eks/aws-node-termination-handler

--- a/config/autoscaler_cik8s.yaml
+++ b/config/autoscaler_cik8s.yaml
@@ -16,7 +16,7 @@ rbac:
     name: cluster-autoscaler-aws-cluster-autoscaler-chart
     annotations:
       # This value should match the ARN of the role created by module.iam_assumable_role_admin
-      eks.amazonaws.com/role-arn: "arn:aws:iam::200564066411:role/cluster-autoscaler-aws-cluster-autoscaler-chart-eks"
+      eks.amazonaws.com/role-arn: "arn:aws:iam::200564066411:role/cluster-autoscaler-aws-cluster-autoscaler-chart-cik8s"
 
 autoDiscovery:
   enabled: true


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3542

This PR updates the values of some helmfile releases installed in `cik8s` to map to the new values (as per the creation of the new `cik8s` cluster).