### PR TITLE
chore(accountapp): switch mail provider from Sendgrid to Mailgun

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -115,7 +115,7 @@ releases:
   - name: accountapp
     namespace: accountapp
     chart: jenkins-infra/accountapp
-    version: 0.3.3
+    version: 0.5.0
     values:
       - "../config/accountapp.yaml"
     secrets:

--- a/config/accountapp.yaml
+++ b/config/accountapp.yaml
@@ -30,6 +30,7 @@ resources:
   requests:
     cpu: 500m
     memory: 512Mi
-# smtp:
-  # server: smtp.mailgun.org
-  # port: 587
+smtp:
+  server: smtp.mailgun.org
+  sender: accounts@jenkins.io
+  port: 587


### PR DESCRIPTION
Switch from Sendgrid to Mailgun to be able to diagnose emails issues.

Set email sender address to `accounts@jenkins.io` instead of `admin@jenkins-ci.org`

Applied locally to check account creation notification: ✅ 

![image](https://user-images.githubusercontent.com/91831478/234543653-d763ce69-c7d6-48bc-81b7-3a04665760e7.png)

Supersedes and closes #3874 

Ref: https://github.com/jenkins-infra/helpdesk/issues/3534