### PR TITLE
feat(cik8s) add a new agent namespace to support experiments

### DIFF
--- a/clusters/cik8s.yaml
+++ b/clusters/cik8s.yaml
@@ -56,6 +56,14 @@ releases:
       - "../config/jenkins-kubernetes-agents_ci.jenkins.io_cik8s-bom.yaml"
     secrets:
       - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
+  - name: jenkins-agents-experiments
+    namespace: jenkins-agents-experiments
+    chart: jenkins-infra/jenkins-kubernetes-agents
+    version: 0.5.0
+    values:
+      - "../config/jenkins-kubernetes-agents_ci.jenkins.io_cik8s-bom.yaml"
+    secrets:
+      - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
   - name: autoscaler
     namespace: autoscaler
     chart: autoscaler/cluster-autoscaler

--- a/config/jenkins-kubernetes-agents_ci.jenkins.io_cik8s-experiments.yaml
+++ b/config/jenkins-kubernetes-agents_ci.jenkins.io_cik8s-experiments.yaml
@@ -1,0 +1,2 @@
+quotas:
+  pods: "345"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3521#issuecomment-1521474486

This PR adds a new namespace for agents in `cik8s`. This namespace is expected to host "experiments" with new node pools/resources.


Updatecli PR will follow once merge, to update the quotas.