### PR TITLE
cleanup(release.ci) change default (unused) windows inbound agent container image

### DIFF
--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -240,7 +240,7 @@ controller:
                     instanceCapStr: "5"
                     containers:
                       - name: jnlp
-                        image: "jenkinsciinfra/inbound-agent:windowsservercore-1809"
+                        image: "jenkins/inbound-agent:jdk11-windowsservercore-ltsc2019"
                         envVars:
                         - envVar:
                             key: "JENKINS_JAVA_BIN"


### PR DESCRIPTION
Follow up of https://github.com/jenkins-infra/docker-inbound-agents/pull/77

The `jnlp-windows` base pod template is not used by the release jobs (they have their own yaml definition) but it's a nice feature to provide a base working image to allow extending from in the future => that's why this PR updates the image instead of removing the template (as you suggested to not remove it)