### PR TITLE
chore: remove custom Datadog HTTP checks from `eks-public` cluster

### DIFF
--- a/clusters/eks-public.yaml
+++ b/clusters/eks-public.yaml
@@ -85,7 +85,6 @@ releases:
     values:
       - "../config/datadog.yaml.gotmpl"
       - "../config/datadog_eks-public.yaml"
-      - "../config/datadog_confd_checksd.yaml"
     secrets:
       - "../secrets/config/datadog/eks-public-secrets.yaml"
   - name: public-nginx-ingress


### PR DESCRIPTION
Avoid surcharging DNS requests from AWS clusters.

Related: https://github.com/jenkins-infra/helpdesk/issues/3559