### PR TITLE
chore: remove `docker-datadog` from infra.ci.jenkins.io jobs

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -34,7 +34,6 @@ jobsDefinition:
       docker-builder:
       docker-confluence-data:
       docker-crond:
-      docker-datadog:
       docker-hashicorp-tools:
       docker-helmfile:
       docker-inbound-agents:


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/docker-datadog/pull/13