### PR TITLE
chore: remove `docker-mamoto` from infra.ci.jenkins.io jobs

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -40,7 +40,6 @@ jobsDefinition:
       docker-inbound-agents:
       docker-jenkins-lts:
       docker-jenkins-weekly:
-      docker-mamoto:
       docker-mirrorbits:
       docker-openvpn:
       docker-packaging:


### PR DESCRIPTION
This repository doesn't exit (anymore?)