### PR TITLE
chore(weekly.ci.jenkins.io): migrate from `prodpublick8s` to `publick8s`

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -180,16 +180,6 @@ releases:
     version: 0.3.75
     values:
       - "../config/wiki.yaml"
-  - name: jenkins-weekly
-    namespace: jenkins-weekly
-    chart: jenkins/jenkins
-    version: 4.3.23
-    needs:
-      - public-nginx-ingress/public-nginx-ingress # Required to expose both the UI and the webhooks endpoint
-    values:
-      - "../config/jenkins_weekly.ci.jenkins.io.yaml"
-    secrets:
-      - "../secrets/config/weekly.ci.jenkins.io/jenkins-secrets.yaml"
   - name: rating
     namespace: rating
     chart: jenkins-infra/rating

--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -16,9 +16,6 @@ repositories:
   # https://github.com/kubernetes/ingress-nginx/
   - name: ingress-nginx
     url: https://kubernetes.github.io/ingress-nginx
-  # https://github.com/jenkinsci/helm-charts/
-  - name: jenkins
-    url: https://charts.jenkins.io
   # https://github.com/jenkins-infra/helm-charts/
   - name: jenkins-infra
     url: https://jenkins-infra.github.io/helm-charts

--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -13,6 +13,9 @@ repositories:
   # https://github.com/kubernetes/ingress-nginx/
   - name: ingress-nginx
     url: https://kubernetes.github.io/ingress-nginx
+  # https://github.com/jenkinsci/helm-charts/
+  - name: jenkins
+    url: https://charts.jenkins.io
   # https://github.com/jenkins-infra/helm-charts/
   - name: jenkins-infra
     url: https://jenkins-infra.github.io/helm-charts

--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -76,3 +76,13 @@ releases:
       - "../config/artifact-caching-proxy_azure.yaml"
     secrets:
       - "../secrets/config/artifact-caching-proxy/secrets.yaml"
+  - name: jenkins-weekly
+    namespace: jenkins-weekly
+    chart: jenkins/jenkins
+    version: 4.3.23
+    needs:
+      - public-nginx-ingress/public-nginx-ingress # Required to expose both the UI and the webhooks endpoint
+    values:
+      - "../config/jenkins_weekly.ci.jenkins.io.yaml"
+    secrets:
+      - "../secrets/config/weekly.ci.jenkins.io/jenkins-secrets.yaml"

--- a/updatecli/updatecli.d/charts/jenkins.yaml
+++ b/updatecli/updatecli.d/charts/jenkins.yaml
@@ -27,7 +27,7 @@ targets:
     spec:
       files:
         - clusters/privatek8s.yaml
-        - clusters/prodpublick8s.yaml
+        - clusters/publick8s.yaml
       matchpattern: 'chart: jenkins\/jenkins((\r\n|\r|\n)(\s+))version: .*'
       replacepattern: 'chart: jenkins/jenkins${1}version: {{ source "lastChartVersion" }}'
     scmid: default


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3351