### PR TITLE
fix(ldap): correct publick8s outbound IP allowed

### DIFF
--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -12,6 +12,7 @@ service:
     - '104.210.5.242/32'  # accept inbound LDAPS from cert.ci.jenkins.io
     - '104.208.238.39/32'  # Accept inbound LDAPS from ci.jenkins.io
     - '52.167.253.43/32'  # Accept inbound LDAPS from public.aks.jenkins.io # TODO: delete when migration from prodpublick8s to publick8s is completed, see https://github.com/jenkins-infra/helpdesk/issues/3351
+    - '20.75.10.224/29'  # Accept inbound connections from prodpublick8s public outbound IPs # TODO: delete when migration from prodpublick8s to publick8s is completed, see https://github.com/jenkins-infra/helpdesk/issues/3351
     - '34.211.101.61/32'  # Accept inbound connections from Linux Foundation test machine
     - '44.240.22.235/32'  # Accept inbound connections from Linux Foundation prod machine
     - '20.62.24.45/32'  # Accept inbound connections from publick8s public outbound IP

--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -11,10 +11,10 @@ service:
     - '172.176.126.194/32'  # accept inbound LDAPS from private.vpn.jenkins.io
     - '104.210.5.242/32'  # accept inbound LDAPS from cert.ci.jenkins.io
     - '104.208.238.39/32'  # Accept inbound LDAPS from ci.jenkins.io
-    - '52.167.253.43/32'  # Accept inbound LDAPS from public.aks.jenkins.io
+    - '52.167.253.43/32'  # Accept inbound LDAPS from public.aks.jenkins.io # TODO: delete when migration from prodpublick8s to publick8s is completed, see https://github.com/jenkins-infra/helpdesk/issues/3351
     - '34.211.101.61/32'  # Accept inbound connections from Linux Foundation test machine
     - '44.240.22.235/32'  # Accept inbound connections from Linux Foundation prod machine
-    - '20.75.10.224/29'  # Accept inbound connections from publick8s public IPs
+    - '20.62.24.45/32'  # Accept inbound connections from publick8s public outbound IP
     - '20.96.66.246/32'  # Accept inbound connections from privatek8s # TODO: find out how to retrieve this IP from terraform
     - '18.214.241.149/32'  # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
     - '34.201.191.93/32'  # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)


### PR DESCRIPTION
The previous one was a range pointing to the "publick8s" (ie the current prodpublick8s) outbound IPs from two years ago.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351