### PR TITLE
chore(javadoc): migrate from `prodpublick8s` to `publick8s`

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -102,14 +102,6 @@ releases:
       - "../config/jenkinsio.yaml"
     secrets:
       - "../secrets/config/jenkinsio/secrets.yaml"
-  - name: javadoc
-    namespace: javadoc
-    chart: jenkins-infra/javadoc
-    version: 0.1.2
-    values:
-      - "../config/javadoc.yaml"
-    secrets:
-      - "../secrets/config/javadoc/secrets.yaml"
   - name: accountapp
     namespace: accountapp
     chart: jenkins-infra/accountapp

--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -89,3 +89,11 @@ releases:
       - "../config/jenkins_weekly.ci.jenkins.io.yaml"
     secrets:
       - "../secrets/config/weekly.ci.jenkins.io/jenkins-secrets.yaml"
+  - name: javadoc
+    namespace: javadoc
+    chart: jenkins-infra/javadoc
+    version: 0.1.2
+    values:
+      - "../config/javadoc.yaml"
+    secrets:
+      - "../secrets/config/javadoc/secrets.yaml"


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3351