### PR TITLE
chore(wiki): migrate from `prodpublick8s` to `publick8s`

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -163,12 +163,6 @@ releases:
     timeout: 150
     values:
       - "../config/keycloak-public.yaml"
-  - name: wiki
-    namespace: wiki
-    chart: jenkins-infra/wiki
-    version: 0.3.75
-    values:
-      - "../config/wiki.yaml"
   - name: rating
     namespace: rating
     chart: jenkins-infra/rating

--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -105,3 +105,9 @@ releases:
       - public-nginx-ingress/public-nginx-ingress # Required to expose both the UI and the webhooks endpoint
     values:
       - "../config/jenkinsisthewayio.yaml"
+  - name: wiki
+    namespace: wiki
+    chart: jenkins-infra/wiki
+    version: 0.3.75
+    values:
+      - "../config/wiki.yaml"


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3351