### PR TITLE
fixup(updatecli): correct target for `wiki` helm chart manifest

### DIFF
--- a/updatecli/updatecli.d/charts/wiki.yaml
+++ b/updatecli/updatecli.d/charts/wiki.yaml
@@ -25,7 +25,7 @@ targets:
     name: "Update the chart version for wiki"
     kind: file
     spec:
-      file: clusters/prodpublick8s.yaml
+      file: clusters/publick8s.yaml
       matchpattern: 'chart: jenkins-infra\/wiki((\r\n|\r|\n)(\s+))version: .*'
       replacepattern: 'chart: jenkins-infra/wiki${1}version: {{ source "lastChartVersion" }}'
     scmid: default


### PR DESCRIPTION
Fixup of #3945 