### PR TITLE
Respect users' os theme on weekly.ci

### DIFF
--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -121,7 +121,7 @@ controller:
           defaultFolderConfiguration:
             # Keep healthMetrics an empty list to ensure weather is disabled
             healthMetrics: []
-          theme-manager:
+          themeManager:
             disableUserThemes: false
             theme: "darkSystem"
         jenkins:

--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -121,6 +121,9 @@ controller:
           defaultFolderConfiguration:
             # Keep healthMetrics an empty list to ensure weather is disabled
             healthMetrics: []
+          theme-manager:
+            disableUserThemes: false
+            theme: "darkSystem"
         jenkins:
           quietPeriod: 0 # No need to wait between build scheduling
           disabledAdministrativeMonitors:


### PR DESCRIPTION
If you're a darkmode user and not logged into weekly.ci, your os theme set is now respected properly.