### PR TITLE
Configure custom header plugin

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -557,6 +557,9 @@ controller:
           defaultFolderConfiguration:
             # Keep healthMetrics an empty list to ensure weather is disabled
             healthMetrics: []
+          customHeaderConfiguration:
+            enabled: false
+            logo: "default"
         jenkins:
           quietPeriod: 0 # No need to wait between build scheduling
           disabledAdministrativeMonitors:

--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -124,6 +124,17 @@ controller:
           themeManager:
             disableUserThemes: false
             theme: "darkSystem"
+          customHeaderConfiguration:
+            enabled: true
+            headerColor:
+              backgroundColor: "#3B3B3B"
+              color: "white"
+              hoverColor: "grey"
+            logo:
+              symbol:
+                symbol: "symbol-jenkins"
+            logoText: "Jenkins"
+            title: "with the customizable-header plugin 🚀"
         jenkins:
           quietPeriod: 0 # No need to wait between build scheduling
           disabledAdministrativeMonitors:


### PR DESCRIPTION
Blocked by https://github.com/jenkins-infra/docker-jenkins-weekly/pull/1244

If I recall correctly, infra.ci pulls the weekly image too. Hence, I disabled the plugin on the infra configuration.

Preview:
![Screenshot 2023-05-22 at 17 30 09](https://github.com/jenkins-infra/kubernetes-management/assets/13383509/7371d89b-de9d-4d43-a59a-b337bdff43e3)