### PR TITLE
hotfix(publick8s) adapt keycloak setup for Ipv6

### DIFF
--- a/config/keycloak.yaml
+++ b/config/keycloak.yaml
@@ -18,11 +18,6 @@ ingress:
         - admin.accounts.jenkins.io
       secretName: keycloak-cert
 
-image:
-  # https://twitter.com/keycloak/status/1471815630655528968?s=20
-  # Until the 16.x versions are available for the helm chart
-  tag: 15.1.1
-
 extraInitContainers: |
   - name: theme-provider
     image: jenkinsciinfra/keycloak-theme:0.0.1
@@ -60,16 +55,17 @@ postgresql:
 extraEnv: |
   - name: PROXY_ADDRESS_FORWARDING
     value: "true"
-  - name: JGROUPS_DISCOVERY_PROTOCOL
-    value: dns.DNS_PING
-  - name: JGROUPS_DISCOVERY_PROPERTIES
-    value: 'dns_query={{ include "keycloak.serviceDnsName" . }}'
-  - name: CACHE_OWNERS_COUNT
-    value: "2"
-  - name: CACHE_OWNERS_AUTH_SESSIONS_COUNT
-    value: "2"
   - name: KEYCLOAK_STATISTICS
     value: all
+  - name: JAVA_OPTS
+    value: >-
+      -Djava.net.preferIPv4Stack=false
+      -Djava.net.preferIPv6Addresses=true
+      -Djboss.bind.address.private=::1
+      -Djboss.bind.address.management=::
+      -Djboss.bind.address=::
+      -Djboss.modules.system.pkgs=org.jboss.byteman
+      -Djava.awt.headless=true
 
 extraEnvFrom: |
   - secretRef:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3351,

This PR fixes the keycloak configuration, following up https://github.com/jenkins-infra/kubernetes-management/pull/3983, for the Dual-Stack setup as it was failing to start with the same errors as in https://github.com/codecentric/helm-charts/issues/415


The current fixup uses the IPv6 interfaces in the pod to listen, but it looks like it's breaking the HA module so the Jgroup setup has been cleaned up.