### PR TITLE
Use default icon for weekly.ci's header

### DIFF
--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -130,9 +130,7 @@ controller:
               backgroundColor: "#3B3B3B"
               color: "white"
               hoverColor: "grey"
-            logo:
-              symbol:
-                symbol: "symbol-jenkins"
+            logo: "default"
             logoText: "Jenkins"
             title: "with the customizable-header plugin 🚀"
         jenkins:


### PR DESCRIPTION
@timja removed the icon a couple of days, but redeploying overwrites these changes. Let's harden it.