### PR TITLE
Revert "Enable context aware headers on weekly.ci"

### DIFF
--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -126,18 +126,13 @@ controller:
             theme: "darkSystem"
           customHeaderConfiguration:
             enabled: true
-            header:
-              context:
-                showFolderWeather: true
-                showJobWeather: true
             headerColor:
               backgroundColor: "#3B3B3B"
               color: "white"
               hoverColor: "grey"
             logo: "default"
             logoText: "Jenkins"
-            title: "with the <a href=\"https://plugins.jenkins.io/customizable-header/\">customizable-header</a>\
-              \ plugin"
+            title: "with the customizable-header plugin"
         jenkins:
           quietPeriod: 0 # No need to wait between build scheduling
           disabledAdministrativeMonitors:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#3991 as it causes the following error in weekly.ci.jenkins.io logs (at startupt):

```
2023-05-26 11:11:09.565+0000 [id=28]	SEVERE	jenkins.InitReactorRunner$1#onTaskFailed: Failed ConfigurationAsCode.init
io.jenkins.plugins.casc.ConfiguratorException: Invalid configuration elements for type class io.jenkins.plugins.customizable_header.CustomHeaderConfiguration : header.
Available attributes : cssResource, enabled, headerColor, logo, logoText, title
	at io.jenkins.plugins.casc.BaseConfigurator.handleUnknown(BaseConfigurator.java:375)
	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:364)
	at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:286)
	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:350)
	at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:286)
	at io.jenkins.plugins.casc.ConfigurationAsCode.lambda$checkWith$8(ConfigurationAsCode.java:776)
	at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:712)
Caused: io.jenkins.plugins.casc.ConfiguratorException: unclassified: error configuring 'unclassified' with class io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator configurator
	at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:718)
	at io.jenkins.plugins.casc.ConfigurationAsCode.checkWith(ConfigurationAsCode.java:776)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:761)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:637)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configure(ConfigurationAsCode.java:306)
	at io.jenkins.plugins.casc.ConfigurationAsCode.init(ConfigurationAsCode.java:298)
Caused: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:109)
Caused: java.lang.Error
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:115)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:185)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:305)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1165)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:221)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:120)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```