### PR TITLE
chore(updatecli) fix PHS manifest to use publick8s

### DIFF
--- a/updatecli/updatecli.d/charts/plugin-health-scoring.yaml
+++ b/updatecli/updatecli.d/charts/plugin-health-scoring.yaml
@@ -25,7 +25,7 @@ targets:
     name: "Update the chart version for plugin-health-scoring"
     kind: file
     spec:
-      file: clusters/prodpublick8s.yaml
+      file: clusters/publick8s.yaml
       matchpattern: 'chart: jenkins-infra\/plugin-health-scoring((\r\n|\r|\n)(\s+))version: .*'
       replacepattern: 'chart: jenkins-infra/plugin-health-scoring${1}version: {{ source "lastChartVersion" }}'
     scmid: default


### PR DESCRIPTION
Follow up of https://github.com/jenkins-infra/kubernetes-management/pull/4000