### PR TITLE
feat(publick8s) migrate rating and uplink

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -116,15 +116,6 @@ releases:
       - "../config/ldap.yaml"
     secrets:
       - "../secrets/config/ldap/secrets.yaml"
-  - name: uplink
-    namespace: uplink
-    chart: jenkins-infra/uplink
-    version: 0.1.2
-    timeout: 600
-    values:
-      - "../config/uplink.yaml"
-    secrets:
-      - "../secrets/config/uplink/secrets.yaml"
   - name: mirrorbits
     namespace: mirrorbits
     chart: jenkins-infra/mirrorbits
@@ -135,11 +126,3 @@ releases:
       - "../config/mirrorbits.yaml"
     secrets:
       - "../secrets/config/mirrorbits/secrets.yaml"
-  - name: rating
-    namespace: rating
-    chart: jenkins-infra/rating
-    version: 0.2.0
-    values:
-      - "../config/rating.yaml"
-    secrets:
-      - "../secrets/config/rating/secrets.yaml"

--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -144,3 +144,20 @@ releases:
       - "../config/incrementals-publisher.yaml"
     secrets:
       - "../secrets/config/incrementals-publisher/secrets.yaml"
+  - name: rating
+    namespace: rating
+    chart: jenkins-infra/rating
+    version: 0.2.0
+    values:
+      - "../config/rating.yaml"
+    secrets:
+      - "../secrets/config/rating/secrets.yaml"
+  - name: uplink
+    namespace: uplink
+    chart: jenkins-infra/uplink
+    version: 0.1.2
+    timeout: 600
+    values:
+      - "../config/uplink.yaml"
+    secrets:
+      - "../secrets/config/uplink/secrets.yaml"

--- a/updatecli/updatecli.d/charts/rating.yaml
+++ b/updatecli/updatecli.d/charts/rating.yaml
@@ -25,7 +25,7 @@ targets:
     name: "Update the chart version for rating"
     kind: file
     spec:
-      file: clusters/prodpublick8s.yaml
+      file: clusters/publick8s.yaml
       matchpattern: 'chart: jenkins-infra\/rating((\r\n|\r|\n)(\s+))version: .*'
       replacepattern: 'chart: jenkins-infra/rating${1}version: {{ source "lastChartVersion" }}'
     scmid: default

--- a/updatecli/updatecli.d/charts/uplink.yaml
+++ b/updatecli/updatecli.d/charts/uplink.yaml
@@ -25,7 +25,7 @@ targets:
     name: "Update the chart version for uplink"
     kind: file
     spec:
-      file: clusters/prodpublick8s.yaml
+      file: clusters/publick8s.yaml
       matchpattern: 'chart: jenkins-infra\/uplink((\r\n|\r|\n)(\s+))version: .*'
       replacepattern: 'chart: jenkins-infra/uplink${1}version: {{ source "lastChartVersion" }}'
     scmid: default


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3351#issuecomment-1568499546

This PR does a "one" shot of the helm releases and the `updatecli` manifest: its checks are expected to fail until the migration is complete.

Important: the helm secrets must be updated before merging.