### PR TITLE
fix(weekly.ci.jenkins.io): replace `pullPolicy` field name by `imagePullPolicy`

### DIFF
--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -20,7 +20,7 @@ networkPolicy:
 controller:
   image: jenkinsciinfra/jenkins-weekly
   tag: 0.116.1-2.407
-  pullPolicy: IfNotPresent
+  imagePullPolicy: IfNotPresent
   resources:
     limits:
       cpu: "2"


### PR DESCRIPTION
There is no `pullPolicy` value property in https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/values.yaml