### PR TITLE
fix(publick8s): add `nodeSelector` to migrated services

### DIFF
--- a/config/artifact-caching-proxy_azure.yaml
+++ b/config/artifact-caching-proxy_azure.yaml
@@ -11,3 +11,6 @@ ingress:
 
 persistence:
   storageClass: managed-csi-premium-retain
+
+nodeSelector:
+  agentpool: arm64small

--- a/config/artifact-caching-proxy_azure.yaml
+++ b/config/artifact-caching-proxy_azure.yaml
@@ -13,4 +13,4 @@ persistence:
   storageClass: managed-csi-premium-retain
 
 nodeSelector:
-  agentpool: arm64small
+  agentpool: x86medium

--- a/config/incrementals-publisher.yaml
+++ b/config/incrementals-publisher.yaml
@@ -12,3 +12,6 @@ ingress:
     - secretName: incrementals-tls
       hosts:
         - incrementals.jenkins.io
+
+nodeSelector:
+  agentpool: publicpool

--- a/config/incrementals-publisher.yaml
+++ b/config/incrementals-publisher.yaml
@@ -14,4 +14,4 @@ ingress:
         - incrementals.jenkins.io
 
 nodeSelector:
-  agentpool: publicpool
+  agentpool: x86medium

--- a/config/javadoc.yaml
+++ b/config/javadoc.yaml
@@ -33,4 +33,4 @@ htmlVolume:
 replicaCount: 2
 
 nodeSelector:
-  agentpool: arm64small
+  agentpool: x86medium

--- a/config/javadoc.yaml
+++ b/config/javadoc.yaml
@@ -16,7 +16,7 @@ ingress:
       hosts:
         - javadoc.jenkins.io
         - javadoc.jenkins-ci.org
-replicaCount: 2
+
 resources:
   limits:
     cpu: 200m
@@ -29,3 +29,8 @@ htmlVolume:
     secretName: javadoc
     shareName: javadoc
     readOnly: true
+
+replicaCount: 2
+
+nodeSelector:
+  agentpool: arm64small

--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -23,7 +23,7 @@ controller:
   pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.azure.com/agentpool: arm64small
+    kubernetes.azure.com/agentpool: x86medium
   resources:
     limits:
       cpu: "2"

--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -21,6 +21,9 @@ controller:
   image: jenkinsciinfra/jenkins-weekly
   tag: 0.116.1-2.407
   pullPolicy: IfNotPresent
+  nodeSelector:
+    kubernetes.io/os: linux
+    kubernetes.azure.com/agentpool: arm64small
   resources:
     limits:
       cpu: "2"

--- a/config/keycloak.yaml
+++ b/config/keycloak.yaml
@@ -27,7 +27,7 @@ resources:
 replicas: 1
 
 nodeSelector:
-  agentpool: publicpool
+  agentpool: x86medium
 
 extraInitContainers: |
   - name: theme-provider

--- a/config/keycloak.yaml
+++ b/config/keycloak.yaml
@@ -1,5 +1,3 @@
-replicas: 1
-
 ingress:
   enabled: true
   ingressClassName: private-nginx
@@ -17,6 +15,19 @@ ingress:
     - hosts:
         - admin.accounts.jenkins.io
       secretName: keycloak-cert
+
+resources:
+  limits:
+    cpu: 1500m
+    memory: 2048Mi
+  requests:
+    cpu: 1500m
+    memory: 2048Mi
+
+replicas: 1
+
+nodeSelector:
+  agentpool: publicpool
 
 extraInitContainers: |
   - name: theme-provider
@@ -40,13 +51,6 @@ extraVolumeMounts: |
 extraVolumes: |
   - name: theme
     emptyDir: {}
-resources:
-  limits:
-    cpu: 1500m
-    memory: 2048Mi
-  requests:
-    cpu: 1500m
-    memory: 2048Mi
 
 ## Database Setup
 # We already have a postgresql database

--- a/config/plugin-health-scoring.yaml
+++ b/config/plugin-health-scoring.yaml
@@ -14,6 +14,9 @@ ingress:
       hosts:
         - plugin-health.jenkins.io
 
+nodeSelector:
+  agentpool: publicpool
+
 database:
   username: plugin_health
   server: public-db.postgres.database.azure.com

--- a/config/plugin-health-scoring.yaml
+++ b/config/plugin-health-scoring.yaml
@@ -15,7 +15,7 @@ ingress:
         - plugin-health.jenkins.io
 
 nodeSelector:
-  agentpool: publicpool
+  agentpool: x86medium
 
 database:
   username: plugin_health

--- a/config/rating.yaml
+++ b/config/rating.yaml
@@ -14,5 +14,8 @@ ingress:
       hosts:
         - rating.jenkins.io
 
+nodeSelector:
+  agentpool: arm64small
+
 readinessProbe:
   enabled: false

--- a/config/rating.yaml
+++ b/config/rating.yaml
@@ -15,7 +15,7 @@ ingress:
         - rating.jenkins.io
 
 nodeSelector:
-  agentpool: arm64small
+  agentpool: x86medium
 
 readinessProbe:
   enabled: false

--- a/config/uplink.yaml
+++ b/config/uplink.yaml
@@ -13,9 +13,13 @@ ingress:
     - secretName: uplink-tls
       hosts:
         - uplink.jenkins.io
-replicaCount: 5
 image:
   # repo & '@sha256' suffix here as we're retrieving a docker digest from updatecli
   repository: jenkinsciinfra/uplink@sha256
   tag: c7ecad0e5e24bc05ac722418faf844d6a0286620c6316ff712459ecfcc3ee7ce
   pullPolicy: IfNotPresent
+
+replicaCount: 5
+
+nodeSelector:
+  agentpool: arm64small

--- a/config/uplink.yaml
+++ b/config/uplink.yaml
@@ -22,4 +22,4 @@ image:
 replicaCount: 5
 
 nodeSelector:
-  agentpool: arm64small
+  agentpool: x86medium

--- a/config/wiki.yaml
+++ b/config/wiki.yaml
@@ -18,6 +18,7 @@ ingress:
       hosts:
         - wiki.jenkins.io
         - wiki.jenkins-ci.org
+
 resources:
   limits:
     cpu: 200m
@@ -25,6 +26,11 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
-replicaCount: 2
+
 image:
   pullPolicy: IfNotPresent
+
+replicaCount: 2
+
+nodeSelector:
+  agentpool: arm64small

--- a/config/wiki.yaml
+++ b/config/wiki.yaml
@@ -33,4 +33,4 @@ image:
 replicaCount: 2
 
 nodeSelector:
-  agentpool: arm64small
+  agentpool: x86medium


### PR DESCRIPTION
This PR ensures pods are assigned to [`x86medium` node pool](https://github.com/jenkins-infra/azure/blob/ecdcc7369199b8494f4b63fd28c240187ac61e49/publick8s.tf#L84-L96) in `publick8s`, and avoid mixing type of nodes for a same service.

~For smaller services, the cheaper [`arm64small` node pool](https://github.com/jenkins-infra/azure/blob/ecdcc7369199b8494f4b63fd28c240187ac61e49/publick8s.tf#L98-L110) has been privileged, while other has been assigned to the `publicpool` by default.~

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351 ~& https://github.com/jenkins-infra/helpdesk/issues/3584~