### PR TITLE
chore(reports): remove nonexistant `reports.jenkins-ci.org` ingress host & TLS

### DIFF
--- a/config/reports.yaml
+++ b/config/reports.yaml
@@ -8,9 +8,6 @@ ingress:
     - host: reports.jenkins.io
       paths:
         - path: /
-    - host: reports.jenkins-ci.org
-      paths:
-        - path: /
   tls:
     - secretName: reports-tls
       hosts:

--- a/config/reports.yaml
+++ b/config/reports.yaml
@@ -15,7 +15,6 @@ ingress:
     - secretName: reports-tls
       hosts:
         - reports.jenkins.io
-        - reports.jenkins-ci.org
 
 resources:
   limits:


### PR DESCRIPTION
As there is no associated record in the `jenkins-ci.org` DNS zone in Azure Portal, this PR removes it.

Ref: https://github.com/jenkins-infra/kubernetes-management/pull/4028#discussion_r1214099796