### PR TITLE
chore(updatecli): correct maven manifest

### DIFF
--- a/updatecli/updatecli.d/charts/jenkins-infra-tools-maven.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-infra-tools-maven.yaml
@@ -30,10 +30,10 @@ sources:
       - getDeployedPackerImageVersion
     spec:
       file: https://raw.githubusercontent.com/jenkins-infra/packer-images/{{ source "getDeployedPackerImageVersion" }}/provisioning/tools-versions.yml
-      matchpattern: 'maven_version:\s"(.*)"'
+      matchpattern: 'maven_version:\s(.*)'
     transformers:
       - findsubmatch:
-          pattern: 'maven_version:\s"(.*)"'
+          pattern: 'maven_version:\s(.*)'
           captureindex: 1
 
 conditions:


### PR DESCRIPTION
follow up https://github.com/jenkins-infra/packer-images/pull/701
and correct : 
```
ERROR: ✗ No line matched in the file "https://raw.githubusercontent.com/jenkins-infra/packer-images/1.10.0/provisioning/tools-versions.yml" for the pattern "maven_version:\\s\"(.*)\""
Pipeline "Bump Maven version (Jenkins tools) on infra.ci.jenkins.io" failed
```