### PR TITLE
chore(publick8s): move javadoc to arm node pool

### DIFF
--- a/config/javadoc.yaml
+++ b/config/javadoc.yaml
@@ -33,4 +33,4 @@ htmlVolume:
 replicaCount: 2
 
 nodeSelector:
-  agentpool: x86medium
+  agentpool: arm64small


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3584
moving javadoc to this new pool