### PR TITLE
Revert "chore(publick8s): move javadoc to arm node pool"

### DIFF
--- a/config/javadoc.yaml
+++ b/config/javadoc.yaml
@@ -33,5 +33,4 @@ htmlVolume:
 replicaCount: 2
 
 nodeSelector:
-  kubernetes.azure.com/agentpool: arm64small
-  kubernetes.io/arch: arm64
+  agentpool: x86medium


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#4038

need to resolve the arm64 nodepool problem : 
```
Allocation failed. VM(s) with the following constraints cannot be allocated, because the condition is too restrictive. Please remove some constraints and try again. Constraints applied are:
                - Availability Zone
                - Differencing (Ephemeral) Disks
                - Networking Constraints (such as Accelerated Networking or IPv6)
                - VM Size
```