### PR TITLE
chore(ldap): deploy to `publick8s`

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -177,3 +177,13 @@ releases:
       - "../config/accountapp.yaml"
     secrets:
       - "../secrets/config/accountapp/secrets.yaml"
+  - name: ldap
+    namespace: ldap
+    chart: jenkins-infra/ldap
+    version: 0.1.6
+    timeout: 600
+    values:
+      - "../config/ldap.yaml"
+    secrets:
+      # TODO: rename to secrets.yaml when the migration is completed: https://github.com/jenkins-infra/helpdesk/issues/3351
+      - "../secrets/config/ldap/secrets_publick8s.yaml"

--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -21,6 +21,7 @@ service:
     - '34.201.191.93/32'  # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
     - '34.233.58.83/32'  # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
     - '54.236.124.56/32'  # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
+
 image:
   slapd:
     # repo & '@sha256' suffix here as we're retrieving a docker digest from updatecli
@@ -32,6 +33,7 @@ image:
     repository: jenkinsciinfra/ldap@sha256
     tag: d662790b4a5f1ca979c186241005e816ff86ccedf8161d9f11df43501f077f31
     pullPolicy: IfNotPresent
+
 resources:
   limits:
     cpu: 500m
@@ -39,3 +41,6 @@ resources:
   requests:
     cpu: 500m
     memory: 1536Mi
+
+nodeSelector:
+  agentpool: x86medium

--- a/updatecli/updatecli.d/charts/ldap.yaml
+++ b/updatecli/updatecli.d/charts/ldap.yaml
@@ -25,7 +25,9 @@ targets:
     name: "Update the chart version for ldap"
     kind: file
     spec:
-      file: clusters/prodpublick8s.yaml
+      files:
+      - clusters/prodpublick8s.yaml
+      - clusters/publick8s.yaml
       matchpattern: 'chart: jenkins-infra\/ldap((\r\n|\r|\n)(\s+))version: .*'
       replacepattern: 'chart: jenkins-infra/ldap${1}version: {{ source "lastChartVersion" }}'
     scmid: default


### PR DESCRIPTION
This PR adds the LDAP service to `publick8s` cluster, with a new secret configuration using the new storage account with restricted access created in https://github.com/jenkins-infra/azure/pull/392 instead of the existing one which will be removed at the end of the migration described in https://github.com/jenkins-infra/helpdesk/issues/3351#issuecomment-1576741071

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351