### PR TITLE
fix(publick8s) stick ingress pods to x86medium (intel) nodepool

### DIFF
--- a/config/private-nginx-ingress_publick8s.yaml
+++ b/config/private-nginx-ingress_publick8s.yaml
@@ -5,3 +5,8 @@ controller:
     annotations:
       # azure-net:vnets.tf/public-vnet-data-tier
       service.beta.kubernetes.io/azure-load-balancer-internal-subnet: public-vnet-data-tier
+  nodeSelector:
+    agentpool: x86medium
+defaultBackend:
+  nodeSelector:
+    agentpool: x86medium

--- a/config/public-nginx-ingress_publick8s.yaml
+++ b/config/public-nginx-ingress_publick8s.yaml
@@ -12,3 +12,8 @@ controller:
       - IPv4
       - IPv6
     ipFamilyPolicy: PreferDualStack
+  nodeSelector:
+    agentpool: x86medium
+defaultBackend:
+  nodeSelector:
+    agentpool: x86medium


### PR DESCRIPTION
https://github.com/jenkins-infra/kubernetes-management/pull/4034 is failing to deploy: AKS tries to schedule the new pods to the `arm64small` nodepool.

This PR is a short-term to ensure nginx ingresses, on `publick8s`, are scheduled on the nodepool name `x86medium`.


=> long term, we should start using toleration and taints to avoid implicit scheduling to ARM64 (and eventually a generic nodeSelector that could span across multiple node pools to allow use doing blue/green on node pools)