### PR TITLE
fix(artifact-caching-proxy): add exception for `jitpack.io` Maven repository

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -434,7 +434,7 @@ controller:
                       <mirror>
                           <id>aws-proxy</id>
                           <url>https://repo.aws.jenkins.io/public/</url>
-                          <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local</mirrorOf>
+                          <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local,!jitpack.io</mirrorOf>
                       </mirror>
                       <mirror>
                           <id>aws-proxy-incrementals</id>
@@ -460,7 +460,7 @@ controller:
                       <mirror>
                           <id>azure-proxy</id>
                           <url>https://repo.azure.jenkins.io/public/</url>
-                          <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local</mirrorOf>
+                          <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local,!jitpack.io</mirrorOf>
                       </mirror>
                       <mirror>
                           <id>azure-proxy-incrementals</id>
@@ -486,7 +486,7 @@ controller:
                       <mirror>
                           <id>do-proxy</id>
                           <url>https://repo.do.jenkins.io/public/</url>
-                          <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local</mirrorOf>
+                          <mirrorOf>*,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local,!jitpack.io</mirrorOf>
                       </mirror>
                       <mirror>
                           <id>do-proxy-incrementals</id>


### PR DESCRIPTION
This exception is added to fix the build of https://github.com/jenkinsci/ircbot-plugin which relies on https://github.com/pircbotx/pircbotx/ whose binary releases (and snapshots) are published to https://jitpack.io/#pircbotx/pircbotx/, not mirrored in our Maven repositories for now.

Twin PR: https://github.com/jenkins-infra/jenkins-infra/pull/2895

Ref: https://github.com/jenkins-infra/helpdesk/issues/3591