### PR TITLE
chore: remove `ldap` release from `prodpublick8s`

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -91,15 +91,6 @@ releases:
       - "../config/jenkinsio.yaml"
     secrets:
       - "../secrets/config/jenkinsio/secrets.yaml"
-  - name: ldap
-    namespace: ldap
-    chart: jenkins-infra/ldap
-    version: 0.1.6
-    timeout: 600
-    values:
-      - "../config/ldap.yaml"
-    secrets:
-      - "../secrets/config/ldap/secrets.yaml"
   - name: mirrorbits
     namespace: mirrorbits
     chart: jenkins-infra/mirrorbits


### PR DESCRIPTION
Follow-up of #4044

A proper cleanup will be made at the end of the migration.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351#issuecomment-1576741071