### PR TITLE
fix(datadog): remove typo from `packageCanBeDownloaded.py` check

### DIFF
--- a/config/datadog_confd_checksd.yaml
+++ b/config/datadog_confd_checksd.yaml
@@ -104,7 +104,7 @@ datadog:
               tags = ["package:" + package,]
 
               if package in endpoints:
-                  self.gauge(metric, is_exist(package, endpoints[package]), tags)helpdes
+                  self.gauge(metric, is_exist(package, endpoints[package]), tags)
               else:
                   self.warning(f"PackageCanDownload: Package {package} is not supported")
 


### PR DESCRIPTION
This PR removes unwanted text I commited by mistake in https://github.com/jenkins-infra/kubernetes-management/pull/3919

Ref: https://github.com/jenkins-infra/helpdesk/issues/3608