### PR TITLE
chore(mirrorbits): migrate from `prodpublick8s` to `publick8s`

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -91,13 +91,3 @@ releases:
       - "../config/jenkinsio.yaml"
     secrets:
       - "../secrets/config/jenkinsio/secrets.yaml"
-  - name: mirrorbits
-    namespace: mirrorbits
-    chart: jenkins-infra/mirrorbits
-    version: 0.46.2
-    timeout: 600
-    atomic: false
-    values:
-      - "../config/mirrorbits.yaml"
-    secrets:
-      - "../secrets/config/mirrorbits/secrets.yaml"

--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -186,3 +186,13 @@ releases:
       - "../config/ldap.yaml"
     secrets:
       - "../secrets/config/ldap/secrets.yaml"
+  - name: mirrorbits
+    namespace: mirrorbits
+    chart: jenkins-infra/mirrorbits
+    version: 0.46.2
+    timeout: 600
+    atomic: false
+    values:
+      - "../config/mirrorbits.yaml"
+    secrets:
+      - "../secrets/config/mirrorbits/secrets.yaml"

--- a/config/mirrorbits.yaml
+++ b/config/mirrorbits.yaml
@@ -1,21 +1,13 @@
-replicaCount:
-  mirrorbits: 2
-  files: 2
-resources:
+image:
   mirrorbits:
-    limits:
-      cpu: 500m
-      memory: 1024Mi
-    requests:
-      cpu: 500m
-      memory: 1024Mi
+    tag: v0.1.2
+    pullPolicy: IfNotPresent
   files:
-    limits:
-      cpu: 2000m
-      memory: 2048Mi
-    requests:
-      cpu: 2000m
-      memory: 2048Mi
+    # repo & '@sha256' suffix here as we're retrieving a docker digest from updatecli
+    repository: httpd@sha256
+    tag: f70876d78442771406d7245b8d3425e8b0a86891c79811af94fb2e12af0fadeb
+    pullPolicy: IfNotPresent
+
 ingress:
   enabled: true
   className: public-nginx
@@ -49,6 +41,23 @@ ingress:
         - mirrors.jenkins.io
         - mirrors.jenkins-ci.org
         - fallback.get.jenkins.io
+
+resources:
+  mirrorbits:
+    limits:
+      cpu: 500m
+      memory: 1024Mi
+    requests:
+      cpu: 500m
+      memory: 1024Mi
+  files:
+    limits:
+      cpu: 2000m
+      memory: 2048Mi
+    requests:
+      cpu: 2000m
+      memory: 2048Mi
+
 repository:
   name: mirrorbits-binary
   persistentVolumeClaim:
@@ -89,12 +98,10 @@ repository:
         - nobrl
         - serverino
         - cache=strict
-image:
-  mirrorbits:
-    tag: v0.1.2
-    pullPolicy: IfNotPresent
-  files:
-    # repo & '@sha256' suffix here as we're retrieving a docker digest from updatecli
-    repository: httpd@sha256
-    tag: f70876d78442771406d7245b8d3425e8b0a86891c79811af94fb2e12af0fadeb
-    pullPolicy: IfNotPresent
+
+replicaCount:
+  mirrorbits: 2
+  files: 2
+
+nodeSelector:
+  agentpool: x86medium

--- a/updatecli/updatecli.d/charts/mirrorbits.yaml
+++ b/updatecli/updatecli.d/charts/mirrorbits.yaml
@@ -25,7 +25,7 @@ targets:
     name: "Update the chart version for mirrorbits"
     kind: file
     spec:
-      file: clusters/prodpublick8s.yaml
+      file: clusters/publick8s.yaml
       matchpattern: 'chart: jenkins-infra\/mirrorbits((\r\n|\r|\n)(\s+))version: .*'
       replacepattern: 'chart: jenkins-infra/mirrorbits${1}version: {{ source "lastChartVersion" }}'
     scmid: default


### PR DESCRIPTION
In draft until 12:00 UTC (cf https://github.com/jenkins-infra/status/pull/316)

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351#issuecomment-1586969797