### PR TITLE
chore(jenkins.io): migrate from `prodpublick8s` to `publick8s`

### DIFF
--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -13,9 +13,6 @@ repositories:
   # https://github.com/kubernetes/ingress-nginx/
   - name: ingress-nginx
     url: https://kubernetes.github.io/ingress-nginx
-  # https://github.com/jenkins-infra/helm-charts/
-  - name: jenkins-infra
-    url: https://jenkins-infra.github.io/helm-charts
   # https://github.com/cert-manager/cert-manager/
   - name: jetstack
     url: https://charts.jetstack.io
@@ -67,11 +64,3 @@ releases:
     version: 2.5.2
     values:
       - "../config/falco.yaml"
-  - name: jenkinsio
-    namespace: jenkinsio
-    chart: jenkins-infra/jenkinsio
-    version: 0.3.0
-    values:
-      - "../config/jenkinsio.yaml"
-    secrets:
-      - "../secrets/config/jenkinsio/secrets.yaml"

--- a/clusters/prodpublick8s.yaml
+++ b/clusters/prodpublick8s.yaml
@@ -13,6 +13,9 @@ repositories:
   # https://github.com/kubernetes/ingress-nginx/
   - name: ingress-nginx
     url: https://kubernetes.github.io/ingress-nginx
+  # https://github.com/jenkins-infra/helm-charts/
+  - name: jenkins-infra
+    url: https://jenkins-infra.github.io/helm-charts
   # https://github.com/cert-manager/cert-manager/
   - name: jetstack
     url: https://charts.jetstack.io

--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -212,3 +212,11 @@ releases:
       - "../config/plugin-site.yaml"
     secrets:
       - "../secrets/config/plugin-site/secrets.yaml"
+  - name: jenkinsio
+    namespace: jenkinsio
+    chart: jenkins-infra/jenkinsio
+    version: 0.3.0
+    values:
+      - "../config/jenkinsio.yaml"
+    secrets:
+      - "../secrets/config/jenkinsio/secrets.yaml"

--- a/config/jenkinsio.yaml
+++ b/config/jenkinsio.yaml
@@ -46,7 +46,9 @@ ingress:
         - jenkins.io
         - www.jenkins-ci.org
         - www.origin.jenkins.io
+
 replicaCount: 5
+
 resources:
   limits:
     cpu: 500m
@@ -54,14 +56,20 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
+
 htmlVolume:
   azureFile:
     secretName: jenkinsio
     shareName: jenkinsio
     readOnly: true
+
 zhHtmlVolume:
   azureFile:
     secretName: jenkinsio
     shareName: zhjenkinsio
     readOnly: true
+
 forceJenkinsIoHost: true
+
+nodeSelector:
+  agentpool: x86medium

--- a/updatecli/updatecli.d/charts/jenkinsio.yaml
+++ b/updatecli/updatecli.d/charts/jenkinsio.yaml
@@ -25,7 +25,7 @@ targets:
     name: "Update the chart version for jenkinsio"
     kind: file
     spec:
-      file: clusters/prodpublick8s.yaml
+      file: clusters/publick8s.yaml
       matchpattern: 'chart: jenkins-infra\/jenkinsio((\r\n|\r|\n)(\s+))version: .*'
       replacepattern: 'chart: jenkins-infra/jenkinsio${1}version: {{ source "lastChartVersion" }}'
     scmid: default


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3351#issuecomment-1588040182