### PR TITLE
cleanup(datadog): remove `mirror.azure.jenkins.io` mirror monitoring

### DIFF
--- a/config/datadog_confd_checksd.yaml
+++ b/config/datadog_confd_checksd.yaml
@@ -456,15 +456,3 @@ datadog:
           check_certificate_expiration: true
           tags:
             - mirror
-        - name: mirror.azure.jenkins.io
-          timeout: 10
-          threshold: 3
-          window: 5
-          days_warning: 10
-          days_critical: 5
-          url: https://mirror.azure.jenkins.io/TIME
-          method: get
-          collect_response_time: true
-          check_certificate_expiration: true
-          tags:
-            - mirror


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3351#issuecomment-1591316525