### PR TITLE
cleanup(plugin-site-issues): remove unused `plugin-site-issues.origin.jenkins.io` host

### DIFF
--- a/config/plugin-site-issues.yaml
+++ b/config/plugin-site-issues.yaml
@@ -8,10 +8,6 @@ ingress:
     "nginx.ingress.kubernetes.io/cors-allow-methods": "GET, OPTIONS"
     "nginx.ingress.kubernetes.io/cors-allow-origin": "*"
   hosts:
-    - host: plugin-site-issues.origin.jenkins.io
-      paths:
-        - path: /
-          pathType: Prefix
     - host: plugin-site-issues.jenkins.io
       paths:
         - path: /
@@ -19,7 +15,6 @@ ingress:
   tls:
     - secretName: plugin-site-issues-tls
       hosts:
-        - plugin-site-issues.origin.jenkins.io
         - plugin-site-issues.jenkins.io
 
 nodeSelector:


### PR DESCRIPTION
Remove this host, initially planned for a use with Fastly CDN like plugin-site and jenkins.io

Ref: https://github.com/jenkins-infra/helpdesk/issues/3351