### PR TITLE
feat(doks/doks-public) disabling during upgrade to 1.25

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -29,7 +29,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'cik8s', 'doks', 'doks-public', 'eks-public', 'privatek8s', 'publick8s'
+            values 'cik8s', 'eks-public', 'privatek8s', 'publick8s'
           }
         } // axes
         agent {


### PR DESCRIPTION
as per https://docs.digitalocean.com/products/kubernetes/how-to/upgrade-cluster/#new-control-plane we have to disable any action on digital ocean clusters 

to follow the process use https://github.com/jenkins-infra/helpdesk/issues/3582