### PR TITLE
feat(publick8s): add `ipv6-lb-service`

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -220,3 +220,11 @@ releases:
       - "../config/jenkinsio.yaml"
     secrets:
       - "../secrets/config/jenkinsio/secrets.yaml"
+  - name: ipv6-lb-service
+    namespace: public-nginx-ingress
+    chart: jenkins-infra/ipv6-lb-service
+    version: 0.1.0
+    needs:
+      - public-nginx-ingress/public-nginx-ingress
+    values:
+      - "../config/ipv6-lb-service.yaml"

--- a/config/ipv6-lb-service.yaml
+++ b/config/ipv6-lb-service.yaml
@@ -1,0 +1,6 @@
+# azurerm_public_ip.publick8s_ipv6.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
+ipv6: 2603:1030:408:7::44
+app:
+  name: "ingress-nginx"
+  component: "controller"
+  instance: "public-nginx-ingress"

--- a/updatecli/updatecli.d/charts/ipv6-lb-service.yaml
+++ b/updatecli/updatecli.d/charts/ipv6-lb-service.yaml
@@ -1,0 +1,41 @@
+name: "Bump `ipv6-lb-service` helm chart version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastChartVersion:
+    kind: helmchart
+    name: get last chart version
+    spec:
+      url: https://jenkins-infra.github.io/helm-charts
+      name: ipv6-lb-service
+
+targets:
+  updateChartVersion:
+    name: "Update the chart version for ipv6-lb-service"
+    kind: file
+    scmid: default
+    spec:
+      file: clusters/publick8s.yaml
+      matchpattern: 'chart: jenkins-infra\/ipv6-lb-service((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/ipv6-lb-service${1}version: {{ source "lastChartVersion" }}'
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump `ipv6-lb-service` helm chart version to {{ source `lastChartVersion` }}
+    spec:
+      labels:
+        - dependencies
+        - ipv6-lb-service


### PR DESCRIPTION
This PR adds an additional LB service dedicated to IPv6 on `publick8s` cluster, cf https://github.com/jenkins-infra/helpdesk/issues/3639#issuecomment-1611147715

Ref: https://github.com/jenkins-infra/helpdesk/issues/3639