### PR TITLE
Revert "Bump `incremental-publisher` helm chart version to 0.5.6"

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -139,7 +139,7 @@ releases:
   - name: incrementals-publisher
     namespace: incrementals-publisher
     chart: jenkins-infra/incrementals-publisher
-    version: 0.5.6
+    version: 0.5.5
     values:
       - "../config/incrementals-publisher.yaml"
     secrets:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#4141 including the switch from NodeJS 16 to NodeJS 18 causing https://github.com/jenkins-infra/incrementals-publisher/issues/45

Ref: https://github.com/jenkins-infra/helpdesk/issues/3649