### PR TITLE
hotifx(publick8s) put back javadoc workload to the arm64small nodepool

### DIFF
--- a/config/javadoc.yaml
+++ b/config/javadoc.yaml
@@ -33,8 +33,5 @@ htmlVolume:
 replicaCount: 2
 
 nodeSelector:
-  agentpool: x86medium
-
-# nodeSelector:
-#   kubernetes.azure.com/agentpool: arm64small
-#   kubernetes.io/arch: arm64
+  kubernetes.azure.com/agentpool: arm64small
+  kubernetes.io/arch: arm64


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3582#issuecomment-1629210833