### PR TITLE
feat(publick8s): add arm64 toleration for datadog agents

### DIFF
--- a/config/datadog_publick8s.yaml
+++ b/config/datadog_publick8s.yaml
@@ -10,7 +10,7 @@ datadog:
     tlsVerify: false
 agents:
   tolerations:
-  - key: "kubernetes.io/arch"
-    operator: "Equal"
-    value: "arm64"
-    effect: "NoSchedule"
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"

--- a/config/datadog_publick8s.yaml
+++ b/config/datadog_publick8s.yaml
@@ -8,3 +8,9 @@ datadog:
     hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
     # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
     tlsVerify: false
+agents:
+  tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3623#issuecomment-1613504371

and datadog documentation: https://github.com/DataDog/helm-charts/blob/f5c0c8699fcb1d19b87c964f6a13dc228a213414/charts/datadog/values.yaml#L1575

<img width="951" alt="Capture d’écran 2023-07-31 à 15 17 01" src="https://github.com/jenkins-infra/kubernetes-management/assets/95630726/2efc205d-0d8a-4fa0-9b21-321009f89e3f">

