### PR TITLE
feat(publick8s): migrate reports to arm64 nodepool

### DIFF
--- a/config/reports.yaml
+++ b/config/reports.yaml
@@ -30,10 +30,9 @@ replicaCount: 2
 
 # Specify the "hard" scheduling constraints
 nodeSelector:
-  # Ensure ARM64 is used to decrease cloud bill (instead of using `amd64`
+  # arm64 is cheaper than x86
   kubernetes.io/arch: arm64
 
-# Tolerates to run on tainted `arm64` nodes
 tolerations:
   - key: "kubernetes.io/arch"
     operator: "Equal"

--- a/config/reports.yaml
+++ b/config/reports.yaml
@@ -28,5 +28,14 @@ htmlVolume:
 
 replicaCount: 2
 
+# Specify the "hard" scheduling constraints
 nodeSelector:
-  agentpool: x86medium
+  # Ensure ARM64 is used to decrease cloud bill (instead of using `amd64`
+  kubernetes.io/arch: arm64
+
+# Tolerates to run on tainted `arm64` nodes
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3619#issue-1745920424

this allow the reports deployment to use the arm64 node-pool in order to save some spending.