### PR TITLE
Add an updatecli manifest to keep mirrorbits httpd docker digest up to date

### DIFF
--- a/updatecli/updatecli.d/docker-images/mirrorbits-httpd.yaml
+++ b/updatecli/updatecli.d/docker-images/mirrorbits-httpd.yaml
@@ -1,0 +1,41 @@
+name: "Bump mirrorbits httpd docker image version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestDockerDigest:
+    name: "Get latest httpd docker digest"
+    kind: dockerdigest
+    spec:
+      image: "docker-library/httpd"
+      tag: "latest"
+      architecture: "amd64"
+
+targets:
+  updateDigestInConfig:
+    name: "Update docker-library/httpd docker image version"
+    kind: yaml
+    spec:
+      file: "config/mirrorbits.yaml"
+      key: "image.files.tag"
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump mirrorbits httpd docker image version
+    spec:
+      labels:
+        - dependencies
+        - httpd


### PR DESCRIPTION
### Description

This PR adds an updatecli manifest to keep the docker digest of httpd docker image up to date

Issue - https://github.com/jenkins-infra/kubernetes-management/issues/4212