### PR TITLE
feat(publick8s) Force SSL redirect for jenkinsio

### DIFF
--- a/config/jenkinsio.yaml
+++ b/config/jenkinsio.yaml
@@ -3,7 +3,6 @@ ingress:
   className: public-nginx
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
-    "nginx.ingress.kubernetes.io/ssl-redirect": "true"
     "nginx.ingress.kubernetes.io/configuration-snippet": |
       more_set_headers "X-Content-Type-Options: nosniff";
       more_set_headers "X-Frame-Options: DENY";

--- a/config/jenkinsio.yaml
+++ b/config/jenkinsio.yaml
@@ -3,7 +3,7 @@ ingress:
   className: public-nginx
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
-    "nginx.ingress.kubernetes.io/ssl-redirect": "false"
+    "nginx.ingress.kubernetes.io/ssl-redirect": "true"
     "nginx.ingress.kubernetes.io/configuration-snippet": |
       more_set_headers "X-Content-Type-Options: nosniff";
       more_set_headers "X-Frame-Options: DENY";


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3686

Forcing to SSL redirect is the default: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#server-side-https-enforcement-through-redirect
