### PR TITLE
Remove httpd image tag from mirrorbits

### DIFF
--- a/config/mirrorbits.yaml
+++ b/config/mirrorbits.yaml
@@ -3,8 +3,6 @@ image:
     tag: v0.1.2
     pullPolicy: IfNotPresent
   files:
-    # repo & '@sha256' suffix here as we're retrieving a docker digest from updatecli
-    repository: httpd@sha256
     pullPolicy: IfNotPresent
 
 ingress:

--- a/config/mirrorbits.yaml
+++ b/config/mirrorbits.yaml
@@ -5,7 +5,6 @@ image:
   files:
     # repo & '@sha256' suffix here as we're retrieving a docker digest from updatecli
     repository: httpd@sha256
-    tag: f70876d78442771406d7245b8d3425e8b0a86891c79811af94fb2e12af0fadeb
     pullPolicy: IfNotPresent
 
 ingress:


### PR DESCRIPTION
### Description

The httpd docker image tag is already kept upto date in the mirrorbits helm chart