### PR TITLE
feat(infra.ci.jenkins.io): activate ANSI color globally

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -646,6 +646,29 @@ controller:
                   installers:
                   - maven:
                       id: "3.9.4"
+      ansi-color: |
+        unclassified:
+          ansiColorBuildWrapper:
+            globalColorMapName: "xterm"
+            colorMaps:
+            - name: "xterm"
+              defaultBackground: 7 # better separation between jenkins output and pipeline output
+              black: "#000000"
+              blackB: "#4C4C4C"
+              blue: "#1E90FF"
+              blueB: "#4682B4"
+              cyan: "#00CDCD"
+              cyanB: "#00FFFF"
+              green: "#00CD00"
+              greenB: "#00FF00"
+              magenta: "#CD00CD"
+              magentaB: "#FF00FF"
+              red: "#CD0000"
+              redB: "#FF0000"
+              white: "#E5E5E5"
+              whiteB: "#FFFFFF"
+              yellow: "#CDCD00"
+              yellowB: "#FFFF00"
   sidecars:
     configAutoReload:
       env:


### PR DESCRIPTION
This PR activates [ANSI color](https://plugins.jenkins.io/ansicolor/) globally on infra.ci.jenkins.io

<details><summary>Screenshots:</summary>

Without ANSI color:
![image](https://github.com/jenkins-infra/kubernetes-management/assets/91831478/cae06f95-2ca0-4387-a6cb-2945f4d3e372)

With ANSI color only:
![image](https://github.com/jenkins-infra/kubernetes-management/assets/91831478/1ddafdfd-3aa6-417a-930f-cedb54ae5518)

With ANSI color and default background set to "White":
![image](https://github.com/jenkins-infra/kubernetes-management/assets/91831478/001eee44-3af0-4aee-9908-cdcf7b3cf949)

</details>