### PR TITLE
feat: cleanup `mirrorbits` values now included by default in its chart and bump it from `0.1.2` to `0.1.94`

### DIFF
--- a/config/mirrorbits.yaml
+++ b/config/mirrorbits.yaml
@@ -1,10 +1,3 @@
-image:
-  mirrorbits:
-    tag: v0.1.2
-    pullPolicy: IfNotPresent
-  files:
-    pullPolicy: IfNotPresent
-
 ingress:
   enabled: true
   className: public-nginx


### PR DESCRIPTION
Follow-up of #4236 

Mirrorbits Docker image changelog: https://github.com/jenkins-infra/docker-mirrorbits/compare/v0.1.2...0.1.94: zero functional change to the mirrorbits app.