### PR TITLE
chore(accountapp): remove default `image.pullPolicy`

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -185,7 +185,7 @@ releases:
   - name: accountapp
     namespace: accountapp
     chart: jenkins-infra/accountapp
-    version: 0.5.26
+    version: 0.6.0
     needs:
       - ldap/ldap
     values:

--- a/config/accountapp.yaml
+++ b/config/accountapp.yaml
@@ -1,5 +1,3 @@
-image:
-  pullPolicy: IfNotPresent
 ingress:
   enabled: true
   className: public-nginx


### PR DESCRIPTION
`IfNotPresent` is already the default value: https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting

Supersedes and closes https://github.com/jenkins-infra/kubernetes-management/pull/4249