### PR TITLE
feat((weekly,infra,release).ci.jenkins.io) switch JVM to JDK17

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -20,7 +20,7 @@ networkPolicy:
       name: "jenkins-infra"
 controller:
   image: jenkinsciinfra/jenkins-weekly
-  tag: 0.127.3-2.419
+  tag: 1.0.1-2.419
   imagePullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux
@@ -116,7 +116,7 @@ controller:
                     nodeSelector: "kubernetes.io/os=linux"
                     containers:
                       - name: jnlp
-                        image: "jenkins/inbound-agent:latest-jdk11"
+                        image: "jenkins/inbound-agent:latest-jdk17"
                         envVars:
                         - envVar:
                             key: "JENKINS_JAVA_BIN"
@@ -150,10 +150,10 @@ controller:
                         envVars:
                         - envVar:
                             key: "JENKINS_JAVA_BIN"
-                            value: "C:/openjdk-11"
+                            value: "C:/openjdk-17"
                         - envVar:
                             key: "JAVA_HOME"
-                            value: "C:/openjdk-11"
+                            value: "C:/openjdk-17"
                         command: "powershell"
                         args: "C:/ProgramData/Jenkins/jenkins-agent.ps1"
                         resourceLimitCpu: "1"
@@ -248,7 +248,7 @@ controller:
                     systemctl start datadog-agent.service
                     rm -f /etc/sudoers.d/90-cloud-init-users
                     echo "END CLOUDINIT"
-                  javaPath: "/opt/jdk-11/bin/java"
+                  javaPath: "/opt/jdk-17/bin/java"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
                   labels: "linux-amd64 linux-amd64-docker"
                   location: "East US 2"
@@ -285,7 +285,7 @@ controller:
                   imageTopLevelType: "advanced"
                   initScript: |-
                     (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ${JENKINS_CI_DATADOG_API_KEY}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
-                  javaPath: "C:/tools/jdk-11/bin/java"
+                  javaPath: "C:/tools/jdk-17/bin/java"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
                   labels: "windows-2019 amd64 azure vm docker-windows docker-windows-2019 windows"
                   location: "East US 2"
@@ -335,7 +335,7 @@ controller:
                     systemctl start datadog-agent.service
                     rm -f /etc/sudoers.d/90-cloud-init-users
                     echo "END CLOUDINIT"
-                  javaPath: "/opt/jdk-11/bin/java"
+                  javaPath: "/opt/jdk-17/bin/java"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
                   labels: "linux-arm64 linux-arm64-docker azure"
                   location: "East US 2"

--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -26,7 +26,7 @@ networkPolicy:
       name: "jenkins-release"
 controller:
   image: jenkinsciinfra/jenkins-lts
-  tag: 0.32.10-2.401.3
+  tag: 1.0.1-2.401.3
   imagePullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux
@@ -208,7 +208,7 @@ controller:
                     nodeSelector: "kubernetes.io/os=linux"
                     containers:
                       - name: jnlp
-                        image: "jenkins/inbound-agent:latest-jdk11"
+                        image: "jenkins/inbound-agent:latest-jdk17"
                         envVars:
                         - envVar:
                             key: "JENKINS_JAVA_BIN"
@@ -239,14 +239,14 @@ controller:
                     instanceCapStr: "5"
                     containers:
                       - name: jnlp
-                        image: "jenkins/inbound-agent:jdk11-windowsservercore-ltsc2019"
+                        image: "jenkins/inbound-agent:jdk17-windowsservercore-ltsc2019"
                         envVars:
                         - envVar:
                             key: "JENKINS_JAVA_BIN"
-                            value: "C:/openjdk-11"
+                            value: "C:/openjdk-17"
                         - envVar:
                             key: "JAVA_HOME"
-                            value: "C:/openjdk-11"
+                            value: "C:/openjdk-17"
                         command: "powershell"
                         args: "C:/ProgramData/Jenkins/jenkins-agent.ps1"
                         resourceLimitCpu: "1"

--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -20,7 +20,7 @@ networkPolicy:
       name: "jenkins-weekly"
 controller:
   image: jenkinsciinfra/jenkins-weekly
-  tag: 0.127.3-2.419
+  tag: 1.0.1-2.419
   imagePullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3072, this PR switches the 3 Jenkins controllers managed in this repository (weekly.ci.jenkins.io, infra.ci.jenkins.io and release.ci.jenkins.io) to JDK17 instead of JDK11.


Superseds and closes #4267 and #4266