### PR TITLE
feat: add custom header to `infra.ci.jenkins.io`

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -703,6 +703,19 @@ controller:
               whiteB: "#FFFFFF"
               yellow: "#CDCD00"
               yellowB: "#FFFF00"
+      custom-header: |
+        unclassified:
+          customHeaderConfiguration:
+            enabled: true
+            header: "logo"
+            headerColor:
+              backgroundColor: "linear-gradient(90deg, rgba(239,192,92,1) 0%, rgba(171,28,28,1) 100%);"
+              color: "white"
+              hoverColor: "grey"
+            logo:
+              svg:
+                logoPath: "https://www.jenkins.io/images/logos/beekeeper/beekeeper.svg"
+            logoText: "Jenkins Infra"
   sidecars:
     configAutoReload:
       env:

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -711,10 +711,10 @@ controller:
             headerColor:
               backgroundColor: "linear-gradient(90deg, rgba(239,192,92,1) 0%, rgba(171,28,28,1) 100%);"
               color: "white"
-              hoverColor: "grey"
+              hoverColor: "#D0763F"
             logo:
-              svg:
-                logoPath: "https://www.jenkins.io/images/logos/beekeeper/beekeeper.svg"
+              image:
+                logoPath: "https://www.jenkins.io/images/logos/beekeeper/beekeeper.png"
             logoText: "Jenkins Infra"
   sidecars:
     configAutoReload:


### PR DESCRIPTION
Configuring https://plugins.jenkins.io/customizable-header already [present in our weekly image](https://github.com/jenkins-infra/docker-jenkins-weekly/blob/f6e01a2e06b18411ae49b974956cba5bd0aa152d/plugins.txt#L56), similar to [what's already set on weekly.ci.jenkins.io](https://github.com/jenkins-infra/kubernetes-management/blob/79b6abcd54527d4dae0eb3718e0c771cc7c65c78/config/jenkins_weekly.ci.jenkins.io.yaml#L131-L144).

Before:
<img width="1402" alt="image" src="https://github.com/jenkins-infra/kubernetes-management/assets/91831478/169a25ed-8e89-43a2-bc12-57c235989996">

Light theme:
<img width="1415" alt="image" src="https://github.com/jenkins-infra/kubernetes-management/assets/91831478/4099083b-556d-4336-859d-f2a9deec94b8">

Dark theme:
<img width="1407" alt="image" src="https://github.com/jenkins-infra/kubernetes-management/assets/91831478/2f365be9-57e4-44b8-8df9-af3ee7fe0521">

Note: not a fan but there is also an option to use a custom "context aware" logo, which outside of the homepage replace the beekeeper logo by the current page icon (not activated in this PR).

<details>

<img width="387" alt="image" src="https://github.com/jenkins-infra/kubernetes-management/assets/91831478/85c39100-5b66-462a-9b7f-a0e5c8a408fc">

<img width="390" alt="image" src="https://github.com/jenkins-infra/kubernetes-management/assets/91831478/762fa5f5-7f7a-4306-b6f6-d31bdfbf8fb4">

</details>