### PR TITLE
feat(updates.jenkins.io): add rsyncd service

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -237,7 +237,7 @@ releases:
   - name: updates-jenkins-io
     namespace: updates-jenkins-io
     chart: jenkins-infra/mirrorbits
-    version: 0.58.1
+    version: 0.59.1
     values:
       - "../config/updates.jenkins.io.yaml"
     secrets:

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -88,14 +88,6 @@ rsyncd:
     enabled: true
     type: ClusterIP
     port: 873
-  ingress:
-    enabled: true
-    annotations:
-      "cert-manager.io/cluster-issuer": "letsencrypt-staging"
-    hosts:
-      - host: rsyncd.updates.jenkins.io
-    tls:
-      - secretName: rsyncd-releasemirror-tls
-
+    IP: 127.0.0.0 # TODO: set from output of https://github.com/jenkins-infra/azure/pull/459>
 nodeSelector:
   agentpool: x86medium

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -86,7 +86,7 @@ replicaCount:
 rsyncd:
   service:
     enabled: true
-    type: ClusterIP
+    type: LoadBalancer
     port: 873
     IP: 172.176.204.85 # rsyncd_jenkins_io_ipv4_address defined in https://github.com/jenkins-infra/azure/blob/main/updates.jenkins.io.tf
   configurationFiles:

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -88,7 +88,7 @@ rsyncd:
     enabled: true
     type: ClusterIP
     port: 873
-    IP: 127.0.0.0 # TODO: set from output of https://github.com/jenkins-infra/azure/pull/459>
+    IP: 172.176.204.85 # rsyncd_jenkins_io_ipv4_address defined in https://github.com/jenkins-infra/azure/blob/main/updates.jenkins.io.tf
   configurationFiles:
     rsyncdConf:
       # override: true

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -81,6 +81,21 @@ repository:
 replicaCount:
   mirrorbits: 1 #2
   files: 1 #2
+  rsyncd: 1
+
+rsyncd:
+  service:
+    enabled: true
+    type: ClusterIP
+    port: 873
+  ingress:
+    enabled: true
+    annotations:
+      "cert-manager.io/cluster-issuer": "letsencrypt-staging"
+    hosts:
+      - host: rsyncd.updates.jenkins.io
+    tls:
+      - secretName: rsyncd-releasemirror-tls
 
 nodeSelector:
   agentpool: x86medium

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -89,5 +89,13 @@ rsyncd:
     type: ClusterIP
     port: 873
     IP: 127.0.0.0 # TODO: set from output of https://github.com/jenkins-infra/azure/pull/459>
+  configurationFiles:
+    rsyncdConf:
+      # override: true
+      # content: "TODO"
+    jenkinsMotd:
+      # override: true
+      # content: "TODO"
+
 nodeSelector:
   agentpool: x86medium

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -87,15 +87,7 @@ rsyncd:
   service:
     enabled: true
     type: LoadBalancer
-    port: 873
     IP: 172.176.204.85 # rsyncd_jenkins_io_ipv4_address defined in https://github.com/jenkins-infra/azure/blob/main/updates.jenkins.io.tf
-  configurationFiles:
-    rsyncdConf:
-      # override: true
-      # content: "TODO"
-    jenkinsMotd:
-      # override: true
-      # content: "TODO"
 
 nodeSelector:
   agentpool: x86medium


### PR DESCRIPTION
From https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-1688304653:

> Hopping mirrorbits accepts different domains for mirror URL and mirror rsync address, I [have] transplant[ed] the rsyncd part of the deleted mirror chart which was used for azure.mirror.jenkins.io decomissionned mirror service (https://github.com/jenkins-infra/helm-charts/pull/607) in the mirrorbits chart[.]
> 
> With this rsyncd service using the same local reference volume of mirrorbits, we should then be able to add the R2 bucket mirror, associated with this rsyncd service address.

Follow-up of https://github.com/jenkins-infra/helm-charts/pull/609

Ref: https://github.com/jenkins-infra/helpdesk/issues/2649