### PR TITLE
feat(ldap) add new cert.ci vnet outbound IP

### DIFF
--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -8,10 +8,11 @@ service:
     - '73.71.177.172/32'  # 106 accept inbound LDAPS request from spambot
     - '140.211.15.101/32'  # 107 accept inbound LDAPS request from accounts.jenkins.io
     - '20.12.27.65/32'  # 107 accept inbound LDAPS request from puppet.jenkins.io
-    - '104.209.128.236/32'  # 107 accept inbound LDAPS from trusted NAT gateway for trusted.ci.jenkins.io
+    - '104.209.128.236/32'  # accept inbound LDAPS from trusted.ci.jenkins.io vnet (public IP for the outbound NAT gateway)
     - '104.209.251.202/32'  # accept inbound LDAPS from vpn.jenkins.io
     - '172.176.126.194/32'  # accept inbound LDAPS from private.vpn.jenkins.io
-    - '104.210.5.242/32'  # accept inbound LDAPS from cert.ci.jenkins.io
+    - '104.210.5.242/32'  # accept inbound LDAPS from cert.ci.jenkins.io (legacy VM). TODO: remove when deleting legacy resources
+    - '104.209.153.13/32' # accept inbound LDAPS from cert.ci.jenkins.io vnet (public IP for the outbound NAT gateway)
     - '52.252.104.110/32'  # Accept inbound LDAPS from ci.jenkins.io
     - '34.211.101.61/32'  # Accept inbound connections from Linux Foundation test machine
     - '44.240.22.235/32'  # Accept inbound connections from Linux Foundation prod machine


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3688, this PR allows incoming requests from the cert.ci.jenkins.io virtual network to the LDAP