### PR TITLE
cleanup(ldap) remove legacy public IP of cert-ci from allow-list

### DIFF
--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -11,7 +11,6 @@ service:
     - '104.209.128.236/32'  # accept inbound LDAPS from trusted.ci.jenkins.io vnet (public IP for the outbound NAT gateway)
     - '104.209.251.202/32'  # accept inbound LDAPS from vpn.jenkins.io
     - '172.176.126.194/32'  # accept inbound LDAPS from private.vpn.jenkins.io
-    - '104.210.5.242/32'  # accept inbound LDAPS from cert.ci.jenkins.io (legacy VM). TODO: remove when deleting legacy resources
     - '104.209.153.13/32' # accept inbound LDAPS from cert.ci.jenkins.io vnet (public IP for the outbound NAT gateway)
     - '52.252.104.110/32'  # Accept inbound LDAPS from ci.jenkins.io
     - '34.211.101.61/32'  # Accept inbound connections from Linux Foundation test machine


### PR DESCRIPTION
Related to jenkins-infra/helpdesk#3688