### PR TITLE
feat(wiki): add nodeselector and tolerations to spawn on arm64 nodepool

### DIFF
--- a/config/wiki.yaml
+++ b/config/wiki.yaml
@@ -33,4 +33,10 @@ image:
 replicaCount: 2
 
 nodeSelector:
-  agentpool: x86medium
+  kubernetes.io/arch: arm64
+
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3619
and now that the docker image is arm64 compliant thanks to https://github.com/jenkins-infra/pipeline-library/pull/730 and https://github.com/jenkins-infra/pipeline-library/pull/739

following the PR #4309 that provide an image compatible both with amd64 and arm64.

we can provide the settings to spawn on ARM64 nodepool