### PR TITLE
Revert "Bump `mirrorbits` helm chart version to 0.65.0"

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -195,7 +195,7 @@ releases:
   - name: mirrorbits
     namespace: mirrorbits
     chart: jenkins-infra/mirrorbits
-    version: 0.65.0
+    version: 0.63.0
     timeout: 600
     atomic: false
     values:
@@ -237,7 +237,7 @@ releases:
   - name: updates-jenkins-io
     namespace: updates-jenkins-io
     chart: jenkins-infra/mirrorbits
-    version: 0.65.0
+    version: 0.63.0
     values:
       - "../config/updates.jenkins.io.yaml"
     secrets:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#4306