### PR TITLE
chore(updates.jenkins.io): comment out release temporarily

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -234,11 +234,11 @@ releases:
       - public-nginx-ingress/public-nginx-ingress
     values:
       - "../config/ipv6-lb-service.yaml"
-  - name: updates-jenkins-io
-    namespace: updates-jenkins-io
-    chart: jenkins-infra/mirrorbits
-    version: 0.63.0
-    values:
-      - "../config/updates.jenkins.io.yaml"
-    secrets:
-      - "../secrets/config/updates.jenkins.io/secrets.yaml"
+  # - name: updates-jenkins-io
+  #   namespace: updates-jenkins-io
+  #   chart: jenkins-infra/mirrorbits
+  #   version: 0.63.0
+  #   values:
+  #     - "../config/updates.jenkins.io.yaml"
+  #   secrets:
+  #     - "../secrets/config/updates.jenkins.io/secrets.yaml"


### PR DESCRIPTION
To work on https://github.com/jenkins-infra/helpdesk/issues/2649 I need to do some tests with resources used by the current updates.jenkins.io POC release.

This PR comments out this release temporarily.