### PR TITLE
fixup(infra.ci.jenkins.io): remove conflicting previous `custom-header` configuration

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -591,9 +591,6 @@ controller:
           defaultFolderConfiguration:
             # Keep healthMetrics an empty list to ensure weather is disabled
             healthMetrics: []
-          customHeaderConfiguration:
-            enabled: false
-            logo: "default"
         jenkins:
           quietPeriod: 0 # No need to wait between build scheduling
           disabledAdministrativeMonitors:


### PR DESCRIPTION
Fixup of #4273, I didn't notice there was already a configuration section for this plugin, with `enabled` set to `false` and causing the following error:

> io.jenkins.plugins.casc.ConfiguratorConflictException: Found conflicting configuration at YamlSource: /var/jenkins_home/casc_configs/system-settings.yaml  in /var/jenkins_home/casc_configs/system-settings.yaml, line 36, column 14:
>         enabled: false