### PR TITLE
chore(updatecli): fix `key "$.spec.containers[0].name", in YAML file "PodTemplates.yaml", is incorrectly set to "\"jnlp\""`

### DIFF
--- a/PodTemplates.yaml
+++ b/PodTemplates.yaml
@@ -28,7 +28,7 @@ spec:
   containers:
     - image: "jenkinsciinfra/helmfile:2.5.105"
       imagePullPolicy: "IfNotPresent"
-      name: "jnlp"
+      name: jnlp
       resources:
         limits:
           memory: "1024Mi"


### PR DESCRIPTION
Follow-up of #4328

Ref: https://github.com/jenkins-infra/kubernetes-management/pull/4320#issuecomment-1713183980