### PR TITLE
feat(wiki): apply antiaffinity rule to avoid multiple pods on the same node

### DIFF
--- a/config/wiki.yaml
+++ b/config/wiki.yaml
@@ -40,3 +40,14 @@ tolerations:
     operator: "Equal"
     value: "arm64"
     effect: "NoSchedule"
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app
+              operator: In
+              values:
+                - wiki
+        topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3719