### PR TITLE
Revert "Bump `wiki` helm chart version to 0.3.98 (#4333)"

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -113,7 +113,7 @@ releases:
   - name: wiki
     namespace: wiki
     chart: jenkins-infra/wiki
-    version: 0.3.98
+    version: 0.3.93
     values:
       - "../config/wiki.yaml"
   - name: ldap


### PR DESCRIPTION
This reverts commit 1d28d3114843c0cb569a13351f32e36f09d67725.