### PR TITLE
feat(account-app): move to arm64 with toleration antiaffinity rules

### DIFF
--- a/config/accountapp.yaml
+++ b/config/accountapp.yaml
@@ -36,4 +36,21 @@ smtp:
 replicaCount: 2
 
 nodeSelector:
-  agentpool: x86medium
+  kubernetes.io/arch: arm64
+
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: app
+              operator: In
+              values:
+                - accountapp
+        topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3619
must wait for https://github.com/jenkins-infra/helm-charts/pull/700 that update the chart that use images compatible with arm64