### PR TITLE
fix(ci.jenkins.io) exclude all externals Maven repositories from ACP mirroring

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -434,7 +434,7 @@ controller:
                       <mirror>
                           <id>aws-proxy</id>
                           <url>https://repo.aws.jenkins.io/public/</url>
-                          <mirrorOf>*,!central,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local,!jitpack.io</mirrorOf>
+                          <mirrorOf>external:*,!central,!incrementals,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io</mirrorOf>
                       </mirror>
                       <mirror>
                           <id>aws-proxy-incrementals</id>
@@ -485,7 +485,7 @@ controller:
                       <mirror>
                           <id>azure-proxy</id>
                           <url>https://repo.azure.jenkins.io/public/</url>
-                          <mirrorOf>*,!central,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local,!jitpack.io</mirrorOf>
+                          <mirrorOf>external:*,!central,!incrementals,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io</mirrorOf>
                       </mirror>
                       <mirror>
                           <id>azure-proxy-incrementals</id>
@@ -511,7 +511,7 @@ controller:
                       <mirror>
                           <id>do-proxy</id>
                           <url>https://repo.do.jenkins.io/public/</url>
-                          <mirrorOf>*,!central,!incrementals,!elementary-releases,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!local,!jitpack.io</mirrorOf>
+                          <mirrorOf>external:*,!central,!incrementals,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io</mirrorOf>
                       </mirror>
                       <mirror>
                           <id>do-proxy-incrementals</id>


### PR DESCRIPTION
Twin of https://github.com/jenkins-infra/jenkins-infra/pull/3070 but for infra.ci.jenkins.io

- https://maven.apache.org/guides/mini/guide-mirror-settings.html#AdvancedMirrorSpecification mentions that `external:*` is a pattern matching "all repositories" except URLs to localhost or file based.
- Found in https://github.com/jenkinsci/maven-hpi-plugin/pull/537 which pointed to https://maven.apache.org/plugins/maven-invoker-plugin/examples/fast-use.html#fast-build-configuration-mergeusersettings-and-mirrors
- Remove the `!local` exception added as part of https://github.com/jenkins-infra/helpdesk/issues/3567 (replaced by the `external:` pattern)