### PR TITLE
feat(infra.ci) disable ANSI color to allow reading pipeline logs

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -677,29 +677,6 @@ controller:
                   installers:
                   - maven:
                       id: "3.9.4"
-      ansi-color: |
-        unclassified:
-          ansiColorBuildWrapper:
-            globalColorMapName: "xterm"
-            colorMaps:
-            - name: "xterm"
-              defaultBackground: 7 # better separation between jenkins output and pipeline output
-              black: "#000000"
-              blackB: "#4C4C4C"
-              blue: "#1E90FF"
-              blueB: "#4682B4"
-              cyan: "#00CDCD"
-              cyanB: "#00FFFF"
-              green: "#00CD00"
-              greenB: "#00FF00"
-              magenta: "#CD00CD"
-              magentaB: "#FF00FF"
-              red: "#CD0000"
-              redB: "#FF0000"
-              white: "#E5E5E5"
-              whiteB: "#FFFFFF"
-              yellow: "#CDCD00"
-              yellowB: "#FFFF00"
       custom-header: |
         unclassified:
           customHeaderConfiguration:


### PR DESCRIPTION
We tried improving the pipelone output logs in https://github.com/jenkins-infra/kubernetes-management/pull/4238.

But since then, it has been impossible to read the pipeline outputs or copy and past. This PR removes the configuration to go back to the default state.