### PR TITLE
feat(wiki): revert back to hard anti affinity rule

### DIFF
--- a/config/wiki.yaml
+++ b/config/wiki.yaml
@@ -43,13 +43,11 @@ tolerations:
 
 affinity:
   podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-              - key: "app.kubernetes.io/name"
-                operator: In
-                values:
-                  - wiki
-          topologyKey: "kubernetes.io/hostname"
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: "app.kubernetes.io/name"
+              operator: In
+              values:
+                - wiki
+        topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
to avoid autoscaler to reduce to one single node with both pods