### PR TITLE
chore(infra.ci.jenkins.io): move `helm-charts` job from `Kubernetes Management` folder to `Dependencies Management`

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -120,9 +120,6 @@ jobsDefinition:
             fileName: "kubeconfig"
             description: "Kubeconfig file for publick8s"
             secretBytes: "${base64:${KUBECONFIG_PUBLICK8S}}"
-      helm-charts:
-        name: Helm Charts
-        description: Custom Helm Charts of the Jenkins Infra
   updatecli:
     name: Dependencies Management with Updatecli
     kind: folder
@@ -148,6 +145,9 @@ jobsDefinition:
             tenant: "${PACKER_AZURE_TENANT_ID}"
       packer-images:
         jenkinsfilePath: Jenkinsfile_updatecli
+      helm-charts:
+        name: Helm Charts
+        description: Custom Helm Charts of the Jenkins Infra
   other-jobs:
     name: Other Jobs
     description: Folder hosting all the jobs not fitting any category


### PR DESCRIPTION
This PR moves this job which is only running updatecli.

We don't really care about build history for this job.

If it was the case, it would have needed to create the new job first, then connect into the controller and manually move the build history to this new job, then delete the old job. 