### PR TITLE
feat(infra.ci.jenkins.io) add support for Windows 2022 Azure VM agents

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -308,6 +308,43 @@ controller:
                   virtualNetworkName: "private-vnet"
                   virtualNetworkResourceGroupName: "private"
                 - launcher: "ssh"
+                  agentWorkspace: "C:/Jenkins"
+                  credentialsId: "azure-login"
+                  diskType: "managed"
+                  doNotUseMachineIfInitFails: true
+                  executeInitScriptAsRoot: true
+                  imageReference:
+                    galleryImageDefinition: "jenkins-agent-windows-2022-amd64"
+                    galleryImageVersion: "1.26.1"
+                    galleryName: "prod_packer_images"
+                    galleryResourceGroup: "prod-packer-images"
+                    gallerySubscriptionId: "${PACKER_AZURE_SUBSCRIPTION_ID}"
+                  imageTopLevelType: "advanced"
+                  initScript: |-
+                    (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ${JENKINS_CI_DATADOG_API_KEY}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
+                  javaPath: "C:/tools/jdk-17/bin/java"
+                  jvmOptions: "-XX:+PrintCommandLineFlags"
+                  labels: "windows-2022 amd64 azure vm docker-windows docker-windows-2022 windows"
+                  location: "East US 2"
+                  maxVirtualMachinesLimit: 50
+                  existingStorageAccountName: "${AZURE_STORAGE_ACCOUNT}"
+                  noOfParallelJobs: 1
+                  osDiskSize: 150
+                  osDiskStorageAccountType: "Premium_LRS"
+                  osType: "Windows"
+                  retentionStrategy: "azureVMCloudOnce"
+                  spotInstance: true
+                  storageAccountNameReferenceType: "existing"
+                  storageAccountType: "Standard_LRS"
+                  subnetName: "privatek8s-tier"
+                  templateDesc: "Dynamically provisioned Windows 2022 machine"
+                  templateName: "win-2022"
+                  usageMode: NORMAL
+                  usePrivateIP: true
+                  virtualMachineSize: "Standard_D4s_v3" # 4 vCPUs / 16 Gb
+                  virtualNetworkName: "private-vnet"
+                  virtualNetworkResourceGroupName: "private"
+                - launcher: "ssh"
                   agentWorkspace: "/home/jenkins"
                   credentialsId: "azure-login"
                   diskType: "managed"


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/packer-images/pull/819, I realized we never added the support of Windows 2022 Azure VM agents.

This PR fixes it to allows using Windows 2022 container images in infra.ci.jenkins.io.


💡 Note: following https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility?tabs=windows-server-2022%2Cwindows-11#windows-server-host-os-compatibility, we should be able to test running 2019 containers on 2022 host OS with success which should greatly simplify configuration in the future to only support 1 Windows line.