### PR TITLE
feat(publick8s) shrink jenkinsio replicas from 5 to 2 

### DIFF
--- a/config/jenkinsio.yaml
+++ b/config/jenkinsio.yaml
@@ -46,7 +46,7 @@ ingress:
         - www.jenkins-ci.org
         - www.origin.jenkins.io
 
-replicaCount: 5
+replicaCount: 2
 
 resources:
   limits:


### PR DESCRIPTION
As it is only a backend for fastly, no need to spin up so many pods.

The idea is to avoid the same issue as https://github.com/jenkins-infra/kubernetes-management/pull/4444 and to avoid running too much process (and VMs) when we don't need it.

(edit) A few CPU and memory metrics for the pods of the `jenkinsio` namespace from the past 3 months demonstrating that don't need that much:

![Capture d’écran 2023-09-26 à 18 49 28](https://github.com/jenkins-infra/kubernetes-management/assets/1522731/cd66fc80-09d4-4ac2-ac6d-6a7cae894d12)
![Capture d’écran 2023-09-26 à 18 49 39](https://github.com/jenkins-infra/kubernetes-management/assets/1522731/c09f4a2d-9319-4b9b-a8a0-bc6941ca8c96)

💡 We keep 2 replicas to ensure HA