### PR TITLE
feat(publick8s) shring uplink replicas from 5 to 2

### DIFF
--- a/config/uplink.yaml
+++ b/config/uplink.yaml
@@ -19,7 +19,7 @@ image:
   tag: c7ecad0e5e24bc05ac722418faf844d6a0286620c6316ff712459ecfcc3ee7ce
   pullPolicy: IfNotPresent
 
-replicaCount: 5
+replicaCount: 2
 
 nodeSelector:
   agentpool: x86medium


### PR DESCRIPTION
Since we deployed https://github.com/jenkins-infra/kubernetes-management/pull/4437, we realized that the node pool scaled from 3 to 5 nodes to fulfill the antiaffinity hard constraint.

The question is: do we need that much of replicas?

Looking at datadog shows that, NO we don't:

![Capture d’écran 2023-09-26 à 18 51 58](https://github.com/jenkins-infra/kubernetes-management/assets/1522731/bb9a5203-40e2-47fd-b97f-fb840c014866) 

![Capture d’écran 2023-09-26 à 18 51 46](https://github.com/jenkins-infra/kubernetes-management/assets/1522731/2575ceac-d913-4ae0-a4c4-db3d9761b555)

💡 We keep 2 replicas to ensure HA
