### PR TITLE
feat: add custom header to `release.ci.jenkins.io`

### DIFF
--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -573,7 +573,7 @@ controller:
               hoverColor: "#C11818"
             logo:
               image:
-                logoUrl: "https://www.jenkins.io/images/logos/stay-safe/256.png"
+                logoUrl: "https://release.ci.jenkins.io/userContent/logos/buttler_stay_safe.png"
             logoText: "Jenkins Release"
   sidecars:
     configAutoReload:

--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -562,6 +562,19 @@ controller:
             sshHostKeyVerificationStrategy:
               manuallyProvidedKeyVerificationStrategy:
                 approvedHostKeys: "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+      custom-header: |
+        unclassified:
+          customHeaderConfiguration:
+            enabled: true
+            header: "logo"
+            headerColor:
+              backgroundColor: "linear-gradient(90deg, rgba(255,0,0,1) 0%, rgba(116,1,1,1) 100%);"
+              color: "white"
+              hoverColor: "#C11818"
+            logo:
+              image:
+                logoUrl: "https://www.jenkins.io/images/logos/stay-safe/256.png"
+            logoText: "Jenkins Release"
   sidecars:
     configAutoReload:
       env:


### PR DESCRIPTION
Similar to https://github.com/jenkins-infra/kubernetes-management/pull/4273, custom header for https://release.ci.jenkins.io

Light theme:
<img width="1293" alt="image" src="https://github.com/jenkins-infra/kubernetes-management/assets/91831478/ccabf19c-a260-4279-99e6-4aaea872b44d">

Dark theme:
<img width="1288" alt="image" src="https://github.com/jenkins-infra/kubernetes-management/assets/91831478/01a97ae1-9d74-4815-a19b-f6df27dabb90">

Dark theme, fullscreen:

<details><summary>Before</summary>

![image](https://github.com/jenkins-infra/kubernetes-management/assets/91831478/79946a73-2272-4b4f-8678-3a160a82bba1)

</details>

<details><summary>After</summary>

![image](https://github.com/jenkins-infra/kubernetes-management/assets/91831478/32ac695e-3d49-4550-8d15-c5448a8b2fb4)

</details>

Note: thinking of a blue gradient for trusted.ci.jenkins.io, and of a green one for cert.ci.jenkins.io