### PR TITLE
chore(infra.ci.jenkins.io): use user content logo for the custom header

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -725,7 +725,7 @@ controller:
               hoverColor: "#D0763F"
             logo:
               image:
-                logoUrl: "https://www.jenkins.io/images/logos/beekeeper/beekeeper.png"
+                logoUrl: "https://infra.ci.jenkins.io/userContent/logos/beekeeper.png"
             logoText: "Jenkins Infra"
   sidecars:
     configAutoReload:


### PR DESCRIPTION
Follow-up of #4273 & https://github.com/jenkins-infra/docker-jenkins-weekly/pull/1379 to avoid logo "flashing"