### PR TITLE
fix(publick8s) enable snippet annotations for public ingress

### DIFF
--- a/config/public-nginx-ingress_publick8s.yaml
+++ b/config/public-nginx-ingress_publick8s.yaml
@@ -1,4 +1,7 @@
 controller:
+  # Disable (default since 4.8.0) when https://github.com/kubernetes/ingress-nginx/issues/7811 is fixed
+  # and replace custom headers (only reason for user snippets - search for `more_set_headers` in ./config) by the replacement.
+  allowSnippetAnnotations: true
   replicaCount: 2
   service:
     annotations:


### PR DESCRIPTION
Since https://github.com/jenkins-infra/kubernetes-management/pull/4415 (see https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.9.0), the custom user snippet in Ingress annotations has been disabled by default.

By enabling the snippet annotations on the public ingress of the `publick8s`, this PR fixes the deployment errors like below caused by this 4.8.0 deployment

```
Error: UPGRADE FAILED: release <redacted> failed, and has been rolled back due to atomic being set: cannot patch "<redacted>" with kind Ingress: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: nginx.ingress.kubernetes.io/configuration-snippet annotation cannot be used. Snippet directives are disabled by the Ingress administrator
```

💡As seen with @smerle33 we still use these snippets in 2 locations: accountapp and jenkinsio ingresses for only 1 feature: adding custom headers per vhost (ingress). We should be able to get rid of user snippet (and keep it disabled) once https://github.com/kubernetes/ingress-nginx/issues/7811 will be fixed (and we will adapt our ingress)