### PR TITLE
Revert "Bump jenkins-infra helmfile docker image to 3.0.17 (#4455)"

### DIFF
--- a/PodTemplates.yaml
+++ b/PodTemplates.yaml
@@ -26,7 +26,7 @@ spec:
       value: "spot"
       effect: "NoSchedule"
   containers:
-    - image: jenkinsciinfra/helmfile:3.0.17
+    - image: jenkinsciinfra/helmfile:3.0.14
       imagePullPolicy: "IfNotPresent"
       name: jnlp
       resources:


### PR DESCRIPTION
This reverts commit a0241601c51c9f55b3a234f66f55dac0bc5a7acf.

The kubernetes-management job is failing with

> ERROR: Unable to pull Docker image "jenkinsciinfra/helmfile:3.0.17". Check if image tag name is spelled correctly.

