### PR TITLE
Revert "Revert "Bump jenkins-infra helmfile docker image to 3.0.17 (#4455)""

### DIFF
--- a/PodTemplates.yaml
+++ b/PodTemplates.yaml
@@ -26,7 +26,7 @@ spec:
       value: "spot"
       effect: "NoSchedule"
   containers:
-    - image: jenkinsciinfra/helmfile:3.0.14
+    - image: jenkinsciinfra/helmfile:3.0.17
       imagePullPolicy: "IfNotPresent"
       name: jnlp
       resources:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#4463

The image is probably fine, there seems to be an issue with Docker Hub, reverting this revert, see https://github.com/jenkins-infra/helpdesk/issues/3767#issuecomment-1739988362