### PR TITLE
hotfix(publick8s) bump plugin-site to 0.3.2

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -213,7 +213,7 @@ releases:
   - name: plugin-site
     namespace: plugin-site
     chart: jenkins-infra/plugin-site
-    version: 0.3.1
+    version: 0.3.2
     values:
       - "../config/plugin-site.yaml"
     secrets:


### PR DESCRIPTION
Self merging as it is an hotfix already applied in production