### PR TITLE
Revert "Bump `plugin-health-scoring` helm chart version to 2.3.1"

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -142,7 +142,7 @@ releases:
   - name: plugin-health-scoring
     namespace: plugin-health-scoring
     chart: jenkins-infra/plugin-health-scoring
-    version: 2.3.1
+    version: 2.3.0
     needs:
       - public-nginx-ingress/public-nginx-ingress # Required to expose the service
     values:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#4500

Reverting as per @alecharp request as there seem to be some hiccups