### PR TITLE
feat(privatek8s) disable Tag discovery for wiki/docker-confluence jobs in infra.ci.jenkins.io

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -33,6 +33,7 @@ jobsDefinition:
       docker-404:
       docker-builder:
       docker-confluence-data:
+        disableTagDiscovery: true
       docker-crond:
       docker-hashicorp-tools:
       docker-helmfile:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3751 to test the PR on the shared pipeline library