### PR TITLE
Revert "Bump `rating` helm chart version to 0.3.1"

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -160,7 +160,7 @@ releases:
   - name: rating
     namespace: rating
     chart: jenkins-infra/rating
-    version: 0.3.1
+    version: 0.3.0
     values:
       - "../config/rating.yaml"
     secrets:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#4521

error with the content type header 
```
<br />
<b>Warning</b>:  Undefined array key "callback" in <b>/var/www/html/rate/result.php</b> on line <b>45</b><br />
<br />
<b>Warning</b>:  Undefined array key "json" in <b>/var/www/html/rate/result.php</b> on line <b>48</b><br />
<br />
<b>Warning</b>:  Cannot modify header information - headers already sent by 
```