### PR TITLE
Revert "Bump `datadog` helm chart version to 3.40.0"

### DIFF
--- a/clusters/cik8s.yaml
+++ b/clusters/cik8s.yaml
@@ -32,7 +32,7 @@ releases:
       - default/docker-registry-secrets
     namespace: datadog
     chart: datadog/datadog
-    version: 3.40.0
+    version: 3.39.2
     values:
       - "../config/datadog.yaml.gotmpl"
       - "../config/datadog_cik8s.yaml"

--- a/clusters/doks-public.yaml
+++ b/clusters/doks-public.yaml
@@ -45,7 +45,7 @@ releases:
   - name: datadog
     namespace: datadog
     chart: datadog/datadog
-    version: 3.40.0
+    version: 3.39.2
     needs:
       - default/docker-registry-secrets
     values:

--- a/clusters/doks.yaml
+++ b/clusters/doks.yaml
@@ -29,7 +29,7 @@ releases:
       - default/docker-registry-secrets
     namespace: datadog
     chart: datadog/datadog
-    version: 3.40.0
+    version: 3.39.2
     values:
       - "../config/datadog.yaml.gotmpl"
       - "../config/datadog_doks.yaml"

--- a/clusters/eks-public.yaml
+++ b/clusters/eks-public.yaml
@@ -81,7 +81,7 @@ releases:
   - name: datadog
     namespace: datadog
     chart: datadog/datadog
-    version: 3.40.0
+    version: 3.39.2
     values:
       - "../config/datadog.yaml.gotmpl"
       - "../config/datadog_eks-public.yaml"

--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -43,7 +43,7 @@ releases:
   - name: datadog
     namespace: datadog
     chart: datadog/datadog
-    version: 3.40.0
+    version: 3.39.2
     values:
       - "../config/datadog.yaml.gotmpl"
       - "../config/datadog_privatek8s.yaml"

--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -29,7 +29,7 @@ releases:
   - name: datadog
     namespace: datadog
     chart: datadog/datadog
-    version: 3.40.0
+    version: 3.39.2
     values:
       - "../config/datadog.yaml.gotmpl"
       - "../config/datadog_publick8s.yaml"


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#4519

We received Pagerduty alerts since 24h on the rating.jenkins.io web service.

The synthetics and the jenkins.io pages shows the service is running perfectly.

Checking in datadog, the metrics collected since Wed. 11 Oct. 2023 15h10 GMT+2 have the field `cluster_name` empty, but *only* for the `url` https://rating.jenkins.io.


<img width="1328" alt="Capture d’écran 2023-10-12 à 16 47 02" src="https://github.com/jenkins-infra/kubernetes-management/assets/1522731/655e2e9e-8ed8-46f6-b93b-3efef639f8c4">
<img width="1316" alt="Capture d’écran 2023-10-12 à 16 56 59" src="https://github.com/jenkins-infra/kubernetes-management/assets/1522731/c1a6980c-b331-4c5f-841a-dd12e6bbee54">


However jenkins-infra/kubernetes-management#4519 was deployed at 15h08. Coincidence? I think not.
Besides, digging in the datadog agent changelog:

- https://github.com/DataDog/datadog-agent/releases/tag/7.48.0 is fine but checking the agent version 7.48.0:
- https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-7480 shows:

> Kubernetes API server metrics 4.0.0 BREAKING CHANGE

- Related: https://github.com/DataDog/integrations-core/blob/master/kube_apiserver_metrics/CHANGELOG.md#400--2023-08-10--agent-7480 but I don't understand what is broken and what to do.


Let's revert and see if the data flows again.


