### PR TITLE
feat(publick8s): migrate `public-nginx-ingress` controller and default backend to arm64

### DIFF
--- a/config/public-nginx-ingress_publick8s.yaml
+++ b/config/public-nginx-ingress_publick8s.yaml
@@ -26,7 +26,17 @@ controller:
       - IPv6
     ipFamilyPolicy: PreferDualStack
   nodeSelector:
-    agentpool: x86medium
+    kubernetes.io/arch: arm64
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
 defaultBackend:
   nodeSelector:
-    agentpool: x86medium
+    kubernetes.io/arch: arm64
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"


### PR DESCRIPTION
Similar to https://github.com/jenkins-infra/kubernetes-management/pull/4540

Status announcement: https://github.com/jenkins-infra/status/pull/390

Ref: https://github.com/jenkins-infra/helpdesk/issues/3619#issuecomment-1713522131