### PR TITLE
feat: update the datadog probe URL for rating to use the healthcheck …

### DIFF
--- a/config/datadog_confd_checksd.yaml
+++ b/config/datadog_confd_checksd.yaml
@@ -216,11 +216,10 @@ datadog:
             - production
             - jenkins.io
         - name: rating.jenkins.io
-          url: https://rating.jenkins.io
+          url: https://rating.jenkins.io/healthcheck.html
           timeout: 10
           threshold: 3
           window: 5
-          http_response_status_code: 403
           collect_response_time: true
           check_certificate_expiration: true
           days_warning: 30


### PR DESCRIPTION
…and avoid the 'no-data' state