### PR TITLE
Revert "feat(privatek8s) disable Tag discovery for wiki/docker-confluence jobs in infra.ci.jenkins.io"

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -33,7 +33,6 @@ jobsDefinition:
       docker-404:
       docker-builder:
       docker-confluence-data:
-        disableTagDiscovery: true
       docker-crond:
       docker-hashicorp-tools:
       docker-helmfile:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#4515

This revert is only there to deliver https://github.com/jenkins-infra/docker-confluence-data/pull/50