### PR TITLE
Revert "feat(publick8s): migrate `mirrorbits` to arm64"

### DIFF
--- a/config/mirrorbits.yaml
+++ b/config/mirrorbits.yaml
@@ -94,13 +94,7 @@ replicaCount:
   files: 2
 
 nodeSelector:
-  kubernetes.io/arch: arm64
-
-tolerations:
-  - key: "kubernetes.io/arch"
-    operator: "Equal"
-    value: "arm64"
-    effect: "NoSchedule"
+  agentpool: x86medium
 
 affinity:
   mirrorbits:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#4577

Mirrorbits:
> exec /bin/tini: exec format error 

Files:
> exec /usr/local/bin/httpd-foreground: exec format error 