### PR TITLE
Revert "feat(doks, doks-public) disable clusters management (#4588)"

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -29,7 +29,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'cik8s', 'eks-public', 'privatek8s', 'publick8s'
+            values 'cik8s', 'doks', 'doks-public', 'eks-public', 'privatek8s', 'publick8s'
           }
         } // axes
         agent {


### PR DESCRIPTION
This reverts commit 631789bf01e289f275217dd70da81ed7ae502fa2.

It enables the management of the 2 clusters `doks` and `doks-public` after their upgrade to Kubernetes 1.26