### PR TITLE
feat: add `uplink` to the Docker jobs on `infra.ci.jenkins.io`

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -50,6 +50,8 @@ jobsDefinition:
       plugin-health-scoring:
         jenkinsfilePath: Jenkinsfile
       rating:
+      uplink:
+        jenkinsfilePath: Jenkinsfile
   infra-tools:
     name: Infrastructure Tooling Jobs
     description: Folder hosting all the Infrastructure Tools jobs


### PR DESCRIPTION
This PR adds `uplink` to the Docker jobs on infra.ci.jenkins.io.

- Closes https://github.com/jenkins-infra/uplink/issues/39
- Related: https://github.com/jenkins-infra/uplink/pull/42
- Ref: https://github.com/jenkins-infra/helpdesk/issues/3619