### PR TITLE
feat(publick8s): adding a service account for mirrorbits for update.jenkins.io

### DIFF
--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -95,3 +95,6 @@ rsyncd:
 
   nodeSelector:
     agentpool: x86medium
+
+serviceaccount:
+  enabled: true


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/2649
provide a service account to trigger mirrobits scan for mirrors