### PR TITLE
fix(publick8s) ensure regexp engine is enabled for updates.jenkins.io ingress paths

### DIFF
--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -5,12 +5,13 @@ global:
     annotations:
       "cert-manager.io/cluster-issuer": "letsencrypt-prod"
       "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+      "nginx.ingress.kubernetes.io/use-regex": "true" # Required to allow regexp path matching with Nginx
     hosts:
       - host: azure.updates.jenkins.io
         paths:
           - path: /
             backendService: httpd
-          - path: /.*[.](deb|hpi|war|rpm|msi|pkg|sha256|md5sum|zip|gz|pdf|json|svg|sh|jpeg|ico|png|html)$
+          - path: /.*[.](deb|hpi|war|rpm|msi|pkg|sha256|md5sum|zip|gz|pdf|json|svg|sh|jpeg|ico|png|html|txt)$ # Requires the regexp engine of Nginx to be enabled
             pathType: ImplementationSpecific
             backendService: mirrorbits
     tls:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649

This PR fixes the failing ingress matching for (azure.)updates.jenkins.io by ensuring the regexp engine is enabled for Nginx (same as get.jenkins.io in fact: annotation was lost when I bootstraped the mirrorbits-parent chart).