### PR TITLE
Revert "feat(publick8s): migrate `uplink` to arm64"

### DIFF
--- a/config/uplink.yaml
+++ b/config/uplink.yaml
@@ -17,13 +17,7 @@ ingress:
 replicaCount: 2
 
 nodeSelector:
-  kubernetes.io/arch: arm64
-
-tolerations:
-  - key: "kubernetes.io/arch"
-    operator: "Equal"
-    value: "arm64"
-    effect: "NoSchedule"
+  agentpool: x86medium
 
 affinity:
   podAntiAffinity:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#4609

The pod image deployed to an arm64 node corresponds to the amd64 architecture, and thus was in crashloopbackoff:
https://github.com/jenkins-infra/helm-charts/blob/773d4f596d73df1ca15401de848895b8548add44/charts/uplink/values.yaml#L7

![image](https://github.com/jenkins-infra/kubernetes-management/assets/91831478/a0467c25-3695-4ca7-bc67-f423aa8d584a)

