### PR TITLE
feat(publick8s): migrate `uplink` to arm64 (second shot)

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -168,7 +168,7 @@ releases:
   - name: uplink
     namespace: uplink
     chart: jenkins-infra/uplink
-    version: 0.3.2
+    version: 0.3.3
     timeout: 600
     values:
       - "../config/uplink.yaml"

--- a/config/uplink.yaml
+++ b/config/uplink.yaml
@@ -17,7 +17,13 @@ ingress:
 replicaCount: 2
 
 nodeSelector:
-  agentpool: x86medium
+  kubernetes.io/arch: arm64
+
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
 
 affinity:
   podAntiAffinity:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#4610

Includes https://github.com/jenkins-infra/helm-charts/pull/903

Ref: https://github.com/jenkins-infra/helpdesk/issues/3619