### PR TITLE
feat(privatek8s) add JDK21 tool installation on infra.ci.jenkins.io

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -706,6 +706,22 @@ controller:
                       label: "linux && arm64"
                       subdir: "jdk-17.0.4.1+1"
                       url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1+1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.4.1_1.tar.gz"
+            - name: "jdk21"
+              properties:
+              - installSource:
+                  installers:
+                  - zip:
+                      label: "linux && amd64"
+                      subdir: "jdk-21.0.1+12"
+                      url: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1+12/OpenJDK21U-jdk_x64_linux_hotspot_21.0.1_12.tar.gz"
+                  - zip:
+                      label: "windows"
+                      subdir: "jdk-21.0.1+12"
+                      url: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1+12/OpenJDK21U-jdk_x64_windows_hotspot_21.0.1_12.zip"
+                  - zip:
+                      label: "linux && arm64"
+                      subdir: "jdk-21.0.1+12"
+                      url: "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1+12/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.1_12.tar.gz"
           maven:
             installations:
             - name: "mvn"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3783

This PR adds the JDK21 tool installation on the infra.ci.jenkins.io controller