### PR TITLE
privatek8s: track JDK tool installations with `updatecli` + bump JDK8, JDK11 and JDK17 to latest available version

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -680,16 +680,16 @@ controller:
                   installers:
                   - zip:
                       label: "linux && amd64"
-                      subdir: "jdk-11.0.16.1+1"
-                      url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1+1/OpenJDK11U-jdk_x64_linux_hotspot_11.0.16.1_1.tar.gz"
+                      subdir: "jdk-11.0.21+9"
+                      url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21+9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.21_9.tar.gz
                   - zip:
                       label: "windows"
-                      subdir: "jdk-11.0.16.1+1"
-                      url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1+1/OpenJDK11U-jdk_x64_windows_hotspot_11.0.16.1_1.zip"
+                      subdir: "jdk-11.0.21+9"
+                      url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21+9/OpenJDK11U-jdk_x64_windows_hotspot_11.0.21_9.zip
                   - zip:
                       label: "linux && arm64"
-                      subdir: "jdk-11.0.16.1+1"
-                      url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.16.1+1/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.16.1_1.tar.gz"
+                      subdir: "jdk-11.0.21+9"
+                      url: "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.21+9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.21_9.tar.gz
             - name: "jdk17"
               properties:
               - installSource:

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -664,16 +664,16 @@ controller:
                   installers:
                   - zip:
                       label: "linux && amd64"
-                      subdir: "jdk8u345-b01"
-                      url: "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_x64_linux_hotspot_8u345b01.tar.gz"
+                      subdir: "jdk8u392-b08"
+                      url: "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u392b08.tar.gz
                   - zip:
                       label: "windows"
-                      subdir: "jdk8u345-b01"
-                      url: "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_x64_windows_hotspot_8u345b01.zip"
+                      subdir: "jdk8u392-b08"
+                      url: "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jdk_x64_windows_hotspot_8u392b08.zip
                   - zip:
                       label: "linux && arm64"
-                      subdir: "jdk8u345-b01"
-                      url: "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_aarch64_linux_hotspot_8u345b01.tar.gz"
+                      subdir: "jdk8u392-b08"
+                      url: "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u392-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u392b08.tar.gz
             - name: "jdk11"
               properties:
               - installSource:

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -696,16 +696,16 @@ controller:
                   installers:
                   - zip:
                       label: "linux && amd64"
-                      subdir: "jdk-17.0.4.1+1"
-                      url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1+1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.4.1_1.tar.gz"
+                      subdir: "jdk-17.0.8.1+1"
+                      url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.8.1_1.tar.gz
                   - zip:
                       label: "windows"
-                      subdir: "jdk-17.0.4.1+1"
-                      url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1+1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.4.1_1.zip"
+                      subdir: "jdk-17.0.8.1+1"
+                      url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jdk_x64_windows_hotspot_17.0.8.1_1.zip
                   - zip:
                       label: "linux && arm64"
-                      subdir: "jdk-17.0.4.1+1"
-                      url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.4.1+1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.4.1_1.tar.gz"
+                      subdir: "jdk-17.0.8.1+1"
+                      url: "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1+1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.8.1_1.tar.gz
             - name: "jdk21"
               properties:
               - installSource:

--- a/updatecli/scripts/check-jdk.sh
+++ b/updatecli/scripts/check-jdk.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# This script checks that the provided JDK version has all the required binaries available for downloads
+# as sometimes, the tag for adoptium is published immediatly while binaries are published later.
+##
+# The source of truth is the ERB template stored at the location dist/profile/templates/jenkinscontroller/casc/tools.yaml.erb
+# It lists all the installations used as "Jenkins Tools" by the Jenkins controllers of the infrastructure
+##
+set -eux -o pipefail
+
+command -v curl >/dev/null 2>&1 || { echo "ERROR: curl command not found. Exiting."; exit 1; }
+
+function get_jdk_download_url() {
+  jdk_version="${1}"
+  platform="${2}"
+  case "${jdk_version}" in
+    8*)
+      ## JDK8 does not have the carret ('-') in their archive names
+      echo "https://github.com/adoptium/temurin8-binaries/releases/download/jdk${jdk_version}/OpenJDK8U-jdk_${platform}_hotspot_${jdk_version//-}";
+      return 0;;
+    11*)
+      ## JDK11 URLs have an underscore ('_') instead of a plus ('+') in their archive names
+      echo "https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${jdk_version}/OpenJDK11U-jdk_${platform}_hotspot_${jdk_version//+/_}";
+      return 0;;
+    17*)
+      ## JDK17 URLs have an underscore ('_') instead of a plus ('+') in their archive names
+      echo "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${jdk_version}/OpenJDK17U-jdk_${platform}_hotspot_${jdk_version//+/_}";
+      return 0;;
+    21*-ea-beta)
+      # JDK preview version (21+35-ea-beta, 21.0.1+12-ea-beta)
+      jdk_version="${jdk_version//-ea-beta}"
+      ##    https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21%2B35-ea-beta/OpenJDK21U-jdk_aarch64_linux_hotspot_ea_21-0-35.tar.gz
+      ##    https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12-ea-beta/OpenJDK21U-jdk_x64_linux_hotspot_ea_21-0-1-12.tar.gz
+      dashJDKVersion="${jdk_version//+/-}"
+      completeDashJDKVersion="${dashJDKVersion//./-}"
+      echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${jdk_version//+/%2B}-ea-beta/OpenJDK21U-jdk_${platform}_hotspot_ea_${completeDashJDKVersion}"
+      return 0;;
+    21*)
+      ## JDK21 URLs have an underscore ('_') instead of a plus ('+') in their archive names
+      echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${jdk_version}/OpenJDK21U-jdk_${platform}_hotspot_${jdk_version//+/_}";
+      return 0;;
+    *)
+      echo "ERROR: unsupported JDK version (${jdk_version}).";
+      exit 1;;
+  esac
+}
+
+case "${1}" in
+  8u*)
+    platforms=("x64_linux" "x64_windows" "aarch64_linux");;
+  11.*)
+    platforms=("x64_linux" "x64_windows" "aarch64_linux");;
+  17.*+*)
+    platforms=("x64_linux" "x64_windows" "aarch64_linux");;
+  21*+*)
+    platforms=("x64_linux" "x64_windows" "aarch64_linux");;
+  *)
+    echo "ERROR: unsupported JDK version (${1}).";
+    exit 1;;
+esac
+
+for platform in "${platforms[@]}"
+do
+  url_to_check="$(get_jdk_download_url "${1}" "${platform}")"
+  if [[ "${platform}" == *windows* ]]
+  then
+    url_to_check+=".zip"
+  else
+    url_to_check+=".tar.gz"
+  fi
+  >&2 curl --connect-timeout 5 --location --head --fail --silent "${url_to_check}" || { echo "ERROR: the following URL is NOT available: ${url_to_check}."; exit 1; }
+done
+
+echo "OK: all JDK URL for version=${1} are available."

--- a/updatecli/updatecli.d/jenkins-controllers/tools-jdk11.yaml
+++ b/updatecli/updatecli.d/jenkins-controllers/tools-jdk11.yaml
@@ -1,0 +1,88 @@
+---
+name: Bump JDK11 version (Jenkins tools) on all controllers
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    spec:
+      owner: "adoptium"
+      repository: "temurin11-binaries"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        # jdk-11.0.12+7(https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.12%2B7) is OK
+        pattern: "^jdk-11.(\\d*).(\\d*).(\\d*)+(\\d*)$"
+  escapedVersion:
+    kind: shell
+    dependson:
+      - lastVersion
+    spec:
+      command: echo {{ source "lastVersion" }}
+    transformers:
+      - trimprefix: jdk-
+      - replacer:
+          from: "+"
+          to: "_"
+
+conditions:
+  checkIfReleaseIsAvailable:
+    sourceid: lastVersion
+    transformers:
+      - trimprefix: jdk-
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+
+targets:
+  setJDK11Subdir:
+    name: "Bump JDK11 version on tools"
+    sourceid: lastVersion
+    kind: file
+    spec:
+      file: config/jenkins_infra.ci.jenkins.io.yaml
+      matchpattern: >
+        subdir: "jdk-11(.*)"
+      replacepattern: >
+        subdir: "{{ source `lastVersion` }}"
+    scmid: default
+  setJDK11UrlPaths:
+    name: "Bump JDK11 version on tools"
+    sourceid: lastVersion
+    kind: file
+    spec:
+      file: config/jenkins_infra.ci.jenkins.io.yaml
+      matchpattern: download/jdk-11(.*)/
+      replacepattern: download/{{ source `lastVersion` }}/
+    scmid: default
+  setJDK11UrlFilenames:
+    name: "Bump JDK11 version on tools"
+    disablesourceinput: true
+    kind: file
+    spec:
+      file: config/jenkins_infra.ci.jenkins.io.yaml
+      matchpattern: '_11(.*)\.(tar.gz|zip)"'
+      replacepattern: '_{{ source `escapedVersion` }}.$2"'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump JDK11 version (Jenkins tools) on all controllers to {{ source "lastVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - jdk11

--- a/updatecli/updatecli.d/jenkins-controllers/tools-jdk17.yaml
+++ b/updatecli/updatecli.d/jenkins-controllers/tools-jdk17.yaml
@@ -1,0 +1,88 @@
+---
+name: Bump JDK17 version (Jenkins tools) on all controllers
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    spec:
+      owner: "adoptium"
+      repository: "temurin17-binaries"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        # jdk-17.0.12+7(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.12%2B7) is OK
+        pattern: "^jdk-17.(\\d*).(\\d*).(\\d*)+(\\d*)$"
+  escapedVersion:
+    kind: shell
+    dependson:
+      - lastVersion
+    spec:
+      command: echo {{ source "lastVersion" }}
+    transformers:
+      - trimprefix: jdk-
+      - replacer:
+          from: "+"
+          to: "_"
+
+conditions:
+  checkIfReleaseIsAvailable:
+    sourceid: lastVersion
+    transformers:
+      - trimprefix: jdk-
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+
+targets:
+  setJDK17Subdir:
+    name: "Bump JDK17 version on tools"
+    sourceid: lastVersion
+    kind: file
+    spec:
+      file: config/jenkins_infra.ci.jenkins.io.yaml
+      matchpattern: >
+        subdir: "jdk-17(.*)"
+      replacepattern: >
+        subdir: "{{ source `lastVersion` }}"
+    # scmid: default
+  setJDK17UrlPaths:
+    name: "Bump JDK17 version on tools"
+    sourceid: lastVersion
+    kind: file
+    spec:
+      file: config/jenkins_infra.ci.jenkins.io.yaml
+      matchpattern: download/jdk-17(.*)/
+      replacepattern: download/{{ source `lastVersion` }}/
+    # scmid: default
+  setJDK17UrlFilenames:
+    name: "Bump JDK17 version on tools"
+    disablesourceinput: true
+    kind: file
+    spec:
+      file: config/jenkins_infra.ci.jenkins.io.yaml
+      matchpattern: '_17(.*)\.(tar.gz|zip)"'
+      replacepattern: '_{{ source `escapedVersion` }}.$2"'
+#     scmid: default
+
+# actions:
+#   default:
+#     kind: github/pullrequest
+#     scmid: default
+#     title: Bump JDK17 version (Jenkins tools) on all controllers to {{ source "lastVersion" }}
+#     spec:
+#       labels:
+#         - dependencies
+#         - jdk17

--- a/updatecli/updatecli.d/jenkins-controllers/tools-jdk21.yaml
+++ b/updatecli/updatecli.d/jenkins-controllers/tools-jdk21.yaml
@@ -1,0 +1,88 @@
+---
+name: Bump JDK21 version (Jenkins tools) on all controllers
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    spec:
+      owner: "adoptium"
+      repository: "temurin21-binaries"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        # jdk-21.0.12+7(https://github.com/adoptium/temurin21-binaries/releases/tag/jdk-21.0.12%2B7) is OK
+        pattern: "^jdk-21.(\\d*).(\\d*).(\\d*)+(\\d*)$"
+  escapedVersion:
+    kind: shell
+    dependson:
+      - lastVersion
+    spec:
+      command: echo {{ source "lastVersion" }}
+    transformers:
+      - trimprefix: jdk-
+      - replacer:
+          from: "+"
+          to: "_"
+
+conditions:
+  checkIfReleaseIsAvailable:
+    sourceid: lastVersion
+    transformers:
+      - trimprefix: jdk-
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+
+targets:
+  setJDK21Subdir:
+    name: "Bump JDK21 version on tools"
+    sourceid: lastVersion
+    kind: file
+    spec:
+      file: config/jenkins_infra.ci.jenkins.io.yaml
+      matchpattern: >
+        subdir: "jdk-21(.*)"
+      replacepattern: >
+        subdir: "{{ source `lastVersion` }}"
+    # scmid: default
+  setJDK21UrlPaths:
+    name: "Bump JDK21 version on tools"
+    sourceid: lastVersion
+    kind: file
+    spec:
+      file: config/jenkins_infra.ci.jenkins.io.yaml
+      matchpattern: /jdk-21(.*)/
+      replacepattern: /{{ source `lastVersion` }}/
+    # scmid: default
+  setJDK21UrlFilenames:
+    name: "Bump JDK21 version on tools"
+    disablesourceinput: true
+    kind: file
+    spec:
+      file: config/jenkins_infra.ci.jenkins.io.yaml
+      matchpattern: '_21(.*)\.(tar.gz|zip)"'
+      replacepattern: '_{{ source `escapedVersion` }}.$2"'
+#     scmid: default
+
+# actions:
+#   default:
+#     kind: github/pullrequest
+#     scmid: default
+#     title: Bump JDK21 version (Jenkins tools) on all controllers to {{ source "lastVersion" }}
+#     spec:
+#       labels:
+#         - dependencies
+#         - jdk21

--- a/updatecli/updatecli.d/jenkins-controllers/tools-jdk8.yaml
+++ b/updatecli/updatecli.d/jenkins-controllers/tools-jdk8.yaml
@@ -1,0 +1,89 @@
+---
+name: Bump JDK8 version (Jenkins tools) on all controllers
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    name: Get the latest Adoptium JDK8 version
+    spec:
+      owner: adoptium
+      repository: temurin8-binaries
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: regex
+        # jdk8u302-b08 is OK, but jdk8u302-b08.1 is not
+        pattern: "^jdk8u(\\d*)-b(\\d*)$"
+  escapedVersion:
+    kind: shell
+    dependson:
+      - lastVersion
+    spec:
+      command: echo {{ source "lastVersion" }}
+    transformers:
+      - trimprefix: jdk
+      - replacer:
+          from: "-"
+          to: ""
+
+conditions:
+  checkIfReleaseIsAvailable:
+    sourceid: lastVersion
+    transformers:
+      - trimprefix: jdk
+    kind: shell
+    spec:
+      command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+
+targets:
+  setJDK8Subdir:
+    name: "Bump JDK8 version on tools"
+    sourceid: lastVersion
+    kind: file
+    spec:
+      file: config/jenkins_infra.ci.jenkins.io.yaml
+      matchpattern: >
+        subdir: "jdk8u(.*)"
+      replacepattern: >
+        subdir: "{{ source `lastVersion` }}"
+    scmid: default
+  setJDK8UrlPaths:
+    name: "Bump JDK8 version on tools"
+    sourceid: lastVersion
+    kind: file
+    spec:
+      file: config/jenkins_infra.ci.jenkins.io.yaml
+      matchpattern: /jdk8u(.*)/
+      replacepattern: /{{ source `lastVersion` }}/
+    scmid: default
+  setJDK8UrlFilenames:
+    name: "Bump JDK8 version on tools"
+    disablesourceinput: true
+    kind: file
+    spec:
+      file: config/jenkins_infra.ci.jenkins.io.yaml
+      matchpattern: '_8u(.*)\.(tar.gz|zip)"'
+      replacepattern: '_{{ source `escapedVersion` }}.$2"'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump JDK8 version (Jenkins tools) on all controllers to {{ source "lastVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - jdk8


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3783, this PR adds updatecli manifests to track the JDK tool installation versions for JDK8, JDK11, JDK17 and JDK21.

To test the manifest, I've used it to update locally:

- JDK8 to `8u392-b08` (`updatecli apply` without `scmid` in targets)
- JDK11 to `11.0.16.1+1` (`updatecli apply` without `scmid` in targets)
- JDK17 to `17.0.8.1+1` ( Custom source + `updatecli apply` without `scmid` in targets) => this is the last version with x64_windows in the same version as Linux


Note: JDK21 is already up to date since #4629 


Note 2: https://github.com/updatecli/updatecli/issues/1733 would help to simplify the manifests here A LOT