### PR TITLE
fixup(publick8s): don't force `datadog` pods to be only on arm64 nodes

### DIFF
--- a/config/datadog_publick8s.yaml
+++ b/config/datadog_publick8s.yaml
@@ -9,8 +9,6 @@ datadog:
     # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
     tlsVerify: false
 agents:
-  nodeSelector:
-    kubernetes.io/arch: arm64
   tolerations:
     - key: "kubernetes.io/arch"
       operator: "Equal"


### PR DESCRIPTION
This PR removes the arm64 toleration (constraint) for the `datadog` pods. (Related: LDAP PagerDuty alert)

Fixup of:
- #4575 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3619