### PR TITLE
feat(publick8s): change LB annotation to move public ips RG

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -231,7 +231,7 @@ releases:
   - name: ipv6-lb-service
     namespace: public-nginx-ingress
     chart: jenkins-infra/ipv6-lb-service
-    version: 0.1.0
+    version: 1.0.0
     needs:
       - public-nginx-ingress/public-nginx-ingress
     values:

--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -121,7 +121,7 @@ releases:
   - name: ldap
     namespace: ldap
     chart: jenkins-infra/ldap
-    version: 0.2.1
+    version: 0.3.0
     timeout: 600
     values:
       - "../config/ldap.yaml"

--- a/config/ipv6-lb-service.yaml
+++ b/config/ipv6-lb-service.yaml
@@ -1,5 +1,6 @@
 # azurerm_public_ip.publick8s_ipv6.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
-ipv6: 2603:1030:408:5::15a
+ipv6PipName: public-publick8s-ipv4
+ipv6ResourceGroup: prod-public-ips
 app:
   name: "ingress-nginx"
   component: "controller"

--- a/config/ipv6-lb-service.yaml
+++ b/config/ipv6-lb-service.yaml
@@ -1,5 +1,5 @@
 # azurerm_public_ip.publick8s_ipv6.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
-ipv6PipName: public-publick8s-ipv4
+ipv6PipName: public-publick8s-ipv6
 ipv6ResourceGroup: prod-public-ips
 app:
   name: "ingress-nginx"

--- a/config/ipv6-lb-service.yaml
+++ b/config/ipv6-lb-service.yaml
@@ -1,6 +1,6 @@
 # azurerm_public_ip.publick8s_ipv6.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
 ipv6PipName: public-publick8s-ipv6
-ipv6ResourceGroup: prod-public-ips
+resourceGroup: prod-public-ips
 app:
   name: "ingress-nginx"
   component: "controller"

--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -1,7 +1,9 @@
 service:
   type: LoadBalancer
   # Public IPv4 defined as code in https://github.com/jenkins-infra/azure/blob/main/ldap.jenkins.io.tf instead of requesting a random new public IP, useful for DNS setup and changes
-  IP: 20.7.180.148
+  azurePip:
+    name: ldap-jenkins-io-ipv4
+    resourceGroup: prod-public-ips
   whitelisted_sources:
     - '20.85.71.108/32'  # Accept inbound connections from publick8s public outbound IP
     - '10.100.0.0/16'  # publick8s Pod CIDR (internal IPs) for intrnal access

--- a/config/public-nginx-ingress_publick8s.yaml
+++ b/config/public-nginx-ingress_publick8s.yaml
@@ -18,9 +18,7 @@ controller:
       service.beta.kubernetes.io/azure-load-balancer-internal: false
       service.beta.kubernetes.io/azure-load-balancer-resource-group: prod-public-ips
       # azurerm_public_ip.publick8s_ipv4.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
-      service.beta.kubernetes.io/azure-load-balancer-ipv4: 20.7.178.24
-      # azurerm_public_ip.publick8s_ipv6.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
-      service.beta.kubernetes.io/azure-load-balancer-ipv6: 2603:1030:408:5::15a
+      service.beta.kubernetes.io/azure-pip-name: public-publick8s-ipv4
     externalTrafficPolicy: Local
     ipFamilies:
       - IPv4

--- a/config/public-nginx-ingress_publick8s.yaml
+++ b/config/public-nginx-ingress_publick8s.yaml
@@ -16,14 +16,11 @@ controller:
   service:
     annotations:
       service.beta.kubernetes.io/azure-load-balancer-internal: false
+      service.beta.kubernetes.io/azure-load-balancer-resource-group: prod-public-ips
       # azurerm_public_ip.publick8s_ipv4.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
-      # service.beta.kubernetes.io/azure-load-balancer-ipv4: 20.7.178.24
-      service.beta.kubernetes.io/azure-pip-name: public-publick8s-ipv4
-      service.beta.kubernetes.io/azure-load-balancer-resource-group: prod-public-ips
+      service.beta.kubernetes.io/azure-load-balancer-ipv4: 20.7.178.24
       # azurerm_public_ip.publick8s_ipv6.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
-      # service.beta.kubernetes.io/azure-load-balancer-ipv6: 2603:1030:408:5::15a
-      service.beta.kubernetes.io/azure-pip-name: public-publick8s-ipv6
-      service.beta.kubernetes.io/azure-load-balancer-resource-group: prod-public-ips
+      service.beta.kubernetes.io/azure-load-balancer-ipv6: 2603:1030:408:5::15a
     externalTrafficPolicy: Local
     ipFamilies:
       - IPv4

--- a/config/public-nginx-ingress_publick8s.yaml
+++ b/config/public-nginx-ingress_publick8s.yaml
@@ -17,9 +17,13 @@ controller:
     annotations:
       service.beta.kubernetes.io/azure-load-balancer-internal: false
       # azurerm_public_ip.publick8s_ipv4.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
-      service.beta.kubernetes.io/azure-load-balancer-ipv4: 20.7.178.24
+      # service.beta.kubernetes.io/azure-load-balancer-ipv4: 20.7.178.24
+      service.beta.kubernetes.io/azure-pip-name: public-publick8s-ipv4
+      service.beta.kubernetes.io/azure-load-balancer-resource-group: prod-public-ips
       # azurerm_public_ip.publick8s_ipv6.ip_address in https://github.com/jenkins-infra/azure/blob/main/publick8s.tf
-      service.beta.kubernetes.io/azure-load-balancer-ipv6: 2603:1030:408:5::15a
+      # service.beta.kubernetes.io/azure-load-balancer-ipv6: 2603:1030:408:5::15a
+      service.beta.kubernetes.io/azure-pip-name: public-publick8s-ipv6
+      service.beta.kubernetes.io/azure-load-balancer-resource-group: prod-public-ips
     externalTrafficPolicy: Local
     ipFamilies:
       - IPv4


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3683#issuecomment-1798182954

WARNING : 
if we change : `service.beta.kubernetes.io/azure-load-balancer-ipv4` and replace it with `service.beta.kubernetes.io/azure-pip-name` we will endup having twice the key `service.beta.kubernetes.io/azure-pip-name` one for ipv4 one for ipv6. 
`Map keys must be unique` as we have one for ipv4 and one for ipv6 !

it seems that the service.beta.kubernetes.io/azure-pip-name is not mandatory to be able to use `service.beta.kubernetes.io/azure-load-balancer-resource-group`



--- 

Requires https://github.com/jenkins-infra/helm-charts/pull/933 and https://github.com/jenkins-infra/helm-charts/pull/934

Closes #4650 #4651