### PR TITLE
feat(infra.ci) align Azure-VM agent sizing with ci.jenkins.io

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -225,6 +225,8 @@ controller:
                   credentialsId: "azure-login"
                   diskType: "managed"
                   doNotUseMachineIfInitFails: true
+                  encryptionAtHost: true
+                  ephemeralOSDisk: true
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-amd64"
@@ -256,7 +258,7 @@ controller:
                   existingStorageAccountName: "${AZURE_STORAGE_ACCOUNT}"
                   noOfParallelJobs: 1
                   osDiskSize: 150
-                  osDiskStorageAccountType: "Premium_LRS"
+                  osDiskStorageAccountType: "Standard_LRS"
                   osType: "Linux"
                   retentionStrategy: "azureVMCloudOnce"
                   spotInstance: true
@@ -267,7 +269,7 @@ controller:
                   templateName: "ubuntu-22"
                   usageMode: NORMAL
                   usePrivateIP: true
-                  virtualMachineSize: "Standard_D4s_v3" # 4 vCPUs / 16 Gb
+                  virtualMachineSize: "Standard_D4ads_v5" # 4 vCPUs / 16 Gb
                   virtualNetworkName: "private-vnet"
                   virtualNetworkResourceGroupName: "private"
                 - launcher: "ssh"
@@ -275,6 +277,8 @@ controller:
                   credentialsId: "azure-login"
                   diskType: "managed"
                   doNotUseMachineIfInitFails: true
+                  encryptionAtHost: true
+                  ephemeralOSDisk: true
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-windows-2019-amd64"
@@ -293,7 +297,7 @@ controller:
                   existingStorageAccountName: "${AZURE_STORAGE_ACCOUNT}"
                   noOfParallelJobs: 1
                   osDiskSize: 150
-                  osDiskStorageAccountType: "Premium_LRS"
+                  osDiskStorageAccountType: "Standard_LRS"
                   osType: "Windows"
                   retentionStrategy: "azureVMCloudOnce"
                   spotInstance: true
@@ -304,7 +308,7 @@ controller:
                   templateName: "win-2019"
                   usageMode: NORMAL
                   usePrivateIP: true
-                  virtualMachineSize: "Standard_D4s_v3" # 4 vCPUs / 16 Gb
+                  virtualMachineSize: "Standard_D4ads_v5" # 4 vCPUs / 16 Gb
                   virtualNetworkName: "private-vnet"
                   virtualNetworkResourceGroupName: "private"
                 - launcher: "ssh"
@@ -312,6 +316,8 @@ controller:
                   credentialsId: "azure-login"
                   diskType: "managed"
                   doNotUseMachineIfInitFails: true
+                  encryptionAtHost: true
+                  ephemeralOSDisk: true
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-windows-2022-amd64"
@@ -330,7 +336,7 @@ controller:
                   existingStorageAccountName: "${AZURE_STORAGE_ACCOUNT}"
                   noOfParallelJobs: 1
                   osDiskSize: 150
-                  osDiskStorageAccountType: "Premium_LRS"
+                  osDiskStorageAccountType: "Standard_LRS"
                   osType: "Windows"
                   retentionStrategy: "azureVMCloudOnce"
                   spotInstance: true
@@ -341,7 +347,7 @@ controller:
                   templateName: "win-2022"
                   usageMode: NORMAL
                   usePrivateIP: true
-                  virtualMachineSize: "Standard_D4s_v3" # 4 vCPUs / 16 Gb
+                  virtualMachineSize: "Standard_D4ads_v5" # 4 vCPUs / 16 Gb
                   virtualNetworkName: "private-vnet"
                   virtualNetworkResourceGroupName: "private"
                 - launcher: "ssh"
@@ -349,6 +355,8 @@ controller:
                   credentialsId: "azure-login"
                   diskType: "managed"
                   doNotUseMachineIfInitFails: true
+                  encryptionAtHost: true
+                  ephemeralOSDisk: true
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
@@ -379,8 +387,8 @@ controller:
                   maxVirtualMachinesLimit: 50
                   existingStorageAccountName: "${AZURE_STORAGE_ACCOUNT}"
                   noOfParallelJobs: 1
-                  osDiskSize: 128
-                  osDiskStorageAccountType: "Premium_LRS"
+                  osDiskSize: 100 # https://github.com/jenkins-infra/helpdesk/issues/3812
+                  osDiskStorageAccountType: "Standard_LRS"
                   osType: "Linux"
                   retentionStrategy: "azureVMCloudOnce"
                   spotInstance: true
@@ -391,7 +399,7 @@ controller:
                   templateName: "ubuntu-22-arm64"
                   usageMode: NORMAL
                   usePrivateIP: true
-                  virtualMachineSize: "Standard_D4ps_v5" # 4 vCPUs / 16 Gb
+                  virtualMachineSize: "Standard_D4pds_v5" # 4 vCPUs / 16 Gb
                   virtualNetworkName: "private-vnet"
                   virtualNetworkResourceGroupName: "private"
       security: |


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3812

This PR ensures we use the same kind of instance (lower costs for spots) with ephemeral disks (faster startup and no $$ to pay for managed disks).


Note that our quota might be limiting : let's keep it like this for now until we start using the new MSOP subscription.