### PR TITLE
hotfix(privatek8s) fix infra.ci JCasc for datadog plugin 0.56.0

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -645,8 +645,6 @@ controller:
           datadogGlobalConfiguration:
             ciInstanceName: "infra.ci.jenkins.io"
             collectBuildLogs: false
-            # Send events on configuration changes to jobs or changes to jenkins. These events include changes by the system which may be frequent and redundant.
-            emitConfigChangeEvents: true
             emitSecurityEvents: true
             emitSystemEvents: true
             enableCiVisibility: true


### PR DESCRIPTION
The datadog plugin [version 0.56.0](https://github.com/jenkinsci/datadog-plugin/blob/master/CHANGELOG.md#560--2023-11-13) introduced a breaking change preventing the infra.ci.jenkins.io controller to start.

The logs showed the following JCasc error during the startup phase:

```
2023-11-14 16:52:17.641+0000 [id=24]	SEVERE	hudson.util.BootFailure#publish: Failed to initialize Jenkins
io.jenkins.plugins.casc.ConfiguratorException: Invalid configuration elements for type class org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration : emitConfigChangeEvents.
Available attributes : cacheBuildRuns, ciInstanceName, collectBuildLogs, emitSecurityEvents, emitSystemEvents, enableCiVisibility, excludeEvents, excluded, globalJobTags, globalTagFile, globalTags, hostname, includeEvents, included, refreshDogstatsdClient, reportWith, retryLogs, targetApiKey, targetApiURL, targetCredentialsApiKey, targetHost, targetLogCollectionPort, targetLogIntakeURL, targetPort, targetTraceCollectionPort, targetWebhookIntakeURL, useAwsInstanceHostname, usedApiKey
	at io.jenkins.plugins.casc.BaseConfigurator.handleUnknown(BaseConfigurator.java:387)
	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:374)
	at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:293)
	at io.jenkins.plugins.casc.BaseConfigurator.configure(BaseConfigurator.java:360)
	at io.jenkins.plugins.casc.BaseConfigurator.check(BaseConfigurator.java:293)
	at io.jenkins.plugins.casc.ConfigurationAsCode.lambda$checkWith$9(ConfigurationAsCode.java:803)
	at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:737)
Caused: io.jenkins.plugins.casc.ConfiguratorException: unclassified: error configuring 'unclassified' with class io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator configurator
	at io.jenkins.plugins.casc.ConfigurationAsCode.invokeWith(ConfigurationAsCode.java:743)
	at io.jenkins.plugins.casc.ConfigurationAsCode.checkWith(ConfigurationAsCode.java:803)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:789)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configureWith(ConfigurationAsCode.java:658)
	at io.jenkins.plugins.casc.ConfigurationAsCode.configure(ConfigurationAsCode.java:315)
	at io.jenkins.plugins.casc.ConfigurationAsCode.init(ConfigurationAsCode.java:307)
Caused: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:109)
Caused: java.lang.Error
	at hudson.init.TaskMethodFinder.invoke(TaskMethodFinder.java:115)
	at hudson.init.TaskMethodFinder$TaskImpl.run(TaskMethodFinder.java:185)
	at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:305)
	at jenkins.model.Jenkins$5.runTask(Jenkins.java:1170)
	at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:221)
	at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:120)
	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:68)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused: org.jvnet.hudson.reactor.ReactorException
	at org.jvnet.hudson.reactor.Reactor.execute(Reactor.java:290)
	at jenkins.InitReactorRunner.run(InitReactorRunner.java:49)
	at jenkins.model.Jenkins.executeReactor(Jenkins.java:1205)
	at jenkins.model.Jenkins.<init>(Jenkins.java:992)
	at hudson.model.Hudson.<init>(Hudson.java:86)
	at hudson.model.Hudson.<init>(Hudson.java:82)
	at hudson.WebAppMain$3.run(WebAppMain.java:247)
Caused: hudson.util.HudsonFailedToLoad
	at hudson.WebAppMain$3.run(WebAppMain.java:264)

```

We tried removing the line from the JCasc configmap and everything went fine, so here is the PR to persist the change in IaC.