### PR TITLE
feat(publick8s) fine tune ingress rule for updates.jenkins.io

### DIFF
--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -11,7 +11,7 @@ global:
         paths:
           - path: /
             backendService: httpd
-          - path: /.*[.](deb|hpi|war|rpm|msi|pkg|sha256|md5sum|zip|gz|pdf|json|svg|sh|jpeg|ico|png|html|txt)$ # Requires the regexp engine of Nginx to be enabled
+          - path: /.*[.](json|html|txt)$ # Requires the regexp engine of Nginx to be enabled
             pathType: ImplementationSpecific
             backendService: mirrorbits
     tls:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-1808612479

This PR fine tune the ingress rule of update.jenkins.io to only send requests ending with `.json`, `.html` or `.txt` extensions to mirrorbits:

- The https://updates.jenkins.io/ URL will still be sent to Apache (which has all the files) so it can serve the index.html file as the default file before trying listing diretctories
- All other `html` and `txt` files are copied to the mirror along the `json` files (both UC and crawler)