### PR TITLE
feat(publick8s): migrate mirrorbits-parents, httpd and rsync to arm64

### DIFF
--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -65,7 +65,12 @@ httpd:
       cpu: 2000m
       memory: 2048Mi
   nodeSelector:
-    agentpool: x86medium
+    kubernetes.io/arch: arm64
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
 
 rsyncd:
   enabled: true
@@ -95,7 +100,12 @@ rsyncd:
       memory: 64Mi
 
   nodeSelector:
-    agentpool: x86medium
+    kubernetes.io/arch: arm64
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
 
 serviceaccount:
   enabled: true


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3619#issuecomment-1816831551

ARM64 version of 
  - `httpd`: https://hub.docker.com/layers/library/httpd/2.4.58/images/sha256-032af99592618d77a391821b7ada3d1917c274a34a62688c847de8a7b017bfbc?context=explore
      no sha : https://github.com/jenkins-infra/helm-charts/blob/109c46956afc2f37fdfedf306cde4f3a21666e53/charts/httpd/values.yaml#L7
  - `rsyncd`: https://hub.docker.com/layers/jenkinsciinfra/rsyncd/1.0.13/images/sha256-0a88d7a622d241f7c177ad5a44ac4fde3eaf60a984b72af960bc11429e2d0a75?context=explore
      sha : https://github.com/jenkins-infra/helm-charts/blob/109c46956afc2f37fdfedf306cde4f3a21666e53/charts/rsyncd/values.yaml#L6C22-L6C86. : `tag: 1.0.13@sha256:d3ed3a8438f0927b5b5e518a53feb098e4d7520433aa20ec20c7398830bb6245`