### PR TITLE
feat(publick8s): add `contributors.jenkins.io`

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -244,3 +244,11 @@ releases:
       - "../config/updates.jenkins.io.yaml"
     secrets:
       - "../secrets/config/updates.jenkins.io/secrets.yaml"
+  - name: contributors-jenkins-io
+    namespace: contributors-jenkins-io
+    chart: jenkins-infra/nginx-website
+    version: 0.1.0
+    values:
+      - "../config/contributors.jenkins.io.yaml"
+    secrets:
+      - "../secrets/config/contributors.jenkins.io/secrets.yaml"

--- a/config/contributors.jenkins.io.yaml
+++ b/config/contributors.jenkins.io.yaml
@@ -1,0 +1,56 @@
+---
+ingress:
+  enabled: true
+  className: public-nginx
+  annotations:
+    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+    "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+  hosts:
+    - host: contributors.jenkins.io
+      paths:
+        - path: /
+          serviceName: contributors-jenkins-io
+    - host: contributors.origin.jenkins.io
+      paths:
+        - path: /
+          serviceName: contributors-jenkins-io
+  # contributors.jenkins.io certificate is managed by Fastly
+  tls:
+    - secretName: contributors-jenkins-io-tls
+      hosts:
+        - contributors.origin.jenkins.io
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+htmlVolume:
+  azureFile:
+    secretName: contributors-jenkins-io
+    shareName: contributors-jenkins-io
+    readOnly: true
+
+replicaCount: 2
+
+nodeSelector:
+  kubernetes.io/arch: arm64
+
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: "app.kubernetes.io/name"
+              operator: In
+              values:
+                - contributors-jenkins-io
+        topologyKey: "kubernetes.io/hostname"

--- a/updatecli/updatecli.d/charts/nginx-website.yaml
+++ b/updatecli/updatecli.d/charts/nginx-website.yaml
@@ -1,0 +1,43 @@
+---
+name: "Bump nginx-website Helm Chart Version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastChartVersion:
+    kind: helmchart
+    name: get last chart version
+    spec:
+      url: https://jenkins-infra.github.io/helm-charts
+      name: nginx-website
+
+targets:
+  updateChartVersion:
+    name: "Update the chart version for nginx-website"
+    kind: file
+    spec:
+      file: clusters/publick8s.yaml
+      matchpattern: 'chart: jenkins-infra\/nginx-website((\r\n|\r|\n)(\s+))version: .*'
+      replacepattern: 'chart: jenkins-infra/nginx-website${1}version: {{ source "lastChartVersion" }}'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump `nginx-website` helm chart version to {{ source "lastChartVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - nginx-website
+        - contributors.jenkins.io


### PR DESCRIPTION
This PR adds a release for deploying `nginx-website` helm chart on `publick8s` cluster with `contributorsjenkinsio` storage account mounted as volume to serve the content generated by https://github.com/jenkins-infra/contributor-spotlight/ on https://contributors.origin.jenkins.io, to be cached by Fastly CDN.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3809#issuecomment-1822357561