### PR TITLE
fix(contributors.jenkins.io): correct secret name

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -247,7 +247,7 @@ releases:
   - name: contributors-jenkins-io
     namespace: contributors-jenkins-io
     chart: jenkins-infra/nginx-website
-    version: 0.1.0
+    version: 0.1.1
     values:
       - "../config/contributors.jenkins.io.yaml"
     secrets:

--- a/config/contributors.jenkins.io.yaml
+++ b/config/contributors.jenkins.io.yaml
@@ -29,7 +29,7 @@ resources:
     memory: 128Mi
 htmlVolume:
   azureFile:
-    secretName: nginx-website
+    secretName: contributors-jenkins-io
     shareName: contributors-jenkins-io
     readOnly: true
 

--- a/config/contributors.jenkins.io.yaml
+++ b/config/contributors.jenkins.io.yaml
@@ -29,7 +29,7 @@ resources:
     memory: 128Mi
 htmlVolume:
   azureFile:
-    secretName: contributors-jenkins-io
+    secretName: contributors-jenkins-io-nginx-website
     shareName: contributors-jenkins-io
     readOnly: true
 


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/helm-charts/pull/961, revert outdated hotfix https://github.com/jenkins-infra/kubernetes-management/commit/208c32f4366a322d3a3a3d65e6783a92c33776b9