### PR TITLE
Use a less aggressive red for release.ci's header

### DIFF
--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -568,7 +568,7 @@ controller:
             enabled: true
             header: "logo"
             headerColor:
-              backgroundColor: "linear-gradient(90deg, rgba(255,0,0,1) 0%, rgba(116,1,1,1) 100%);"
+              backgroundColor: "linear-gradient(90deg, rgba(255, 80, 80, 1) 0%, rgba(198, 112, 112, 1) 100%);"
               color: "white"
               hoverColor: "#C11818"
             logo:


### PR DESCRIPTION
Before:
<img width="1468" alt="Screenshot 2023-11-26 at 19 30 13" src="https://github.com/jenkins-infra/kubernetes-management/assets/13383509/0ac4f182-a008-4042-a931-75e12f505769">

After:
<img width="1539" alt="Screenshot 2023-11-26 at 19 30 33" src="https://github.com/jenkins-infra/kubernetes-management/assets/13383509/145bf721-ef90-4951-9084-3f25b135c2d2">

Additionally, I've reversed the gradient, so its color intensity goes from left to right, instead of right to left.