### PR TITLE
feat(publick8s): migration of weekly.ci to ARM64 with Volume migration

### DIFF
--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -9,7 +9,10 @@ rbac:
 persistence:
   enabled: true
   size: 8Gi
-  storageClass: managed-csi-premium-retain
+  storageClass: managed-csi-premium-zrs-retain
+  dataSource:
+    name: jenkins-weekly-snap
+    kind: PersistentVolumeClaim
 agent:
   componentName: "agent"
 networkPolicy:
@@ -23,8 +26,12 @@ controller:
   tag: 1.15.0-2.433
   imagePullPolicy: IfNotPresent
   nodeSelector:
-    kubernetes.io/os: linux
-    kubernetes.azure.com/agentpool: x86medium
+    kubernetes.io/arch: arm64
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
   resources:
     limits:
       cpu: "2"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3619#issuecomment-1825661926

migration of weekly.ci.jenkins.io to ARM64

we created manually a disk volume : jenkins-weekly-snap from a snapshot as an ZRS storage to serve as a source for the cloning from the helmchart : https://github.com/jenkinsci/helm-charts/blob/a052ad9f6fc0f95e67802edc7cef9ab9c3572bee/charts/jenkins/values.yaml#L860-L864

this storage should be destroyed with the corresponding PV/PVC after the cloning https://kubernetes.io/docs/concepts/storage/volume-pvc-datasource/
