### PR TITLE
chore(updates.jenkins.io): remove yamllint warnings

### DIFF
--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -5,13 +5,13 @@ global:
     annotations:
       "cert-manager.io/cluster-issuer": "letsencrypt-prod"
       "nginx.ingress.kubernetes.io/ssl-redirect": "true"
-      "nginx.ingress.kubernetes.io/use-regex": "true" # Required to allow regexp path matching with Nginx
+      "nginx.ingress.kubernetes.io/use-regex": "true"  # Required to allow regexp path matching with Nginx
     hosts:
       - host: azure.updates.jenkins.io
         paths:
           - path: /
             backendService: httpd
-          - path: /.*[.](json|html|txt)$ # Requires the regexp engine of Nginx to be enabled
+          - path: /.*[.](json|html|txt)$  # Requires the regexp engine of Nginx to be enabled
             pathType: ImplementationSpecific
             backendService: mirrorbits
     tls:


### PR DESCRIPTION
Fix the following warnings from kubernetes-management build logs:
```
 + yamllint --config-file yamllint.config config
 config/updates.jenkins.io.yaml
   8:55      warning  too few spaces before comment  (comments)
   14:42     warning  too few spaces before comment  (comments)
```