### PR TITLE
chore(contributors.jenkins.io): add File Share SAS query string credentials

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -464,3 +464,7 @@ jobsDefinition:
         description: "Jenkins Contributor Spotlight Website"
         allowUntrustedChanges: true
         jenkinsfilePath: Jenkinsfile
+        credentials:
+          contributors-jenkins-io-fileshare-sas-querystring:
+            secret: "${CONTRIBUTORS_JENKINS_IO_FILESHARE_SAS_QUERYSTRING}"
+            description: "File Share SAS query string to update contributors.jenkins.io content"


### PR DESCRIPTION
This PR adds File Share SAS query string credentials to contributors.jenkins.io job on infra.ci.jenkins.io to update the webiste content with azcopy.

Corresponding secret added in the private repo charts-secrets: https://github.com/jenkins-infra/charts-secrets/commit/9e59870ebab7497c084d3e790d09e481338dcadd

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3809#issuecomment-1822357561