### PR TITLE
feat(infra.ci): add arm64 agent to use on the new node pool

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -140,6 +140,38 @@ controller:
                           operator: "Equal"
                           value: "spot"
                           effect: "NoSchedule"
+                  - name: jnlp-linux-arm64
+                    nodeSelector: "kubernetes.io/arch=arm64"
+                    containers:
+                      - name: jnlp-arm64
+                        image: "jenkins/inbound-agent:latest-jdk17"
+                        envVars:
+                        - envVar:
+                            key: "JENKINS_JAVA_BIN"
+                            value: "/opt/java/openjdk/bin/java"
+                        resourceLimitCpu: "500m"
+                        resourceLimitMemory: "512Mi"
+                        resourceRequestCpu: "500m"
+                        resourceRequestMemory: "512Mi"
+                        alwaysPullImage: true
+                    yamlMergeStrategy: "merge"
+                    yaml: |-
+                      apiVersion: v1
+                      kind: Pod
+                      spec:
+                        tolerations:
+                        - key: "jenkins"
+                          operator: "Equal"
+                          value: "infra.ci.jenkins.io"
+                          effect: "NoSchedule"
+                        - key: "kubernetes.azure.com/scalesetpriority"
+                          operator: "Equal"
+                          value: "spot"
+                          effect: "NoSchedule"
+                        - key: "kubernetes.io/arch"
+                          operator: "Equal"
+                          value: "arm64"
+                          effect: "NoSchedule"
                   - name: jnlp-windows
                     nodeSelector: "kubernetes.io/os=windows"
                     instanceCap: 5 # Usual sizing is 2 pods per Windows node, and max 3 windows nodes


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3823
and following https://github.com/jenkins-infra/azure/pull/533

provide arm64 pods agents from infra.ci