### PR TITLE
Revert "Bump `github-comment-ops` helm chart version to 1.4.3"

### DIFF
--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -127,7 +127,7 @@ releases:
   - name: github-comment-ops
     namespace: github-comment-ops
     chart: github-comment-ops/github-comment-ops
-    version: 1.4.3
+    version: 1.4.0
     needs:
       - public-nginx-ingress/public-nginx-ingress # Required to expose the webhooks endpoint
     values:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#4754

because it fails to deploy:

- helmfile reaches a timeout in the build
- Trying to deploy manually shows the following errors:

```
Events:
  Type     Reason     Age               From               Message
  ----     ------     ----              ----               -------
# ...
  Normal   BackOff    16s               kubelet            Back-off pulling image "ghcr.io/timja/github-comment-ops:v1.4.3"
  Warning  Failed     16s               kubelet            Error: ImagePullBackOff
  Normal   Pulling    3s (x2 over 17s)  kubelet            Pulling image "ghcr.io/timja/github-comment-ops:v1.4.3"
  Warning  Failed     3s (x2 over 17s)  kubelet            Failed to pull image "ghcr.io/timja/github-comment-ops:v1.4.3": rpc error: code = NotFound desc = failed to pull and unpack image "ghcr.io/timja/github-comment-ops:v1.4.3": failed to resolve reference "ghcr.io/timja/github-comment-ops:v1.4.3": ghcr.io/timja/github-comment-ops:v1.4.3: not found
  Warning  Failed     3s (x2 over 17s)  kubelet            Error: ErrImagePull
```
