### PR TITLE
feat(infra.ci): add a child to reports

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -219,10 +219,10 @@ jobsDefinition:
             username: "${JIRA_API_INFRA_REPORTS_USERNAME}"
             usernameSecret: true
             password: "${JIRA_API_INFRA_REPORTS_PASSWORD}"
-      mirrorbits-mirrors-list:
-        name: "List of Mirrorbits mirrors"
+      jenkins-infra-data:
+        name: "Jenkins Infrastructure Public Data"
         repository: "infra-reports"
-        jenkinsfilePath: "mirrorbits-mirrors-list/Jenkinsfile"
+        jenkinsfilePath: "jenkins-infra-data/Jenkinsfile"
       permissions-report:
         name: "GitHub Permissions Report"
         repository: "infra-reports"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3832

provide an infra.ci.jenkins.io child to reports for mirrorbits mirror list for downloads.