### PR TITLE
fixup(infra.ci): correct the command for amd/arm agents

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -117,6 +117,8 @@ controller:
                     containers:
                       - name: jnlp
                         image: "jenkins/inbound-agent:latest-jdk17"
+                        command: "/usr/local/bin/jenkins-agent"
+                        args: ""
                         envVars:
                         - envVar:
                             key: "JENKINS_JAVA_BIN"
@@ -145,6 +147,8 @@ controller:
                     containers:
                       - name: jnlp
                         image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.42.0"
+                        command: "/usr/local/bin/jenkins-agent"
+                        args: ""
                         envVars:
                         - envVar:
                             key: "JENKINS_JAVA_BIN"


### PR DESCRIPTION
related to https://github.com/jenkins-infra/helpdesk/issues/3823

as per the error : 
```
Error in provisioning; agent=KubernetesSlave name: jnlp-linux-arm64-5wgv9, template=PodTemplate{id='redacted', name='jnlp-linux-arm64', label='jnlp-linux-arm64', nodeSelector='kubernetes.io/arch=arm64', containers=[ContainerTemplate{name='jnlp', image='jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.42.0', alwaysPullImage=true, workingDir='/home/jenkins/agent', **command='sleep', args='9999999'**, resourceRequestCpu='500m', resourceRequestMemory='512Mi', resourceRequestEphemeralStorage='', resourceLimitCpu='500m', resourceLimitMemory='512Mi', resourceLimitEphemeralStorage='', envVars=[KeyValueEnvVar [getValue()=/opt/java/openjdk/bin/java, getKey()=JENKINS_JAVA_BIN]], livenessProbe=ContainerLivenessProbe{execArgs='', timeoutSeconds=0, initialDelaySeconds=0, failureThreshold=0, periodSeconds=0, successThreshold=0}}]}
```
we need to correct the command to launch the agent jar