### PR TITLE
fix(infra.ci) ensure azure VM init script for Linux set up proper permissions for datadog-agent config dir

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -277,13 +277,13 @@ controller:
                     #!/bin/bash
                     set -eux
                     echo "START CLOUDINIT"
-                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
-                    sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
                     systemctl stop datadog-agent.service
                     mkdir -p /var/log/datadog /etc/datadog-agent
-                    chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+                    chown -R dd-agent:dd-agent /etc/datadog-agent
                     chmod 640 /etc/datadog-agent/datadog.yaml
-                    chown dd-agent:dd-agent /var/log/datadog
+                    chown -R dd-agent:dd-agent /var/log/datadog
                     chmod 770 /var/log/datadog
                     systemctl start datadog-agent.service
                     rm -f /etc/sudoers.d/90-cloud-init-users
@@ -407,13 +407,13 @@ controller:
                     #!/bin/bash
                     set -eux
                     echo "START CLOUDINIT"
-                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
-                    sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
                     systemctl stop datadog-agent.service
                     mkdir -p /var/log/datadog /etc/datadog-agent
-                    chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+                    chown -R dd-agent:dd-agent /etc/datadog-agent
                     chmod 640 /etc/datadog-agent/datadog.yaml
-                    chown dd-agent:dd-agent /var/log/datadog
+                    chown -R dd-agent:dd-agent /var/log/datadog
                     chmod 770 /var/log/datadog
                     systemctl start datadog-agent.service
                     rm -f /etc/sudoers.d/90-cloud-init-users


### PR DESCRIPTION
We had VM initializations failing on infra.ci but randomly.

After torough testing with @smerle33 , we did not find any usable logs about the datadog-agent startup.

However, https://github.com/DataDog/datadog-agent/pull/5064 and https://github.com/DataDog/datadog-agent/issues/16559 are tipping us about the permissions in `/etc/datadog-agent` directory which must stay writeable by the user `dd-agent` to allow creation of configurations such as `auth_token` file during the start and stop phases

This PR updates the init script to ensure these permissions are correct:

- Stopping the datadog-agent service as a first step avoid concurence between the datadog-agent process (`dd-agent`) and the init script (`root`)
- Setting ownership to the 2 datadog dirs (config and logs) with a recursive flag ensures the dirs and their content are owned by `dd-agent`


=> We weren't able to prove this change unblocked the VM allocation but it won't have any negative behavior so let's roll!