### PR TITLE
fixup(infra.ci): update environment variable with correct path for java

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -119,10 +119,6 @@ controller:
                         image: "jenkins/inbound-agent:latest-jdk17"
                         command: "/usr/local/bin/jenkins-agent"
                         args: ""
-                        envVars:
-                        - envVar:
-                            key: "JENKINS_JAVA_BIN"
-                            value: "/opt/java/openjdk/bin/java"
                         resourceLimitCpu: "500m"
                         resourceLimitMemory: "512Mi"
                         resourceRequestCpu: "500m"
@@ -150,10 +146,6 @@ controller:
                         image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.42.0"
                         command: "/usr/local/bin/jenkins-agent"
                         args: ""
-                        envVars:
-                        - envVar:
-                            key: "JENKINS_JAVA_BIN"
-                            value: "/opt/java/openjdk/bin/java"
                         resourceLimitCpu: "500m"
                         resourceLimitMemory: "512Mi"
                         resourceRequestCpu: "500m"


### PR DESCRIPTION
for pod agents amd64 and arm64

the java path is set within the packer-image process : https://github.com/jenkins-infra/packer-images/blob/1b0f119e8458058cf7dc1dde0c2ef667fe892b77/provisioning/ubuntu-provision.sh#L312C27-L312C38