### PR TITLE
feat(infra.ci): persist usage of VM even if init fail to avoid failure on transiant error from datadog

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -262,7 +262,7 @@ controller:
                   agentWorkspace: "/home/jenkins"
                   credentialsId: "azure-login"
                   diskType: "managed"
-                  doNotUseMachineIfInitFails: true
+                  doNotUseMachineIfInitFails: false
                   encryptionAtHost: true
                   ephemeralOSDisk: true
                   executeInitScriptAsRoot: true
@@ -392,7 +392,7 @@ controller:
                   agentWorkspace: "/home/jenkins"
                   credentialsId: "azure-login"
                   diskType: "managed"
-                  doNotUseMachineIfInitFails: true
+                  doNotUseMachineIfInitFails: false
                   encryptionAtHost: true
                   ephemeralOSDisk: true
                   executeInitScriptAsRoot: true


### PR DESCRIPTION
to avoid temporary error on datadog startup that forbid the VM to be used