### PR TITLE
feat(infra.ci) bump packer-image to 1.43.0 in the new subscription

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -154,7 +154,7 @@ jobsDefinition:
             clientId: "${PACKER_AZURE_CLIENT_ID}"
             clientSecret: "${PACKER_AZURE_CLIENT_SECRET_VALUE}"
             description: "Azure Service Principal credential used by updatecli"
-            subscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
+            subscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
             tenant: "${PACKER_AZURE_TENANT_ID}"
       packer-images:
         jenkinsfilePath: Jenkinsfile_updatecli

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -147,7 +147,7 @@ controller:
                     nodeSelector: "kubernetes.io/arch=arm64"
                     containers:
                       - name: jnlp
-                        image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.42.0"
+                        image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.43.0"
                         command: "/usr/local/bin/jenkins-agent"
                         args: ""
                         envVars:
@@ -268,10 +268,10 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-amd64"
-                    galleryImageVersion: "1.42.0"
+                    galleryImageVersion: "1.43.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     #!/bin/bash
@@ -320,10 +320,10 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-windows-2019-amd64"
-                    galleryImageVersion: "1.42.0"
+                    galleryImageVersion: "1.43.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ${JENKINS_CI_DATADOG_API_KEY}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
@@ -359,10 +359,10 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-windows-2022-amd64"
-                    galleryImageVersion: "1.42.0"
+                    galleryImageVersion: "1.43.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ${JENKINS_CI_DATADOG_API_KEY}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
@@ -398,10 +398,10 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
-                    galleryImageVersion: "1.42.0"
+                    galleryImageVersion: "1.43.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     #!/bin/bash


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3818#issuecomment-1868237892

This PR switches to the new azure subscription the following elements:

- The updatecli job configuration (credential value)
- The all in one tempolates for VMs and pod template to 1.43.0