### PR TITLE
feat(publick8s) tune keycloak resources 

### DIFF
--- a/config/keycloak.yaml
+++ b/config/keycloak.yaml
@@ -18,11 +18,11 @@ ingress:
 
 resources:
   limits:
-    cpu: 1500m
+    cpu: 2
     memory: 2048Mi
   requests:
-    cpu: 1500m
-    memory: 2048Mi
+    cpu: 1
+    memory: 1500Mi
 
 replicas: 1
 


### PR DESCRIPTION
The goal is to pack more containers by compressing requests (scheduler) while keeping sustainable limits

Ref. https://github.com/jenkins-infra/helpdesk/issues/3827

Metrics in datadogs:

<img width="1585" alt="Capture d’écran 2024-01-03 à 15 31 37" src="https://github.com/jenkins-infra/kubernetes-management/assets/1522731/faa9ff72-f7a8-471b-91d7-02dec585b22b">

<img width="1700" alt="Capture d’écran 2024-01-03 à 15 34 22" src="https://github.com/jenkins-infra/kubernetes-management/assets/1522731/6e090adf-106b-45ad-8b2e-536c08a47839">
