### PR TITLE
feat(publick8s) tune ldap resources

### DIFF
--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -39,8 +39,8 @@ resources:
     cpu: 500m
     memory: 1536Mi
   requests:
-    cpu: 500m
-    memory: 1536Mi
+    cpu: 200m
+    memory: 1024Mi
 
 nodeSelector:
   kubernetes.io/arch: amd64


### PR DESCRIPTION
The goal is to pack more containers by compressing requests (scheduler) while keeping sustainable limits

Ref. https://github.com/jenkins-infra/helpdesk/issues/3827

Metrics in datadogs:

<img width="1714" alt="Capture d’écran 2024-01-03 à 15 37 33" src="https://github.com/jenkins-infra/kubernetes-management/assets/1522731/101ed17f-44a5-4f66-8a01-befe7b6784e7">

<img width="1704" alt="Capture d’écran 2024-01-03 à 15 39 54" src="https://github.com/jenkins-infra/kubernetes-management/assets/1522731/41d98f41-c3d2-4e81-b2c0-60a2d7bb5600">
