### PR TITLE
feat(publick8s) tune mirrorbits (get.jenkins.io) resources

### DIFF
--- a/config/mirrorbits.yaml
+++ b/config/mirrorbits.yaml
@@ -35,18 +35,18 @@ ingress:
 resources:
   mirrorbits:
     limits:
-      cpu: 500m
-      memory: 1024Mi
+      cpu: 2
+      memory: 2048Mi
     requests:
       cpu: 500m
-      memory: 1024Mi
+      memory: 500Mi
   files:
     limits:
-      cpu: 2000m
+      cpu: 800m
       memory: 2048Mi
     requests:
-      cpu: 2000m
-      memory: 2048Mi
+      cpu: 200m
+      memory: 500Mi
 
 repository:
   name: mirrorbits-binary


### PR DESCRIPTION
The goal is to pack more containers by compressing requests (scheduler) while keeping sustainable limits

Ref. https://github.com/jenkins-infra/helpdesk/issues/3827

Metrics in datadogs:

<img width="1714" alt="Capture d’écran 2024-01-03 à 15 43 34" src="https://github.com/jenkins-infra/kubernetes-management/assets/1522731/60e3659b-512c-439d-b36e-29be1e12e6dd">
<img width="1730" alt="Capture d’écran 2024-01-03 à 15 43 41" src="https://github.com/jenkins-infra/kubernetes-management/assets/1522731/b9fb7b95-12e6-4d02-9491-dbfab78d248e">
<img width="1734" alt="Capture d’écran 2024-01-03 à 15 43 55" src="https://github.com/jenkins-infra/kubernetes-management/assets/1522731/223bfdda-5863-407e-98df-8b82d7dad651">
![Uploading Capture d’écran 2024-01-03 à 15.46.21.png…]()
