### PR TITLE
feat(privatek8s) infra.ci: enable github checks for updatecli and contributor-spotlight jobs

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -143,11 +143,15 @@ jobsDefinition:
       jenkins-infra:
         name: Puppet (jenkins-infra)
         jenkinsfilePath: Jenkinsfile_updatecli
+        enableGitHubChecks: true
+        githubCheckName: "Updatecli (infra.ci.jenkins.io)"
         branchIncludes: "production staging updatecli_* PR-* main"
         disableTagDiscovery: true
       kubernetes-management:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
+        enableGitHubChecks: true
+        githubCheckName: "Updatecli (infra.ci.jenkins.io)"
         credentials:
           updatecli-azure-serviceprincipal:
             azureEnvironmentName: "Azure"
@@ -159,10 +163,14 @@ jobsDefinition:
       packer-images:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
+        enableGitHubChecks: true
+        githubCheckName: "Updatecli (infra.ci.jenkins.io)"
       helm-charts:
         name: Helm Charts
         description: Custom Helm Charts of the Jenkins Infra
         disableTagDiscovery: true
+        enableGitHubChecks: true
+        githubCheckName: "Updatecli (infra.ci.jenkins.io)"
   other-jobs:
     name: Other Jobs
     description: Folder hosting all the jobs not fitting any category
@@ -476,6 +484,8 @@ jobsDefinition:
         description: "Jenkins Contributor Spotlight Website"
         allowUntrustedChanges: true
         jenkinsfilePath: Jenkinsfile
+        enableGitHubChecks: true
+        githubCheckName: "infra.ci.jenkins.io"
         credentials:
           contributors-jenkins-io-fileshare-sas-querystring:
             secret: "${CONTRIBUTORS_JENKINS_IO_FILESHARE_SAS_QUERYSTRING}"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3888

This PR enable (and names) the GH checks for all the updatecli the jenkins-infra/contributor-spotlight jobs