### PR TITLE
feat(weekly.ci.jenkins.io): use specific Docker image variant

### DIFF
--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -23,7 +23,7 @@ networkPolicy:
       name: "jenkins-weekly"
 controller:
   image: jenkinsciinfra/jenkins-weekly
-  tag: 1.23.1-2.439
+  tag: 1.23.2-2.439-weeklyci
   imagePullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/arch: arm64

--- a/updatecli/updatecli.d/docker-images/jenkins-weekly.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-weekly.yaml
@@ -46,6 +46,8 @@ targets:
       file: "config/jenkins_weekly.ci.jenkins.io.yaml"
       key: "controller.tag"
     scmid: default
+    transformers:
+      - addsuffix: "-weeklyci"
 
 actions:
   default:


### PR DESCRIPTION
This PR adds `-weeklyci` as suffix to the Docker image tag used by weekly.ci.jenkins.io in order to retrieve its specific variant containing less plugins than the base Jenkins weekly Docker image used for infra.ci.jenkins.io.

Follow-up of:
- https://github.com/jenkins-infra/docker-jenkins-weekly/pull/1462

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3887