### PR TITLE
Remove remoting from release.ci

### DIFF
--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -270,43 +270,6 @@ controller:
       jobs-settings: |
         jobs:
           - script: >
-              folder('components') {
-                displayName('Components')
-                description('Folder containing Jenkins components release job')
-              }
-
-          - script: >
-              multibranchPipelineJob('components/remoting') {
-                displayName "Remoting"
-                description "Jenkins Remoting"
-                branchSources {
-                  github {
-                    id('2020052601')
-                    scanCredentialsId('github-access-token')
-                    repoOwner('jenkins-infra')
-                    repository('release')
-                    includes('master')
-                  }
-                }
-                factory {
-                  workflowBranchProjectFactory {
-                    scriptPath('Jenkinsfile.d/components/remoting')
-                  }
-                }
-                configure {
-                  it / sources / 'data' / 'jenkins.branch.BranchSource' << {
-                      strategy(class: 'jenkins.branch.DefaultBranchPropertyStrategy') {
-                          properties(class: 'java.util.Arrays$ArrayList') {
-                              a(class: 'jenkins.branch.BranchProperty-array') {
-                                  'jenkins.branch.NoTriggerBranchProperty'()
-                              }
-                          }
-                      }
-                  }
-                }
-              }
-
-          - script: >
               folder('core') {
                 displayName('Core')
                 description('Folder containing Jenkins core release job')


### PR DESCRIPTION
With the removal of remoting from the release infrastructure in https://github.com/jenkins-infra/release/pull/491, I propose to remove remoting from the preconfigured folder and job setup too.