### PR TITLE
chore(updatecli/docker-jenkins-weekly): adapt manifests to individually update instances

### DIFF
--- a/updatecli/updatecli.d/docker-images/jenkins-weekly_infra.ci.jenkins.io.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-weekly_infra.ci.jenkins.io.yaml
@@ -1,0 +1,53 @@
+name: "Bump Jenkins Weekly docker image version on infra.ci.jenkins.io"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestRelease:
+    name: "Get latest jenkins-weekly version"
+    kind: githubrelease
+    spec:
+      owner: "jenkins-infra"
+      repository: "docker-jenkins-weekly"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+
+conditions:
+  checkDockerImagePublished:
+    name: "Test jenkinsciinfra/jenkins-weekly:<latest_version> docker image tag"
+    kind: dockerimage
+    spec:
+      image: "jenkinsciinfra/jenkins-weekly"
+      ## Tag from source
+      architecture: amd64
+
+targets:
+  updateReleaseInConfig:
+    sourceid: latestRelease
+    name: "Update jenkinsciinfra/jenkins-weekly docker image tag on infra.ci.jenkins.io"
+    kind: yaml
+    spec:
+      file: "config/jenkins_infra.ci.jenkins.io.yaml"
+      key: "controller.tag"
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump Jenkins Weekly docker image version on infra.ci.jenkins.io to {{ source "latestRelease" }}
+    spec:
+      labels:
+        - dependencies
+        - docker-jenkins-weekly
+        - infra.ci.jenkins.io

--- a/updatecli/updatecli.d/docker-images/jenkins-weekly_weekly.ci.jenkins.io.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-weekly_weekly.ci.jenkins.io.yaml
@@ -1,4 +1,4 @@
-name: "Bump Jenkins Weekly docker image version"
+name: "Bump Jenkins Weekly docker image version on weekly.ci.jenkins.io"
 
 scms:
   default:
@@ -21,10 +21,12 @@ sources:
       repository: "docker-jenkins-weekly"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
+    transformers:
+      - addsuffix: "-weeklyci"
 
 conditions:
   checkDockerImagePublished:
-    name: "Test jenkinsciinfra/jenkins-weekly:<latest_version> docker image tag"
+    name: "Test jenkinsciinfra/jenkins-weekly:<latest_version> docker image tag with '-weeklyci' suffix"
     kind: dockerimage
     spec:
       image: "jenkinsciinfra/jenkins-weekly"
@@ -33,28 +35,21 @@ conditions:
 
 targets:
   updateReleaseInConfig:
-    name: "Update jenkinsciinfra/jenkins-weekly docker image tag"
-    kind: yaml
-    spec:
-      file: "config/jenkins_infra.ci.jenkins.io.yaml"
-      key: "controller.tag"
-    scmid: default
-  updateReleaseInWeeklyConfig:
-    name: "Update jenkinsciinfra/jenkins-weekly docker image tag"
+    sourceid: latestRelease
+    name: "Update jenkinsciinfra/jenkins-weekly docker image tag on weekly.ci.jenkins.io"
     kind: yaml
     spec:
       file: "config/jenkins_weekly.ci.jenkins.io.yaml"
       key: "controller.tag"
     scmid: default
-    transformers:
-      - addsuffix: "-weeklyci"
 
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump Jenkins Weekly docker image version to {{ source "latestRelease" }}
+    title: Bump Jenkins Weekly docker image version on weekly.ci.jenkins.io to {{ source "latestRelease" }}
     spec:
       labels:
         - dependencies
         - docker-jenkins-weekly
+        - weekly.ci.jenkins.io


### PR DESCRIPTION
This PR allows to update only infra.ci.jenkins.io or weekly.ci.jenkins.io if only one of them has a new version.

Tested with https://github.com/jenkins-infra/docker-jenkins-weekly/releases/tag/1.26.2-2.441 containing only the weekly.ci.jenkins.io image variant, validating no update for infra.ci.jenkins.io:

<details>

```
$ updatecli diff --config updatecli/updatecli.d/docker-images/jenkins-weekly_weekly.ci.jenkins.io.yaml --values updatecli/values.yaml


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/docker-images/jenkins-weekly_weekly.ci.jenkins.io.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



####################################################################
# BUMP JENKINS WEEKLY DOCKER IMAGE VERSION ON WEEKLY.CI.JENKINS.IO #
####################################################################


SOURCES
=======

latestRelease
-------------
Searching for version matching pattern "latest"
✔ GitHub release version "1.26.2-2.441" found matching pattern "latest" of kind "latest"


CHANGELOG:
----------

Release published on the 2024-01-23 11:19:42 +0000 UTC at the url https://github.com/jenkins-infra/docker-jenkins-weekly/releases/tag/1.26.2-2.441

<!-- Optional: add a release summary here -->
## ✍ Other changes

* test: update only pipeline-graph-view in weekly.ci plugins to get a single image variant (#1490) @lemeurherve



CONDITIONS:
===========

checkDockerImagePublished
-------------------------
✔ docker image jenkinsciinfra/jenkins-weekly:1.26.2-2.441-weeklyci found


TARGETS
========

updateReleaseInConfig
---------------------

**Dry Run enabled**

WARNING: current yaml key is "controller.tag" and should be updated to "$.controller.tag"
⚠ - change detected:
        * key "$.controller.tag" should be updated from "1.26.1-2.441-weeklyci" to "1.26.2-2.441-weeklyci", in file "config/jenkins_weekly.ci.jenkins.io.yaml"


ACTIONS
========

[Dry Run] An action of kind "github/pullrequest" is expected.

=============================

REPORTS:



⚠ Bump Jenkins Weekly docker image version on weekly.ci.jenkins.io:
        Source:
                ✔ [latestRelease] Get latest jenkins-weekly version
        Condition:
                ✔ [checkDockerImagePublished] Test jenkinsciinfra/jenkins-weekly:<latest_version> docker image tag with '-weeklyci' suffix
        Target:
                ⚠ [updateReleaseInConfig] Update jenkinsciinfra/jenkins-weekly docker image tag on weekly.ci.jenkins.io


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1







$ updatecli diff --config updatecli/updatecli.d/docker-images/jenkins-weekly_infra.ci.jenkins.io.yaml --values updatecli/values.yaml 


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/docker-images/jenkins-weekly_infra.ci.jenkins.io.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



###################################################################
# BUMP JENKINS WEEKLY DOCKER IMAGE VERSION ON INFRA.CI.JENKINS.IO #
###################################################################


SOURCES
=======

latestRelease
-------------
Searching for version matching pattern "latest"
✔ GitHub release version "1.26.2-2.441" found matching pattern "latest" of kind "latest"


CHANGELOG:
----------

Release published on the 2024-01-23 11:19:42 +0000 UTC at the url https://github.com/jenkins-infra/docker-jenkins-weekly/releases/tag/1.26.2-2.441

<!-- Optional: add a release summary here -->
## ✍ Other changes

* test: update only pipeline-graph-view in weekly.ci plugins to get a single image variant (#1490) @lemeurherve



CONDITIONS:
===========

checkDockerImagePublished
-------------------------
ERROR: GET https://index.docker.io/v2/jenkinsciinfra/jenkins-weekly/manifests/1.26.2-2.441: MANIFEST_UNKNOWN: manifest unknown; unknown tag=1.26.2-2.441

✗ condition not met, skipping pipeline

=============================

REPORTS:



- Bump Jenkins Weekly docker image version on infra.ci.jenkins.io:
        Source:
                ✔ [latestRelease] Get latest jenkins-weekly version
        Condition:
                ✗ [checkDockerImagePublished] Test jenkinsciinfra/jenkins-weekly:<latest_version> docker image tag
        Target:
                - [updateReleaseInConfig] 


Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    1
  * Succeeded:  0
  * Total:      1

```

</details>

Follow-up of:
- https://github.com/jenkins-infra/docker-jenkins-weekly/pull/1471

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3887#issuecomment-1894297763