### PR TITLE
feat(publick8s) allow ci.jenkins.io's secondary NAT gateway to LDAP

### DIFF
--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -13,7 +13,8 @@ service:
     - '104.209.128.236/32'  # accept inbound LDAPS from trusted.ci.jenkins.io vnet (public IP for the outbound NAT gateway)
     - '172.176.126.194/32'  # accept inbound LDAPS from private.vpn.jenkins.io
     - '104.209.153.13/32'  # accept inbound LDAPS from cert.ci.jenkins.io vnet (public IP for the outbound NAT gateway)
-    - '20.230.90.10/32'  # Accept inbound LDAPS from ci.jenkins.io
+    - '20.230.90.10/32'  # Accept inbound LDAPS from NAT gateway for ci.jenkins.io - https://github.com/jenkins-infra/azure-net/blob/88464e36e7e07eccd2ede427ee670638a8458db1/gateways.tf#L62-L72
+    - '172.177.87.156/32'  # Accept inbound LDAPS from NAT gateway for ci.jenkins.io "sponsorship" secondary network - https://github.com/jenkins-infra/azure-net/blob/88464e36e7e07eccd2ede427ee670638a8458db1/gateways.tf#L73-L86
     - '34.211.101.61/32'  # Accept inbound connections from Linux Foundation test machine
     - '44.240.22.235/32'  # Accept inbound connections from Linux Foundation prod machine
     - '20.22.6.81/32'  # Accept inbound connections from privatek8s # TODO: find out how to retrieve this IP from terraform


### PR DESCRIPTION
This PR is related to https://github.com/jenkins-infra/helpdesk/issues/3908#issuecomment-1892555342

It will allow ci.jenkins.io secondary (new) controller to reach LDAP