### PR TITLE
feat(privatek8s) add docker-ldap job to infra.ci.jenkins.io

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -38,6 +38,7 @@ jobsDefinition:
       docker-inbound-agents:
       docker-jenkins-lts:
       docker-jenkins-weekly:
+      docker-ldap:
       docker-mirrorbits:
       docker-openvpn:
       docker-packaging:


### PR DESCRIPTION
ref. https://github.com/jenkins-infra/helpdesk/issues/3837#issuecomment-1898378430

This PRs adds the `ldap` jobs in infra.ci (in Docker jobs folder)