### PR TITLE
Add a pipeline overview to the build page

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -678,6 +678,10 @@ controller:
           quietPeriod: 0 # No need to wait between build scheduling
           disabledAdministrativeMonitors:
             - "jenkins.security.QueueItemAuthenticatorMonitor"
+        appearance:
+          pipelineGraphView:
+            showGraphOnBuildPage: true
+            showGraphOnJobPage: false # change to true if pipeline-stage-view is removed
       datadog: |
         unclassified:
           datadogGlobalConfiguration:

--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -512,6 +512,10 @@ controller:
           timestamper:
             allPipelines: true
       system-settings: |
+        appearance:
+          pipelineGraphView:
+            showGraphOnBuildPage: true
+            showGraphOnJobPage: false # change to true if pipeline-stage-view is removed
         unclassified:
           defaultFolderConfiguration:
             # Keep healthMetrics an empty list to ensure weather is disabled

--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -145,6 +145,9 @@ controller:
             # Keep healthMetrics an empty list to ensure weather is disabled
             healthMetrics: []
         appearance:
+          pipelineGraphView:
+            showGraphOnBuildPage: true
+            showGraphOnJobPage: false # change to true if pipeline-stage-view is removed
           themeManager:
             disableUserThemes: false
             theme: "darkSystem"


### PR DESCRIPTION
The change proposed adds a pipeline overview to the build page:

![Screenshot 2024-01-21 at 13 46 36](https://github.com/jenkins-infra/kubernetes-management/assets/13383509/9553e5f8-dbc9-4ee6-933b-a819f97d54c0)

I have disabled adding the overview to the job page because the pipeline-stage-view plugin clogs up the page with its overview, unfortunately:
![Screenshot 2024-01-21 at 16 07 20](https://github.com/jenkins-infra/kubernetes-management/assets/13383509/315fb39a-a700-498b-a691-47b161730275)