### PR TITLE
(un)feat(infra.ci): remove docker-hashicorp-tools  from docker-jobs

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -34,7 +34,6 @@ jobsDefinition:
       docker-builder:
       docker-confluence-data:
       docker-crond:
-      docker-hashicorp-tools:
       docker-inbound-agents:
       docker-jenkins-lts:
       docker-jenkins-weekly:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3823