### PR TITLE
Revert "Add a pipeline overview to the build page"

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -678,10 +678,6 @@ controller:
           quietPeriod: 0 # No need to wait between build scheduling
           disabledAdministrativeMonitors:
             - "jenkins.security.QueueItemAuthenticatorMonitor"
-        appearance:
-          pipelineGraphView:
-            showGraphOnBuildPage: true
-            showGraphOnJobPage: false # change to true if pipeline-stage-view is removed
       datadog: |
         unclassified:
           datadogGlobalConfiguration:

--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -512,10 +512,6 @@ controller:
           timestamper:
             allPipelines: true
       system-settings: |
-        appearance:
-          pipelineGraphView:
-            showGraphOnBuildPage: true
-            showGraphOnJobPage: false # change to true if pipeline-stage-view is removed
         unclassified:
           defaultFolderConfiguration:
             # Keep healthMetrics an empty list to ensure weather is disabled

--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -145,9 +145,6 @@ controller:
             # Keep healthMetrics an empty list to ensure weather is disabled
             healthMetrics: []
         appearance:
-          pipelineGraphView:
-            showGraphOnBuildPage: true
-            showGraphOnJobPage: false # change to true if pipeline-stage-view is removed
           themeManager:
             disableUserThemes: false
             theme: "darkSystem"


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#4886 as it causes the following error:

<img width="1664" alt="Capture d’écran 2024-01-22 à 16 11 55" src="https://github.com/jenkins-infra/kubernetes-management/assets/1522731/47dc88b4-0e73-4ed7-8599-2d7bb2ae600d">

cc @NotMyFault 