### PR TITLE
chore(infra.ci.jenkins.io): create azure service principal credentials for contributors.jenkins.io

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -489,3 +489,11 @@ jobsDefinition:
           contributors-jenkins-io-fileshare-sas-querystring:
             secret: "${CONTRIBUTORS_JENKINS_IO_FILESHARE_SAS_QUERYSTRING}"
             description: "File Share SAS query string to update contributors.jenkins.io content"
+          contributors-jenkins-io-fileshare-service-principal-writer:
+            kind: azure-serviceprincipal
+            azureEnvironmentName: "Azure"
+            clientId: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
+            clientSecret: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET}"
+            description: "Contributors.jenkins.io File Share Service Principal Writer"
+            subscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
+            tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"


### PR DESCRIPTION
This PR creates an Azure Service Principal credentials in contributors.jenkins.io job on infra.ci.jenkins.io so it can be used in pipeline to log in with `az`.

Note: using Service Principal Application as source.

Follow-up of:
- https://github.com/jenkins-infra/azure/pull/599
- https://github.com/jenkins-infra/charts-secrets/commit/972d04793108f2232c3adc720881a26bbba79d34 (private repo)

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414