### PR TITLE
Bump Jenkins Weekly docker image version on infra.ci.jenkins.io to 1.27.5-2.442

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -20,7 +20,7 @@ networkPolicy:
       name: "jenkins-infra"
 controller:
   image: jenkinsciinfra/jenkins-weekly
-  tag: 1.27.4-2.442
+  tag: 1.27.5-2.442
   imagePullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux


### PR DESCRIPTION
manual upgrade as updatecli doesn't catch the update anymore