### PR TITLE
chore(updatecli) fix all jenkins manifests related to 5.x chart's image specification

### DIFF
--- a/updatecli/updatecli.d/docker-images/jenkins-lts.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-lts.yaml
@@ -37,7 +37,7 @@ targets:
     kind: yaml
     spec:
       file: "config/jenkins_release.ci.jenkins.io.yaml"
-      key: "controller.tag"
+      key: "$.controller.image.tag"
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/docker-images/jenkins-weekly_infra.ci.jenkins.io.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-weekly_infra.ci.jenkins.io.yaml
@@ -38,7 +38,7 @@ targets:
     kind: yaml
     spec:
       file: "config/jenkins_infra.ci.jenkins.io.yaml"
-      key: "controller.tag"
+      key: "$.controller.image.tag"
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/docker-images/jenkins-weekly_weekly.ci.jenkins.io.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-weekly_weekly.ci.jenkins.io.yaml
@@ -31,7 +31,8 @@ conditions:
     spec:
       image: "jenkinsciinfra/jenkins-weekly"
       ## Tag from source
-      architecture: amd64
+      architectures:
+      - arm64
 
 targets:
   updateReleaseInConfig:
@@ -40,7 +41,7 @@ targets:
     kind: yaml
     spec:
       file: "config/jenkins_weekly.ci.jenkins.io.yaml"
-      key: "controller.tag"
+      key: "$.controller.image.tag"
     scmid: default
 
 actions:


### PR DESCRIPTION
Fixup of #4925 

Closes #4934 closes #4933 
(new PRs will be opened)