### PR TITLE
Revert "Bump agent templates for infra.ci.jenkins.io (packer-image 1.51.0)"

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -148,7 +148,7 @@ controller:
                     nodeSelector: "kubernetes.io/arch=arm64"
                     containers:
                       - name: jnlp
-                        image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.51.0"
+                        image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.50.0"
                         command: "/usr/local/bin/jenkins-agent"
                         args: ""
                         envVars:
@@ -269,7 +269,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-amd64"
-                    galleryImageVersion: "1.51.0"
+                    galleryImageVersion: "1.50.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
@@ -321,7 +321,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-windows-2019-amd64"
-                    galleryImageVersion: "1.51.0"
+                    galleryImageVersion: "1.50.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
@@ -360,7 +360,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-windows-2022-amd64"
-                    galleryImageVersion: "1.51.0"
+                    galleryImageVersion: "1.50.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
@@ -399,7 +399,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
-                    galleryImageVersion: "1.51.0"
+                    galleryImageVersion: "1.50.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#4946

infra.ci can't spawn agent pods, failing with:

> stream logs failed container "jnlp" in pod "jnlp-linux-arm64-b9rj5" is waiting to start: ContainerCreating for jenkins-infra-agents/jnlp-linux-arm64-b9rj5 (jnlp)
> exec /usr/local/bin/jenkins-agent: exec format error
> Stream closed EOF for jenkins-infra-agents/jnlp-linux-arm64-b9rj5 (jnlp)
