### PR TITLE
chore: add `azure` as updatecli job children

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -170,6 +170,11 @@ jobsDefinition:
         disableTagDiscovery: true
         enableGitHubChecks: true
         githubCheckName: "Updatecli (infra.ci.jenkins.io)"
+      azure:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+        enableGitHubChecks: true
+        githubCheckName: "Updatecli (infra.ci.jenkins.io)"
   other-jobs:
     name: Other Jobs
     description: Folder hosting all the jobs not fitting any category


### PR DESCRIPTION
This PR complements (and needs) https://github.com/jenkins-infra/azure/pull/617

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2778