### PR TITLE
fix(updatecli/pod-quotas): new hieradata location

### DIFF
--- a/updatecli/updatecli.d/charts/kubernetes-pods-quotas.yaml
+++ b/updatecli/updatecli.d/charts/kubernetes-pods-quotas.yaml
@@ -17,19 +17,19 @@ sources:
     kind: yaml
     name: get pods number for cik8s in ci.jenkins.io, namespace 'jenkins-agents'
     spec:
-      file: "https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/production/hieradata/clients/controller.ci.jenkins.io.yaml"
+      file: "https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/production/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml"
       key: "profile::jenkinscontroller::jcasc.cloud_agents.kubernetes.cik8s.max_capacity"
   cik8s_bom_maxcapacity:
     kind: yaml
     name: get pods number for cik8s in ci.jenkins.io, namespace 'jenkins-agents-bom'
     spec:
-      file: "https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/production/hieradata/clients/controller.ci.jenkins.io.yaml"
+      file: "https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/production/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml"
       key: "profile::jenkinscontroller::jcasc.cloud_agents.kubernetes.cik8s-bom.max_capacity"
   doks_maxcapacity:
     kind: yaml
     name: get pods number for doks in ci.jenkins.io
     spec:
-      file: "https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/production/hieradata/clients/controller.ci.jenkins.io.yaml"
+      file: "https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/production/hieradata/clients/controller.sponsorship.ci.jenkins.io.yaml"
       key: "profile::jenkinscontroller::jcasc.cloud_agents.kubernetes.doks.max_capacity"
 
 targets:


### PR DESCRIPTION
This PR fixes the kubernetes-pods-quotas updatecli manifest, broken since https://github.com/jenkins-infra/jenkins-infra/pull/3272

Ref:
- https://github.com/jenkins-infra/jenkins-infra/pull/3272
- https://github.com/jenkins-infra/helpdesk/issues/3913