### PR TITLE
chore(infra-jobs/account-app): use one Jenkinsfile for both ci.jenkins.io and infra.ci.jenkins.io

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -30,6 +30,7 @@ jobsDefinition:
             owner: "jenkinsci"
             privateKey: "${GITHUB_APP_JENKINSCI_PRIVATE_KEY}"
       account-app:
+        jenkinsfilePath: Jenkinsfile
       docker-404:
       docker-builder:
       docker-confluence-data:


### PR DESCRIPTION
This PR sets the infra.ci.jenkins.io account app job to use the same Jenkinsfile as ci.jenkins.io.

Related:
- https://github.com/jenkins-infra/account-app/pull/354

Ref:
- https://github.com/jenkins-infra/account-app/pull/351#discussion_r1485875113