### PR TITLE
chore(infra.ci): set `JAVA_HOME` by default to `/opt/jdk17` on agents

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -124,6 +124,9 @@ controller:
                         - envVar:
                             key: "JENKINS_JAVA_BIN"
                             value: "/opt/jdk-17/bin/java"
+                        - envVar:
+                            key: "JAVA_HOME"
+                            value: "/opt/jdk-17"
                         resourceLimitCpu: "500m"
                         resourceLimitMemory: "512Mi"
                         resourceRequestCpu: "500m"
@@ -155,6 +158,9 @@ controller:
                         - envVar:
                             key: "JENKINS_JAVA_BIN"
                             value: "/opt/jdk-17/bin/java"
+                        - envVar:
+                            key: "JAVA_HOME"
+                            value: "/opt/jdk-17"
                         resourceLimitCpu: "500m"
                         resourceLimitMemory: "1024Mi"
                         resourceRequestCpu: "500m"
@@ -239,6 +245,9 @@ controller:
                         - envVar:
                             key: "JENKINS_JAVA_BIN"
                             value: "/opt/java/openjdk/bin/java"
+                        - envVar:
+                            key: "JAVA_HOME"
+                            value: "/opt/jdk-17"
                         - envVar:
                             key: "PATH"
                             value: "~/.asdf/shims:~/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"


### PR DESCRIPTION
This PR sets `JAVA_HOME` by default to `/opt/jdk17` in infra.ci.jenkins.io kubernetes agents pod templates.

Ref:
- https://github.com/jenkins-infra/account-app/pull/354#discussion_r1490539848