### PR TITLE
feat(all): config cert-manager webhooks timout for validating and mutating

### DIFF
--- a/clusters/doks-public.yaml
+++ b/clusters/doks-public.yaml
@@ -31,9 +31,8 @@ releases:
     namespace: cert-manager
     chart: jetstack/cert-manager
     version: v1.14.2
-    set:
-      - name: installCRDs
-        value: true
+    values:
+      - "../config/cert-manager.yaml"
   - name: acme
     namespace: cert-manager
     chart: jenkins-infra/acme

--- a/clusters/eks-public.yaml
+++ b/clusters/eks-public.yaml
@@ -67,9 +67,8 @@ releases:
     namespace: cert-manager
     chart: jetstack/cert-manager
     version: v1.14.2
-    set:
-      - name: installCRDs
-        value: true
+    values:
+      - "../config/cert-manager.yaml"
   - name: acme
     namespace: cert-manager
     chart: jenkins-infra/acme

--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -37,9 +37,8 @@ releases:
     namespace: cert-manager
     chart: jetstack/cert-manager
     version: v1.14.2
-    set:
-      - name: installCRDs
-        value: true
+    values:
+      - "../config/cert-manager.yaml"
   - name: datadog
     namespace: datadog
     chart: datadog/datadog

--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -40,10 +40,8 @@ releases:
     namespace: cert-manager
     chart: jetstack/cert-manager
     version: v1.14.2
-    set:
-      - name: installCRDs
-        value: true
     values:
+      - "../config/cert-manager.yaml"
       - "../config/cert-manager_publick8s.yaml"
   - name: acme
     namespace: cert-manager

--- a/config/cert-manager.yaml
+++ b/config/cert-manager.yaml
@@ -1,0 +1,4 @@
+installCRDs: true
+webhook:
+  # need to be between 1 and 30 for Digital Ocean see https://github.com/jenkins-infra/helpdesk/issues/3948#issuecomment-1948206377
+  timeoutSeconds: 25


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3948#issuecomment-1948206377

need to change the timeout to a value between 1 and 29 for kubernetes upgrade.

```
cert-manager, cert-manager-webhook, MutatingWebhookConfiguration (admissionregistration.k8s.io) has changed:
...
      # this webhook (after the resources have been converted to v1).
      matchPolicy: Equivalent
-     timeoutSeconds: 30
+     timeoutSeconds: 25
      failurePolicy: Fail
      # Only include 'sideEffects' field in Kubernetes 1.12+
...
cert-manager, cert-manager-webhook, ValidatingWebhookConfiguration (admissionregistration.k8s.io) has changed:
...
      # this webhook (after the resources have been converted to v1).
      matchPolicy: Equivalent
-     timeoutSeconds: 30
+     timeoutSeconds: 25
      failurePolicy: Fail
      sideEffects: None
...
```