### PR TITLE
updatecli jdk tools

### DIFF
--- a/updatecli/updatecli.d/jenkins-controllers/tools-jdk11.yaml
+++ b/updatecli/updatecli.d/jenkins-controllers/tools-jdk11.yaml
@@ -24,7 +24,8 @@ sources:
       versionfilter:
         kind: regex
         # jdk-11.0.12+7(https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.12%2B7) is OK
-        pattern: "^jdk-11.(\\d*).(\\d*).(\\d*)+(\\d*)$"
+        # jdk-11.0.22+7.1 (https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.22%2B7.1) is Ok
+        pattern: ^jdk-11.*.(\d*)+(\d*)$
   escapedVersion:
     kind: shell
     dependson:

--- a/updatecli/updatecli.d/jenkins-controllers/tools-jdk17.yaml
+++ b/updatecli/updatecli.d/jenkins-controllers/tools-jdk17.yaml
@@ -24,7 +24,7 @@ sources:
       versionfilter:
         kind: regex
         # jdk-17.0.12+7(https://github.com/adoptium/temurin17-binaries/releases/tag/jdk-17.0.12%2B7) is OK
-        pattern: "^jdk-17.(\\d*).(\\d*).(\\d*)+(\\d*)$"
+        pattern: ^jdk-17.*.(\d*)+(\d*)$
   escapedVersion:
     kind: shell
     dependson:
@@ -75,14 +75,14 @@ targets:
       file: config/jenkins_infra.ci.jenkins.io.yaml
       matchpattern: '_17(.*)\.(tar.gz|zip)"'
       replacepattern: '_{{ source `escapedVersion` }}.$2"'
-#     scmid: default
+    scmid: default
 
-# actions:
-#   default:
-#     kind: github/pullrequest
-#     scmid: default
-#     title: Bump JDK17 version (Jenkins tools) on all controllers to {{ source "lastVersion" }}
-#     spec:
-#       labels:
-#         - dependencies
-#         - jdk17
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump JDK17 version (Jenkins tools) on all controllers to {{ source "lastVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - jdk17

--- a/updatecli/updatecli.d/jenkins-controllers/tools-jdk21.yaml
+++ b/updatecli/updatecli.d/jenkins-controllers/tools-jdk21.yaml
@@ -24,7 +24,7 @@ sources:
       versionfilter:
         kind: regex
         # jdk-21.0.12+7(https://github.com/adoptium/temurin21-binaries/releases/tag/jdk-21.0.12%2B7) is OK
-        pattern: "^jdk-21.(\\d*).(\\d*).(\\d*)+(\\d*)$"
+        pattern: ^jdk-21.*.(\d*)+(\d*)$
   escapedVersion:
     kind: shell
     dependson:
@@ -75,14 +75,14 @@ targets:
       file: config/jenkins_infra.ci.jenkins.io.yaml
       matchpattern: '_21(.*)\.(tar.gz|zip)"'
       replacepattern: '_{{ source `escapedVersion` }}.$2"'
-#     scmid: default
+    scmid: default
 
-# actions:
-#   default:
-#     kind: github/pullrequest
-#     scmid: default
-#     title: Bump JDK21 version (Jenkins tools) on all controllers to {{ source "lastVersion" }}
-#     spec:
-#       labels:
-#         - dependencies
-#         - jdk21
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump JDK21 version (Jenkins tools) on all controllers to {{ source "lastVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - jdk21


### PR DESCRIPTION
https://github.com/jenkins-infra/kubernetes-management/issues/4630

updatecli track JDK tools installation
Updated the regex to include the release of the following:
[jdk-21.0.2+13](https://github.com/adoptium/temurin21-binaries/releases/tag/jdk-21.0.2%2B13)
[jdk-21+35](https://github.com/adoptium/temurin21-binaries/releases/tag/jdk-21%2B35)
[jdk-21.0.1+12](https://github.com/adoptium/temurin21-binaries/releases/tag/jdk-21.0.1%2B12)
or something similar in java 11 and java 17.

Will ignore the rest: eg: [jdk21u-2024-02-07-08-08-beta](https://github.com/adoptium/temurin21-binaries/releases/tag/jdk21u-2024-02-07-08-08-beta)
