### PR TITLE
chore(jenkins.io): migrate to its new `jenkinsio` storage account

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -219,11 +219,11 @@ releases:
   - name: jenkinsio
     namespace: jenkinsio
     chart: jenkins-infra/jenkinsio
-    version: 1.1.2
+    version: 1.2.0
     values:
       - "../config/jenkinsio.yaml"
     secrets:
-      - "../secrets/config/jenkinsio/secrets.yaml"
+      - "../secrets/config/jenkinsio/secrets2.yaml"
   - name: ipv6-lb-service
     namespace: public-nginx-ingress
     chart: jenkins-infra/ipv6-lb-service

--- a/config/jenkinsio.yaml
+++ b/config/jenkinsio.yaml
@@ -59,12 +59,12 @@ resources:
 htmlVolume:
   azureFile:
     secretName: jenkinsio
-    shareName: jenkinsio
+    shareName: jenkins-io
     readOnly: true
 
 zhHtmlVolume:
   azureFile:
-    secretName: jenkinsio
+    secretName: jenkinsio-zh
     shareName: zhjenkinsio
     readOnly: true
 


### PR DESCRIPTION
This PR uses the last version 1.2.0 of jenkinsio chart to allow specifying a different storage account for jenkinsio & jenkinsio-zh so we can migrate jenkins.io to its new `jenkinsio` storage account.

I've put the original `prodjenkinsio` storage account credentials as a `zh` one in https://github.com/jenkins-infra/charts-secrets/blob/main/config/jenkinsio/secrets2.yaml (private repo) alongside the new `jenkinsio` storage account (which does not contain the `zhjenkinsio` File Share, only the new `jenkins-io` one) to avoid service disruption.
I'll update https://github.com/jenkins-infra/charts-secrets/blob/main/config/jenkinsio/secrets.yaml to contain both storage account credentials and change the release config in a follow-up pull request.

Tested on another release locally with success.

Supersedes and closes #5022

Follow-up of:
- https://github.com/jenkins-infra/jenkins.io/pull/7123

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414