### PR TITLE
chore(jenkins.io): use secrets.yaml instead of secrets2.yaml

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -223,7 +223,7 @@ releases:
     values:
       - "../config/jenkinsio.yaml"
     secrets:
-      - "../secrets/config/jenkinsio/secrets2.yaml"
+      - "../secrets/config/jenkinsio/secrets.yaml"
   - name: ipv6-lb-service
     namespace: public-nginx-ingress
     chart: jenkins-infra/ipv6-lb-service


### PR DESCRIPTION
This PR is the follow-up to reuse secrets.yaml now updated with the content of secrets2.yaml. (Two steps migration to avoid service disruption)

Follow-up of:
- #5023 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414