### PR TITLE
chore(infra-jobs): remove `githubCheckName`s

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -145,14 +145,12 @@ jobsDefinition:
         name: Puppet (jenkins-infra)
         jenkinsfilePath: Jenkinsfile_updatecli
         enableGitHubChecks: true
-        githubCheckName: "Updatecli (infra.ci.jenkins.io)"
         branchIncludes: "production staging updatecli_* PR-* main"
         disableTagDiscovery: true
       kubernetes-management:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
         enableGitHubChecks: true
-        githubCheckName: "Updatecli (infra.ci.jenkins.io)"
         credentials:
           updatecli-azure-serviceprincipal:
             azureEnvironmentName: "Azure"
@@ -165,18 +163,15 @@ jobsDefinition:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
         enableGitHubChecks: true
-        githubCheckName: "Updatecli (infra.ci.jenkins.io)"
       helm-charts:
         name: Helm Charts
         description: Custom Helm Charts of the Jenkins Infra
         disableTagDiscovery: true
         enableGitHubChecks: true
-        githubCheckName: "Updatecli (infra.ci.jenkins.io)"
       azure:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
         enableGitHubChecks: true
-        githubCheckName: "Updatecli (infra.ci.jenkins.io)"
   other-jobs:
     name: Other Jobs
     description: Folder hosting all the jobs not fitting any category
@@ -491,7 +486,6 @@ jobsDefinition:
         allowUntrustedChanges: true
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: true
-        githubCheckName: "infra.ci.jenkins.io"
         credentials:
           contributors-jenkins-io-fileshare-sas-querystring:
             secret: "${CONTRIBUTORS_JENKINS_IO_FILESHARE_SAS_QUERYSTRING}"


### PR DESCRIPTION
This PR removes the GitHub check names, now useless since the use of https://github.com/jenkinsci/github-scm-trait-notification-context-plugin:

<img width="793" alt="image" src="https://github.com/jenkins-infra/kubernetes-management/assets/91831478/97f40eec-0996-42c9-996f-07e8ff746c7c">


Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2778#issuecomment-1959565465