### PR TITLE
chore(plugins.jenkins.io): add AzureServiceprincipal credential for `plugins-jenkins-io` File Share

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -457,6 +457,14 @@ jobsDefinition:
           algolia-plugins-write-key:
             secret: "${ALGOLIA_PLUGINS_JENKINS_IO_WRITE_KEY}"
             description: "Algolia credentials to write data for plugin site"
+          infraci-pluginsjenkinsio-fileshare-service-principal-writer:
+            kind: azure-serviceprincipal
+            azureEnvironmentName: "Azure"
+            clientId: "${INFRACI_PLUGINSJENKINSIO_FILESHARE_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
+            clientSecret: "${INFRACI_PLUGINSJENKINSIO_FILESHARE_SERVICE_PRINCIPAL_WRITER_PASSWORD}"
+            description: "plugins.jenkins.io File Share Service Principal Writer"
+            subscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
+            tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
       jenkins-io-components:
         name: Jenkins.io Web Components
         allowUntrustedChanges: true


### PR DESCRIPTION
This PR adds an Azure Service Principal credentials to interact with `plugins-jenkins-io` File Share.

Follow-up of:
- https://github.com/jenkins-infra/azure/pull/630
- https://github.com/jenkins-infra/charts-secrets/commit/7ef0d46bddd554f39691e11c24884d3adffa7849 (private repo)

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1964568638