### PR TITLE
chore(plugins.jenkins.io): use new `pluginsjenkinsio` storage account

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -215,7 +215,7 @@ releases:
     values:
       - "../config/plugin-site.yaml"
     secrets:
-      - "../secrets/config/plugin-site/secrets.yaml"
+      - "../secrets/config/plugin-site/intermediate-secrets.yaml"
   - name: jenkinsio
     namespace: jenkinsio
     chart: jenkins-infra/jenkinsio

--- a/config/plugin-site.yaml
+++ b/config/plugin-site.yaml
@@ -22,7 +22,7 @@ backend:
 htmlVolume:
   azureFile:
     secretName: plugin-site
-    shareName: pluginsite
+    shareName: plugins-jenkins-io
     readOnly: true
 
 nodeSelector:


### PR DESCRIPTION
This PR  migrates plugins.jenkins.io to its new `pluginsjenkinsio` storage account, using an intermediate secret to avoid any service interruption.

Needs:
- https://github.com/jenkins-infra/plugin-site/pull/1596

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1964568638