### PR TITLE
chore(plugins.jenkins.io): use secrets.yaml instead of intermediate-secrets.yaml

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -215,7 +215,7 @@ releases:
     values:
       - "../config/plugin-site.yaml"
     secrets:
-      - "../secrets/config/plugin-site/intermediate-secrets.yaml"
+      - "../secrets/config/plugin-site/secrets.yaml"
   - name: jenkinsio
     namespace: jenkinsio
     chart: jenkins-infra/jenkinsio


### PR DESCRIPTION
This PR get rid of the intermediate secret used to avoid service interruption while migrating to the new storage account.

Follow-up of:
- #5027 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1964568638