### PR TITLE
chore(javadoc.jenkins.io): use new `javadocjenkinsio` storage account

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -101,7 +101,7 @@ releases:
     values:
       - "../config/javadoc.yaml"
     secrets:
-      - "../secrets/config/javadoc/secrets.yaml"
+      - "../secrets/config/javadoc/intermediate-secrets.yaml"
   - name: jenkinsisthewayio-redirect
     namespace: jenkinsisthewayio-redirector
     chart: jenkins-infra/httpredirector

--- a/config/javadoc.yaml
+++ b/config/javadoc.yaml
@@ -27,7 +27,7 @@ resources:
 htmlVolume:
   azureFile:
     secretName: javadoc
-    shareName: javadoc
+    shareName: javadoc-jenkins-io
     readOnly: true
 
 replicaCount: 2


### PR DESCRIPTION
This PR  migrates javadoc.jenkins.io to its new `javadocjenkinsio` storage account, using an intermediate secret to avoid any service interruption.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1966067802