### PR TITLE
chore(javadoc.jenkins.io): use secrets.yaml instead of intermediate-secrets.yaml

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -101,7 +101,7 @@ releases:
     values:
       - "../config/javadoc.yaml"
     secrets:
-      - "../secrets/config/javadoc/intermediate-secrets.yaml"
+      - "../secrets/config/javadoc/secrets.yaml"
   - name: jenkinsisthewayio-redirect
     namespace: jenkinsisthewayio-redirector
     chart: jenkins-infra/httpredirector


### PR DESCRIPTION
This PR get rid of the intermediate secret used to avoid service interruption while migrating to the new storage account.

Follow-up of:
- #5029 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3414#issuecomment-1966067802