### PR TITLE
Update matching branches for plugin-site job

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -439,6 +439,7 @@ jobsDefinition:
         name: Plugin Site
         allowUntrustedChanges: true
         jenkinsfilePath: Jenkinsfile
+        branchIncludes: "main PR-*"
         credentials:
           PLUGINSITE_STORAGEACCOUNTKEY:
             secret: "${PLUGINSITE_STORAGEACCOUNTKEY}"


### PR DESCRIPTION
Hardens https://github.com/jenkins-infra/plugin-site/issues/1595 by defining the existing config on infra.ci as code.

Btw, is possible to the kubernetes team? Then I don't need to trigger my PRs manually on infra.ci 😅