### PR TITLE
Revert "chore: remove privatek8s cluster from the pipeline"

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'cik8s', 'doks', 'doks-public', 'eks-public', 'publick8s'
+            values 'cik8s', 'doks', 'doks-public', 'eks-public', 'privatek8s', 'publick8s'
           }
         } // axes
         agent {


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#5053

to re-enable privatek8s and check the helmfile diff 