### PR TITLE
feat(publick8s/plugin-site-issues) specify an ECDSA LetsEncrypt certificate instead of RSA

### DIFF
--- a/config/plugin-site-issues.yaml
+++ b/config/plugin-site-issues.yaml
@@ -3,6 +3,7 @@ ingress:
   className: public-nginx
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+    "cert-manager.io/private-key-algorithm": "ECDSA"
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
     "nginx.ingress.kubernetes.io/enable-cors": "true"
     "nginx.ingress.kubernetes.io/cors-allow-methods": "GET, OPTIONS"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3978#issuecomment-2008687538


This PR specifies the use of an ECDSA certificate instead of RSA for the https://plugin-site-issues.jenkins.io/ website.
Certificates are auto-generated by cert-manager with Let's Encrypt.

Note we can only specify ECDSA per `Certificate` custom resource through ingress annotation as per https://cert-manager.io/docs/usage/ingress/. 

As we cannot specify to use `ECDSA` by default at the `ClusterIssuer`  level (ref. https://github.com/cert-manager/cert-manager/issues/2764) we might have to do this change to all ingresses.

So this PR is a first test to validate it is worth the effort.
Once merged, we'll force-renew the certificate to validate it works and the user in https://github.com/jenkins-infra/helpdesk/issues/3978 is happy with the outcome. Then we'll decide to either rollback the PR here or make the change everywhere.