### PR TITLE
feat(privatek8s/infra.ci) remove GitHub checks for updatecli jobs in favor of customized scm notifications

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -144,13 +144,11 @@ jobsDefinition:
       jenkins-infra:
         name: Puppet (jenkins-infra)
         jenkinsfilePath: Jenkinsfile_updatecli
-        enableGitHubChecks: true
         branchIncludes: "production staging updatecli_* PR-* main"
         disableTagDiscovery: true
       kubernetes-management:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
-        enableGitHubChecks: true
         credentials:
           updatecli-azure-serviceprincipal:
             azureEnvironmentName: "Azure"
@@ -162,16 +160,13 @@ jobsDefinition:
       packer-images:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
-        enableGitHubChecks: true
       helm-charts:
         name: Helm Charts
         description: Custom Helm Charts of the Jenkins Infra
         disableTagDiscovery: true
-        enableGitHubChecks: true
       azure:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
-        enableGitHubChecks: true
   other-jobs:
     name: Other Jobs
     description: Folder hosting all the jobs not fitting any category


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2778

Since https://github.com/jenkins-infra/helm-charts/pull/1081 (deployed in https://github.com/jenkins-infra/kubernetes-management/pull/5015), we have customized SCM notifications from controllers to GitHub to allow splitting jobs on the same repository without messing up checks.

Following up the changes in https://github.com/jenkins-infra/kubernetes-management/pull/5025/files, this PR also fully disable GH Notification Checks to remove the `jenkins` check which we do not need anymore for the `updatecli` jobs:

<img width="682" alt="Capture d’écran 2024-03-22 à 08 14 44" src="https://github.com/jenkins-infra/kubernetes-management/assets/1522731/7bcf4e95-67de-40dd-bad7-6bc0607ca143">
