### PR TITLE
chore(updatecli) improve condition for packer-image detection to avoid opening PR until the image release is complete.

### DIFF
--- a/updatecli/updatecli.d/charts/jenkins-agents-infra.ci.jenkins.io.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-agents-infra.ci.jenkins.io.yaml
@@ -22,7 +22,34 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
 
+  getLatestInboundAllInOneContainerImageX86:
+    kind: dockerdigest
+    name: Get digest of the jenkinsciinfra/jenkins-agent-ubuntu-22.04 image
+    dependson:
+      - packerImageVersion
+    spec:
+      image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04"
+      tag: '{{ source "packerImageVersion"}}'
+      architecture: linux/amd64
+
+  getLatestInboundAllInOneContainerImageARM:
+      kind: dockerdigest
+      name: Get digest of the jenkinsciinfra/jenkins-agent-ubuntu-22.04 image
+      dependson:
+        - packerImageVersion
+      spec:
+        image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04"
+        tag: '{{ source "packerImageVersion"}}'
+        architecture: linux/arm64
+
 conditions:
+  checkAllInOneContainerImages:
+    # If the 2 Docker images are different, it means the release build of packer-images failed (and never pushed the multi-arch manifest as last stage)
+    disablesourceinput: true
+    name: Check that x86 and arm64 all-in-one images are different
+    kind: shell
+    spec:
+      command: test {{ source "getLatestInboundAllInOneContainerImageX86" }} != {{ source "getLatestInboundAllInOneContainerImageARM" }}
   checkifazureimagejenkins-agent-ubuntu-22.04-amd64isavailable:
     kind: shell
     disablesourceinput: true
@@ -44,13 +71,6 @@ conditions:
       environments:
         - name: PATH
       command: az sig image-version list --resource-group prod-packer-images --gallery-name prod_packer_images --gallery-image-definition jenkins-agent-ubuntu-22.04-arm64 --query "[?tags.version == '{{ source `packerImageVersion` }}']" --output tsv
-  checkDockerImageARM64:
-    name: Ensure that the image "jenkinsciinfra/jenkins-agent-ubuntu-22.04:<found_version>" is published
-    kind: dockerimage
-    spec:
-      image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04"
-      ## tag come from the input source
-      architecture: arm64
 
 targets:
   setAzureGalleryImageVersion:


### PR DESCRIPTION
This PR improves the condition to detect a new packer-image all in on version:

If the release of jenkins-infra/packer-images fails, then the last stage is never run.
This last stage is expected to build and deploy a multi-architecture manifest to the DockerHub for the new image version being released (see https://github.com/jenkins-infra/packer-images/blob/7f910ad4457d6f62d45af4762235ea5457581997/Jenkinsfile_k8s#L211-L238)

Until this stage is reached, all architectures on the DockerHub answers with the same image SHA: this is the goal of the added condition.

Copy and pasted (mostly) from https://github.com/jenkins-infra/jenkins-infra/blob/c6efe085075ff612e6340946716d3ca9ef037699/updatecli/weekly.d/jenkinscontroller-agents-packer-agent-all-in-one.yaml#L46-L51 where it has worked as expected since months.

Closes #5079