### PR TITLE
chore(updates.jenkins.io): activate HA for mirrorbits and httpd

### DIFF
--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -45,6 +45,7 @@ global:
 
 mirrorbits:
   enabled: true
+  replicaCount: 2
   resources:
     limits:
       cpu: 2
@@ -57,6 +58,7 @@ mirrorbits:
 
 httpd:
   enabled: true
+  replicaCount: 2
   resources:
     limits:
       cpu: 1000m


### PR DESCRIPTION
This PR set the replica count to 2 for the mirrorbits and the httpd subcharts of updates.jenkins.io to activate the High Availability of this service.

As the rsync server won't be requested as much as mirrorbits and Apache, I've kept its replica count to 1.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2649