### PR TITLE
feat(privatek8s/infra.ci) add PHS Report job in infra-reports

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -210,6 +210,10 @@ jobsDefinition:
             appId: "${GITHUB_APP_JENKINSCI_INFRA_REPORTS_ID}"
             owner: "jenkinsci"
             privateKey: "${GITHUB_APP_JENKINSCI_INFRA_REPORTS_PRIVATE_KEY}"
+      jenkins-infra-data:
+        name: "Jenkins Infrastructure Public Data"
+        repository: "infra-reports"
+        jenkinsfilePath: "jenkins-infra-data/Jenkinsfile"
       jira-users-report:
         name: "Jira Users Report"
         repository: "infra-reports"
@@ -230,10 +234,6 @@ jobsDefinition:
             username: "${JIRA_API_INFRA_REPORTS_USERNAME}"
             usernameSecret: true
             password: "${JIRA_API_INFRA_REPORTS_PASSWORD}"
-      jenkins-infra-data:
-        name: "Jenkins Infrastructure Public Data"
-        repository: "infra-reports"
-        jenkinsfilePath: "jenkins-infra-data/Jenkinsfile"
       permissions-report:
         name: "GitHub Permissions Report"
         repository: "infra-reports"
@@ -248,6 +248,10 @@ jobsDefinition:
       pipeline-steps-doc-generator:
         name: "Pipeline Steps Documentation Generator"
         jenkinsfilePath: Jenkinsfile
+      plugin-health-scoring:
+        name: "Plugin Health Scoring Report"
+        repository: "infra-reports"
+        jenkinsfilePath: "plugin-health-scoring/Jenkinsfile"
       plugin-migration:
         name: "Plugin Migration Status Report"
         repository: "infra-reports"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3961

This PR creates a new job on infra.ci, inside the top-level "Infra Report" folder, to handle the Plugin Health Score report generation.

Note: the job can be created first: it won't find any `Jenkinsfile` for now when scanning until a PR on infra-report is opened :)