### PR TITLE
hotfix(publick8s/plugin-site-issue) force TLS certificate private key renewal when changing alogrithm - uses ingress annotation for cert-manager

### DIFF
--- a/config/plugin-site-issues.yaml
+++ b/config/plugin-site-issues.yaml
@@ -4,6 +4,7 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "cert-manager.io/private-key-algorithm": "ECDSA"
+    "cert-manager.io/private-key-rotation-policy": "Always"
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
     "nginx.ingress.kubernetes.io/enable-cors": "true"
     "nginx.ingress.kubernetes.io/cors-allow-methods": "GET, OPTIONS"


### PR DESCRIPTION
Hotfix of https://github.com/jenkins-infra/kubernetes-management/pull/5080.
Already applied on production (hotfix) with success.


Related to https://github.com/jenkins-infra/helpdesk/issues/3978

Ref. https://cert-manager.io/docs/usage/ingress/#supported-annotations

This change fixes the message `Existing private key is not up to date for spec <...>` in the `kubectl describe certificate` output which prevented the certificate renewal due to an algorithm change (RSA -> ECDSA in this case)