### PR TITLE
chore(infraci): move persistence volume to ZRS in prevision for ARM64 migration

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -8,7 +8,7 @@ rbac:
   readSecrets: true
 persistence:
   enabled: true
-  size: 50Gi
+  size: 64Gi
   storageClass: managed-csi-premium-zrs-retain
   dataSource:
     name: jenkins-infraci-snap

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -9,7 +9,10 @@ rbac:
 persistence:
   enabled: true
   size: 50Gi
-  storageClass: managed-csi-premium-retain
+  storageClass: managed-csi-premium-zrs-retain
+  dataSource:
+    name: jenkins-infraci-snap
+    kind: PersistentVolumeClaim
 agent:
   componentName: "agent"
 networkPolicy:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3823#issuecomment-2036372624

move the persistence volume to a ZRS storage to be able to move the instance from zone 3 to zone 1, which is compliant with ARM64