### PR TITLE
cleanup(publick8s/plugin-site-issues) rollback custom annotations back to default key algorithm (RSA)

### DIFF
--- a/config/plugin-site-issues.yaml
+++ b/config/plugin-site-issues.yaml
@@ -3,8 +3,6 @@ ingress:
   className: public-nginx
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
-    "cert-manager.io/private-key-algorithm": "ECDSA"
-    "cert-manager.io/private-key-rotation-policy": "Always"
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
     "nginx.ingress.kubernetes.io/enable-cors": "true"
     "nginx.ingress.kubernetes.io/cors-allow-methods": "GET, OPTIONS"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3978

As there are no strong compelling reason to use ECDSA over RSA and we can't default to ECDSA by default, this PR rolls back the changes introduced in https://github.com/jenkins-infra/kubernetes-management/pull/5080 and https://github.com/jenkins-infra/kubernetes-management/pull/5110 as we want to keep with the same default settings for all of our certificates: enforcing the ECDSA-related annotation across all ingresses is time-consuming.

Please note that a one-time manual change will be required to re-issue an RSA certificate by adding the following annotation to the `plugin-site-issue` ingress right before force-renewing (with `cmctl`):

```
cert-manager.io/private-key-rotation-policy: Always
```