### PR TITLE
chore(infra.ci): migrate to arm64

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -31,7 +31,8 @@ controller:
     tag: 1.37.0-2.453
     pullPolicy: IfNotPresent
   nodeSelector:
-    - kubernetes.azure.com/agentpool: infracictrl
+    kubernetes.azure.com/agentpool: infracictrl
+    kubernetes.io/arch: arm64
   tolerations:
     - key: "kubernetes.io/arch"
       operator: "Equal"

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -28,7 +28,7 @@ controller:
     supplementalGroups: [1000]
   image:
     repository: jenkinsciinfra/jenkins-weekly
-    tag: 1.37.0-2.453
+    tag: 1.37.2-2.453
     pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -31,8 +31,20 @@ controller:
     tag: 1.37.0-2.453
     pullPolicy: IfNotPresent
   nodeSelector:
-    kubernetes.io/os: linux
-    kubernetes.azure.com/agentpool: linuxpool
+    - kubernetes.azure.com/agentpool: infracictrl
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
+    - key: "jenkins"
+      operator: "Equal"
+      value: "infra.ci.jenkins.io"
+      effect: "NoSchedule"
+    - key: "jenkins-component"
+      operator: "Equal"
+      value: "controller"
+      effect: "NoSchedule"
   resources:
     limits:
       cpu: "2"

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -31,6 +31,7 @@ controller:
     tag: 1.37.0-2.453
     pullPolicy: IfNotPresent
   nodeSelector:
+    kubernetes.io/os: linux
     kubernetes.azure.com/agentpool: infracictrl
     kubernetes.io/arch: arm64
   tolerations:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3823#issuecomment-2036372624

this will migrate infra.ci to it's specific pool which is arm64 as per https://github.com/jenkins-infra/azure/pull/658 

----
Deployment procedure

as this is an heavy change on infra.ci infrastructure it is safer to apply it manually (instead of relying on agent re-connection if everything goes according to the plan) 

- from a local administrator machine with access to privatek8s API (and same kubectl / helmfile version as packer image allinone agent)
- ensure that the local kubernetes-management repository is up to date with this PR (including `./secrets` sub repository)
- execute helmfile diff to ensure that the change is correctly plan
- deploy with helmfile apply
    - merge this PR as soon as the pod is scheduled and before infra.ci is up and running
