### PR TITLE
fix(privatek8s/datadog) ensure datadog agent runs on all nodes by updating tolerations

### DIFF
--- a/config/datadog_privatek8s.yaml
+++ b/config/datadog_privatek8s.yaml
@@ -8,3 +8,29 @@ datadog:
     hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
     # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
     tlsVerify: false
+agents:
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
+    - key: "CriticalAddonsOnly"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "jenkins"
+      operator: "Equal"
+      value: "infra.ci.jenkins.io"
+      effect: "NoSchedule"
+    - key: "jenkins"
+      operator: "Equal"
+      value: "release.ci.jenkins.io"
+      effect: "NoSchedule"
+    - key: "jenkins-component"
+      operator: "Equal"
+      value: "controller"
+      effect: "NoSchedule"
+    - key: "kubernetes.azure.com/scalesetpriority"
+      operator: "Equal"
+      value: "spot"
+      effect: "NoSchedule"


### PR DESCRIPTION
Follow up of #5126
Related to https://github.com/jenkins-infra/helpdesk/issues/3823

This PR fixes the datadog configuration in the `privatek8s` cluster to ensure we have an agent per node.

Today we only have datadog agents on the syspool and linuxpool node pools.
The arm64 node pools have taints forbidding the datadog agent to be scheduled.

By adding tolerations to the datadog deployment, we allow them to be scheduled on any kind of nodes.

----

Notes:

- The Windows node pool (used only during Jenkins core releases by release.ci.jenkins.io is out of scope)
- The tolerations added in this PR covers ALL the other node pools: all controllers, all agents, etc.
- Tested manually with success on production and then roll backed.
- Thanks @MarionPlt for the rubber ducking on this one!