### PR TITLE
fix(publick8s,privatek8s) ensure datadog setup works on AKS (Azure Linux, Admission Controller)

### DIFF
--- a/config/datadog_privatek8s.yaml
+++ b/config/datadog_privatek8s.yaml
@@ -1,5 +1,10 @@
 datadog:
   clusterName: 'privatek8s'
+  env:
+    - name: DD_HOSTNAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
   kubelet:
     host:
       valueFrom:

--- a/config/datadog_privatek8s.yaml
+++ b/config/datadog_privatek8s.yaml
@@ -1,3 +1,6 @@
+providers:
+  aks:
+    enabled: true
 datadog:
   clusterName: 'privatek8s'
   env:

--- a/config/datadog_publick8s.yaml
+++ b/config/datadog_publick8s.yaml
@@ -1,3 +1,6 @@
+providers:
+  aks:
+    enabled: true
 datadog:
   clusterName: 'publick8s'
   env:

--- a/config/datadog_publick8s.yaml
+++ b/config/datadog_publick8s.yaml
@@ -1,5 +1,10 @@
 datadog:
   clusterName: 'publick8s'
+  env:
+    - name: DD_HOSTNAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
   kubelet:
     host:
       valueFrom:


### PR DESCRIPTION
Follow up of #5132
Related to https://github.com/jenkins-infra/helpdesk/issues/3823

This PR ensures that datadog installation works as expected in our AKS clusters by following datadog recommendations:

- First change allows datadog agent to run on Azure Linux (ref. https://github.com/jenkins-infra/azure/pull/662). It applies the datadog troubleshooting trick (https://docs.datadoghq.com/agent/troubleshooting/hostname_containers/?tab=helm#accessing-the-container-runtime-api) to use the container runtime API when resolving the hostname.
    - Fixes the error message `Error: Error while getting hostname, exiting: unable to reliably determine the host name. You can define one in the agent config file or in your hosts file` in the datadog-agent pod logs (when it is in `CrashLoopBackOff`)
- Second change ensures that the AKS admission controller works with datadog. It follows the datadog official instructions for AKS (ref. https://docs.datadoghq.com/containers/kubernetes/distributions/?tab=helm#AKS)


----

Thanks @MarionPlt for the rubber ducking on this one!