### PR TITLE
feat(privatek8s/release.ci) add podSecurityContextOverride to avoid long volume attach/mount times

### DIFF
--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -39,6 +39,11 @@ controller:
     requests:
       cpu: "2"
       memory: "4Gi"
+  controller:
+    podSecurityContextOverride:
+      runAsUser: 1000
+      runAsNonRoot: true
+      supplementalGroups: [1000]
   probes:
     startupProbe:
       initialDelaySeconds: 120

--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -39,11 +39,10 @@ controller:
     requests:
       cpu: "2"
       memory: "4Gi"
-  controller:
-    podSecurityContextOverride:
-      runAsUser: 1000
-      runAsNonRoot: true
-      supplementalGroups: [1000]
+  podSecurityContextOverride:
+    runAsUser: 1000
+    runAsNonRoot: true
+    supplementalGroups: [1000]
   probes:
     startupProbe:
       initialDelaySeconds: 120


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3823#issuecomment-2056385986

adding a podSecurityContextOverride to avoid long volume mount attach times https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/README.md#long-volume-attachmount-times