### PR TITLE
chore(release.ci): migrate to arm64

### DIFF
--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -34,7 +34,21 @@ controller:
     pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.azure.com/agentpool: linuxpool
+    kubernetes.azure.com/agentpool: releacictrl
+    kubernetes.io/arch: arm64
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
+    - key: "jenkins"
+      operator: "Equal"
+      value: "release.ci.jenkins.io"
+      effect: "NoSchedule"
+    - key: "jenkins-component"
+      operator: "Equal"
+      value: "controller"
+      effect: "NoSchedule"
   resources:
     limits:
       cpu: "2"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4042
migrate release.ci to arm64 dedicated nodepool.