### PR TITLE
chore(release.ci): migrate to arm64 with correct docker image version

### DIFF
--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -30,11 +30,25 @@ networkPolicy:
 controller:
   image:
     repository: jenkinsciinfra/jenkins-lts
-    tag: 1.8.4-2.440.2
+    tag: 1.9.0-2.440.2
     pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux
-    kubernetes.azure.com/agentpool: linuxpool
+    kubernetes.azure.com/agentpool: releacictrl
+    kubernetes.io/arch: arm64
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
+    - key: "jenkins"
+      operator: "Equal"
+      value: "release.ci.jenkins.io"
+      effect: "NoSchedule"
+    - key: "jenkins-component"
+      operator: "Equal"
+      value: "controller"
+      effect: "NoSchedule"
   resources:
     limits:
       cpu: "2"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4042

following #5140 and #5141 using last docker image version compatible with arm64 as per https://github.com/jenkins-infra/docker-jenkins-lts/pull/857 