### PR TITLE
feat(updates.jenkins.io): set azure.updates.jenkins.io backend to `httpd` and mirrors.updates.jenkins.io to `mirrorbits`

### DIFF
--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -5,19 +5,20 @@ global:
     annotations:
       "cert-manager.io/cluster-issuer": "letsencrypt-prod"
       "nginx.ingress.kubernetes.io/ssl-redirect": "true"
-      "nginx.ingress.kubernetes.io/use-regex": "true"  # Required to allow regexp path matching with Nginx
     hosts:
       - host: azure.updates.jenkins.io
         paths:
           - path: /
             backendService: httpd
-          - path: /.*[.](json|html|txt)$  # Requires the regexp engine of Nginx to be enabled
-            pathType: ImplementationSpecific
+      - host: mirrors.updates.jenkins.io
+        paths:
+          - path: /
             backendService: mirrorbits
     tls:
       - secretName: updates-jenkins-io-tls
         hosts:
           - azure.updates.jenkins.io
+          - mirrors.updates.jenkins.io
 
   storage:
     enabled: true


### PR DESCRIPTION
This PR update the new Update Center deployment (Azure + mirrorbits) to have the described setup (azure.updates.jenkins.io => httpd and mirrors.updates.jenkins.io => mirrorbits).

As we don't need to filter path with nginx-ingress & regexp anymore, removing the correspond snippet annotation.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2075477428