### PR TITLE
feat(updates.jenkins.io): dedicated File Share for the `httpd` service

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -241,6 +241,14 @@ releases:
       - "../config/updates.jenkins.io.yaml"
     secrets:
       - "../secrets/config/updates.jenkins.io/secrets.yaml"
+  - name: updates-jenkins-io-httpd
+    namespace: updates-jenkins-io
+    chart: jenkins-infra/httpd
+    version: 0.4.0
+    values:
+      - "../config/updates.jenkins.io_httpd.yaml"
+    secrets:
+      - "../secrets/config/updates.jenkins.io/httpd-secrets.yaml"
   - name: contributors-jenkins-io
     namespace: contributors-jenkins-io
     chart: jenkins-infra/nginx-website

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -6,10 +6,6 @@ global:
       "cert-manager.io/cluster-issuer": "letsencrypt-prod"
       "nginx.ingress.kubernetes.io/ssl-redirect": "true"
     hosts:
-      - host: azure.updates.jenkins.io
-        paths:
-          - path: /
-            backendService: httpd
       - host: mirrors.updates.jenkins.io
         paths:
           - path: /
@@ -17,7 +13,6 @@ global:
     tls:
       - secretName: updates-jenkins-io-tls
         hosts:
-          - azure.updates.jenkins.io
           - mirrors.updates.jenkins.io
 
   storage:
@@ -58,22 +53,7 @@ mirrorbits:
     kubernetes.io/arch: amd64
 
 httpd:
-  enabled: true
-  replicaCount: 2
-  resources:
-    limits:
-      cpu: 1000m
-      memory: 2048Mi
-    requests:
-      cpu: 200m
-      memory: 500Mi
-  nodeSelector:
-    kubernetes.io/arch: arm64
-  tolerations:
-    - key: "kubernetes.io/arch"
-      operator: "Equal"
-      value: "arm64"
-      effect: "NoSchedule"
+  enabled: false
 
 rsyncd:
   enabled: true

--- a/config/updates.jenkins.io_httpd.yaml
+++ b/config/updates.jenkins.io_httpd.yaml
@@ -1,0 +1,70 @@
+replicaCount: 2
+resources:
+  limits:
+    cpu: 1000m
+    memory: 2048Mi
+  requests:
+    cpu: 200m
+    memory: 500Mi
+nodeSelector:
+  kubernetes.io/arch: arm64
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+repository:
+  name: httpd-binary
+  # To reuse an existing PVC, ensure repository.name is set to the PVC name, set the value below to true and keep persistentVolumeClaim to false
+  reuseExistingPersistentVolumeClaim: false
+  persistentVolumeClaim:
+    enabled: true
+    spec:
+      accessModes:
+        - ReadOnlyMany
+      resources:
+        requests:
+          storage: 1Gi  # See httpd file share size in https://github.com/jenkins-infra/azure/blob/main/updates.jenkins.io.tf
+      storageClassName: azurefile-csi-premium
+      volumeMode: Filesystem
+      volumeName: httpd-binary
+  persistentVolume:
+    enabled: true
+    spec:
+      accessModes:
+        - ReadOnlyMany
+      storageSize: 1Gi  # See httpd file share size in https://github.com/jenkins-infra/azure/blob/main/updates.jenkins.io.tf
+      storageClassName: azurefile-csi-premium
+      azureFile:
+        resourceGroup: updates-jenkins-io
+        shareName: updates-jenkins-io-httpd
+        readOnly: true
+      additionalSpec:
+        persistentVolumeReclaimPolicy: Retain
+        mountOptions:
+          - dir_mode=0755
+          - file_mode=0644
+          - uid=1000
+          - gid=1000
+          - mfsymlinks
+          - nobrl
+          - serverino
+          - cache=strict
+  secrets:
+    enabled: true
+
+ingress:
+  enabled: true
+  className: public-nginx
+  annotations:
+    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+    "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+  hosts:
+    - host: azure.updates.jenkins.io
+      paths:
+        - path: /
+          backendService: httpd
+  tls:
+    - secretName: updates-jenkins-io-tls
+      hosts:
+        - azure.updates.jenkins.io


### PR DESCRIPTION
As the httpd service doesn't need to have a common File Share with the mirrorbits service, this PR ~disables it from the mirrorbits-parent release~ (extracted in #5186), and adds a dedicated httpd release from its own chart so it can use its own updates-jenkins-io-httpd File Share created in https://github.com/jenkins-infra/azure/pull/676.

We're keeping the mirrorbits and the rsync services under mirrorbits-parent umbrella as they still need to share the same updates-jenkins-io File Share.

Corresponding secret added in https://github.com/jenkins-infra/charts-secrets/commit/688566ee492e9026f09289d79ece7f8f4f06cdf3 (private repo).

Follow-up of:
- https://github.com/jenkins-infra/kubernetes-management/pull/5175

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2076659536