### PR TITLE
chore(updates.jenkins.io): disable `httpd` service in mirrorbits-parent release

### DIFF
--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -6,10 +6,6 @@ global:
       "cert-manager.io/cluster-issuer": "letsencrypt-prod"
       "nginx.ingress.kubernetes.io/ssl-redirect": "true"
     hosts:
-      - host: azure.updates.jenkins.io
-        paths:
-          - path: /
-            backendService: httpd
       - host: mirrors.updates.jenkins.io
         paths:
           - path: /
@@ -17,7 +13,6 @@ global:
     tls:
       - secretName: updates-jenkins-io-tls
         hosts:
-          - azure.updates.jenkins.io
           - mirrors.updates.jenkins.io
 
   storage:
@@ -58,22 +53,7 @@ mirrorbits:
     kubernetes.io/arch: amd64
 
 httpd:
-  enabled: true
-  replicaCount: 2
-  resources:
-    limits:
-      cpu: 1000m
-      memory: 2048Mi
-    requests:
-      cpu: 200m
-      memory: 500Mi
-  nodeSelector:
-    kubernetes.io/arch: arm64
-  tolerations:
-    - key: "kubernetes.io/arch"
-      operator: "Equal"
-      value: "arm64"
-      effect: "NoSchedule"
+  enabled: false
 
 rsyncd:
   enabled: true


### PR DESCRIPTION
As the httpd service doesn't need to have a common File Share with the mirrorbits service, this PR disables it from the mirrorbits-parent release.

Cherry-picking https://github.com/jenkins-infra/kubernetes-management/pull/5184/commits/c84ef20723470f7c15ff3a51773b5ae740aa1f9e from:
- https://github.com/jenkins-infra/kubernetes-management/pull/5184

We need to do it in two steps to avoid the concurrency error described in https://github.com/jenkins-infra/kubernetes-management/pull/5184#issuecomment-2085520946

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2076659536