### PR TITLE
feat(publick8s/updates.jenkins.io): deploys a dedicated `httpd` service with a distinct fileshare

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -241,6 +241,14 @@ releases:
       - "../config/updates.jenkins.io.yaml"
     secrets:
       - "../secrets/config/updates.jenkins.io/secrets.yaml"
+  - name: updates-jenkins-io-httpd
+    namespace: updates-jenkins-io
+    chart: jenkins-infra/httpd
+    version: 0.4.0
+    values:
+      - "../config/updates.jenkins.io_httpd.yaml"
+    secrets:
+      - "../secrets/config/updates.jenkins.io/httpd-secrets.yaml"
   - name: contributors-jenkins-io
     namespace: contributors-jenkins-io
     chart: jenkins-infra/nginx-website

--- a/config/updates.jenkins.io_httpd.yaml
+++ b/config/updates.jenkins.io_httpd.yaml
@@ -14,42 +14,58 @@ tolerations:
     value: "arm64"
     effect: "NoSchedule"
 repository:
-  name: httpd-binary
-  # To reuse an existing PVC, ensure repository.name is set to the PVC name, set the value below to true and keep persistentVolumeClaim to false
-  reuseExistingPersistentVolumeClaim: false
-  persistentVolumeClaim:
-    enabled: true
-    spec:
-      accessModes:
-        - ReadOnlyMany
-      resources:
-        requests:
-          storage: 1Gi  # See httpd file share size in https://github.com/jenkins-infra/azure/blob/main/updates.jenkins.io.tf
-      storageClassName: azurefile-csi-premium
-      volumeMode: Filesystem
-      volumeName: httpd-binary
+  name: updates-jenkins-io-httpd
+  ## Storage is statically provisioned: https://learn.microsoft.com/en-us/azure/aks/azure-csi-files-storage-provision#statically-provision-a-volume
   persistentVolume:
     enabled: true
     spec:
       accessModes:
         - ReadOnlyMany
-      storageSize: 1Gi  # See httpd file share size in https://github.com/jenkins-infra/azure/blob/main/updates.jenkins.io.tf
-      storageClassName: azurefile-csi-premium
-      azureFile:
-        resourceGroup: updates-jenkins-io
-        shareName: updates-jenkins-io-httpd
+      capacity:
+        # See httpd file share size in https://github.com/jenkins-infra/azure/blob/main/updates.jenkins.io.tf
+        storage: 1Gi
+      # Retain Azure file storage even if PV is deleted in AKS to avoid serving files accidentally
+      storageClassName: azurefile-csi-premium-retain
+      csi:
+        # Driver maps to storageclass specification
+        driver: file.csi.azure.com
+        # Secret is created by the httpd chart: name is deterministic (but need to be repeated here)
+        nodeStageSecretRef:
+          name: updates-jenkins-io-httpd-binary
+          namespace: updates-jenkins-io
         readOnly: true
-      additionalSpec:
-        persistentVolumeReclaimPolicy: Retain
-        mountOptions:
-          - dir_mode=0755
-          - file_mode=0644
-          - uid=1000
-          - gid=1000
-          - mfsymlinks
-          - nobrl
-          - serverino
-          - cache=strict
+        # See httpd file share size in https://github.com/jenkins-infra/azure/blob/main/updates.jenkins.io.tf
+        volumeAttributes:
+          resourceGroup: updates-jenkins-io
+          shareName: updates-jenkins-io-httpd
+        # `volumeHandle` is for every identical share in the cluster
+        volumeHandle: updates-jenkins-io-httpd
+      # `mountOptions` maps to storageclass specification
+      mountOptions:
+        - dir_mode=0755
+        - file_mode=0644
+        - uid=1000
+        - gid=1000
+        - mfsymlinks
+        - nobrl
+        - serverino
+        - cache=strict
+      # `persistentVolumeReclaimPolicy` maps to storageclass specification
+      persistentVolumeReclaimPolicy: Retain
+  persistentVolumeClaim:
+    enabled: true
+    spec:
+      # Must match with the PV `metadata.name`, eg. the helm value `repository.name`
+      volumeName: updates-jenkins-io-httpd
+      accessModes:
+        - ReadOnlyMany
+      resources:
+        requests:
+          # See httpd file share size in https://github.com/jenkins-infra/azure/blob/main/updates.jenkins.io.tf
+          # Must be lower or equal than the associated's PV capacity size
+          storage: 1Gi
+      # Only visual, not functional (static provisioning) but should map to PV for clarity
+      storageClassName: azurefile-csi-premium-retain
   secrets:
     enabled: true
 

--- a/config/updates.jenkins.io_httpd.yaml
+++ b/config/updates.jenkins.io_httpd.yaml
@@ -1,0 +1,70 @@
+replicaCount: 2
+resources:
+  limits:
+    cpu: 1000m
+    memory: 2048Mi
+  requests:
+    cpu: 200m
+    memory: 500Mi
+nodeSelector:
+  kubernetes.io/arch: arm64
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+repository:
+  name: httpd-binary
+  # To reuse an existing PVC, ensure repository.name is set to the PVC name, set the value below to true and keep persistentVolumeClaim to false
+  reuseExistingPersistentVolumeClaim: false
+  persistentVolumeClaim:
+    enabled: true
+    spec:
+      accessModes:
+        - ReadOnlyMany
+      resources:
+        requests:
+          storage: 1Gi  # See httpd file share size in https://github.com/jenkins-infra/azure/blob/main/updates.jenkins.io.tf
+      storageClassName: azurefile-csi-premium
+      volumeMode: Filesystem
+      volumeName: httpd-binary
+  persistentVolume:
+    enabled: true
+    spec:
+      accessModes:
+        - ReadOnlyMany
+      storageSize: 1Gi  # See httpd file share size in https://github.com/jenkins-infra/azure/blob/main/updates.jenkins.io.tf
+      storageClassName: azurefile-csi-premium
+      azureFile:
+        resourceGroup: updates-jenkins-io
+        shareName: updates-jenkins-io-httpd
+        readOnly: true
+      additionalSpec:
+        persistentVolumeReclaimPolicy: Retain
+        mountOptions:
+          - dir_mode=0755
+          - file_mode=0644
+          - uid=1000
+          - gid=1000
+          - mfsymlinks
+          - nobrl
+          - serverino
+          - cache=strict
+  secrets:
+    enabled: true
+
+ingress:
+  enabled: true
+  className: public-nginx
+  annotations:
+    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+    "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+  hosts:
+    - host: azure.updates.jenkins.io
+      paths:
+        - path: /
+          backendService: httpd
+  tls:
+    - secretName: updates-jenkins-io-tls
+      hosts:
+        - azure.updates.jenkins.io


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2089993133.

The goal of this PR is to instantiate an `httpd` service for the `azure.updates.jenkins.io` webservice with its own distinct fileshare.

It is a second tentative of delivering #5184 with an additional fixup commit to ensure PV + PVC are created without error and it reverts #5190.

The `httpd` chart does not require (at least for now) a change: we can set up a statically provisioned PVC.

Validations:
- The official AKS documentation was used to set up the attributes: https://learn.microsoft.com/en-us/azure/aks/azure-csi-files-storage-provision#statically-provision-a-volume
- The resulting YAML had been statically verified: 
  - The command `helmfile template -f ./clusters/publick8s.yaml -l name=updates-jenkins-io-httpd > .tmp/uc-httpd.yaml` has been used to generate a local Kubernetes manifest file for ALL objects
  - This file has been linted and validated with the official Kubernetes JSON schemas to ensure all attributes are 👍 
- Then, the triplet secret + PV + PVC had been provisionned in the `default` namespace of `publick8s` using the (stripped from other objects such as `Deployment` file `tmp/uc-httpd.yaml`) with success: the PVC was seen as a 1 Gb  Bound volume!).