### PR TITLE
hotfix(publick8s/updates.jenkins.io) ensure each distinct ingress uses a distinct secret to store their certificates

### DIFF
--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -11,7 +11,7 @@ global:
           - path: /
             backendService: mirrorbits
     tls:
-      - secretName: updates-jenkins-io-tls
+      - secretName: mirrorbits-updates-jenkins-io-tls
         hosts:
           - mirrors.updates.jenkins.io
 

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -11,7 +11,7 @@ global:
           - path: /
             backendService: mirrorbits
     tls:
-      - secretName: mirrorbits-updates-jenkins-io-tls
+      - secretName: updates-jenkins-io-mirrorbits-tls
         hosts:
           - mirrors.updates.jenkins.io
 

--- a/config/updates.jenkins.io_httpd.yaml
+++ b/config/updates.jenkins.io_httpd.yaml
@@ -81,6 +81,6 @@ ingress:
         - path: /
           backendService: httpd
   tls:
-    - secretName: updates-jenkins-io-tls
+    - secretName: httpd-updates-jenkins-io-tls
       hosts:
         - azure.updates.jenkins.io

--- a/config/updates.jenkins.io_httpd.yaml
+++ b/config/updates.jenkins.io_httpd.yaml
@@ -81,6 +81,6 @@ ingress:
         - path: /
           backendService: httpd
   tls:
-    - secretName: httpd-updates-jenkins-io-tls
+    - secretName: updates-jenkins-io-httpd-tls
       hosts:
         - azure.updates.jenkins.io


### PR DESCRIPTION
Fixup of #5192 and #5186

Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2090743133

This PR specifies distinct secret names for cert-manager to store TLS certificates.
It should fix the TLS errors when reaching the services