### PR TITLE
feat: add docs.jenkins.io to publick8s cluster

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -257,3 +257,11 @@ releases:
       - "../config/contributors.jenkins.io.yaml"
     secrets:
       - "../secrets/config/contributors.jenkins.io/secrets.yaml"
+  - name: docs-jenkins-io
+    namespace: docs-jenkins-io
+    chart: jenkins-infra/nginx-website
+    version: 0.1.2
+    values:
+      - "../config/docs.jenkins.io.yaml"
+    secrets:
+      - "../secrets/config/docs.jenkins.io/secrets.yaml"

--- a/config/docs.jenkins.io.yaml
+++ b/config/docs.jenkins.io.yaml
@@ -1,0 +1,56 @@
+---
+ingress:
+  enabled: true
+  className: public-nginx
+  annotations:
+    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+    "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+  hosts:
+    - host: docs.jenkins.io
+      paths:
+        - path: /
+          serviceName: docs-jenkins-io
+    - host: docs.origin.jenkins.io
+      paths:
+        - path: /
+          serviceName: docs-jenkins-io
+  # docs.jenkins.io certificate is managed by Fastly
+  tls:
+    - secretName: docs-jenkins-io-tls
+      hosts:
+        - docs.origin.jenkins.io
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+htmlVolume:
+  azureFile:
+    secretName: docs-jenkins-io-nginx-website
+    shareName: docs-jenkins-io
+    readOnly: true
+
+replicaCount: 2
+
+nodeSelector:
+  kubernetes.io/arch: arm64
+
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: "app.kubernetes.io/name"
+              operator: In
+              values:
+                - docs-jenkins-io
+        topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
This PR adds docs.jenkins.io nginx website release to publick8s cluster.

Secrets added in https://github.com/jenkins-infra/charts-secrets/commit/b2ff9092b64d6b1a7d685f7d724b144a55e31ee5 (private repo).

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3885#issuecomment-2090052823