### PR TITLE
chore(infra.ci.jenkins.io): create azure service principal credentials for docs.jenkins.io

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -513,3 +513,12 @@ jobsDefinition:
         description: "Versioned docs of jenkins.io"
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: true
+        credentials:
+          infraci-docs-jenkins-io-fileshare-service-principal-writer:
+            kind: azure-serviceprincipal
+            azureEnvironmentName: "Azure"
+            clientId: "${DOCS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
+            clientSecret: "${DOCS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET}"
+            description: "docs.jenkins.io File Share Service Principal Writer"
+            subscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
+            tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"


### PR DESCRIPTION
This PR creates an Azure Service Principal credentials in docs.jenkins.io job on infra.ci.jenkins.io so it can be used in pipeline to log in with `az`.

Note: using Service Principal Application ID as source.

Secrets added in https://github.com/jenkins-infra/charts-secrets/commit/b274498850438b91617150b608c9fa624a7527d6 (private repo).

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3885#issuecomment-2090052823