### PR TITLE
feat(infra.ci): remove datadog plugin configuration

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -698,26 +698,6 @@ controller:
           pipelineGraphView:
             showGraphOnBuildPage: true
             showGraphOnJobPage: false # change to true if pipeline-stage-view is removed
-      datadog: |
-        unclassified:
-          datadogGlobalConfiguration:
-            ciInstanceName: "infra.ci.jenkins.io"
-            collectBuildLogs: false
-            emitSecurityEvents: true
-            emitSystemEvents: true
-            enableCiVisibility: true
-            hostname: "infra.ci.jenkins.io"
-            # A list of tags to apply globally to all submissions.
-            globalTags: "controller:infra.ci.jenkins.io"
-            # Refresh Dogstatsd Client when your agent IP changes
-            refreshDogstatsdClient: true
-            reportWith: "DSD"
-            retryLogs: true
-            targetApiURL: "https://api.datadoghq.com/api/"
-            targetHost: "datadog.datadog.svc.cluster.local"
-            targetLogIntakeURL: "https://http-intake.logs.datadoghq.com/v1/input/"
-            targetPort: 8125
-            targetTraceCollectionPort: 8126
       tools-config: |
         tool:
           jdk:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4080#issuecomment-2095863202

removing datadog plugin configuration before removing the plugin with https://github.com/jenkins-infra/docker-jenkins-weekly/pull/1606

no configuration found for datadog on weekly.ci 