### PR TITLE
chore(infra/weekly.ci.jenkins.io): switch default notification URL to Jenkins Classic

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -787,6 +787,10 @@ controller:
               image:
                 logoUrl: "https://infra.ci.jenkins.io/userContent/logos/beekeeper.png"
             logoText: "Jenkins Infra"
+      default-notification-url: |
+        unclassified:
+          defaultDisplayUrlProvider:
+            providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
   sidecars:
     configAutoReload:
       env:

--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -564,10 +564,6 @@ controller:
               image:
                 logoUrl: "https://release.ci.jenkins.io/userContent/logos/buttler_stay_safe.png"
             logoText: "Jenkins Release"
-      default-notification-url: |
-        unclassified:
-          defaultDisplayUrlProvider:
-            providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
   sidecars:
     configAutoReload:
       env:

--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -564,6 +564,10 @@ controller:
               image:
                 logoUrl: "https://release.ci.jenkins.io/userContent/logos/buttler_stay_safe.png"
             logoText: "Jenkins Release"
+      default-notification-url: |
+        unclassified:
+          defaultDisplayUrlProvider:
+            providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
   sidecars:
     configAutoReload:
       env:

--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -233,6 +233,10 @@ controller:
                   }
                 }
               }
+      default-notification-url: |
+        unclassified:
+          defaultDisplayUrlProvider:
+            providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
   sidecars:
     configAutoReload:
       env:


### PR DESCRIPTION
This PR switches the default notification URL of infra.ci.jenkins.io and weekly.ci.jenkins.io from "default" to "Jenkins Classic" so `display/redirect` links redirect to the main build page instead of the less useful pipeline graph view page.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2833#issuecomment-2100635026

