### PR TITLE
feat: add a new ci.jio.agents-1 cluster in AKS

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'cik8s', 'doks', 'doks-public', 'eks-public', 'privatek8s', 'publick8s'
+            values 'cik8s', 'doks', 'doks-public', 'eks-public', 'privatek8s', 'publick8s', 'cijioagents1'
           }
         } // axes
         agent {

--- a/clusters/cijioagents1.yaml
+++ b/clusters/cijioagents1.yaml
@@ -1,0 +1,64 @@
+helmDefaults:
+  atomic: true
+  force: false
+  timeout: 300
+  wait: true
+repositories:
+  # https://github.com/DataDog/helm-charts/
+  - name: datadog
+    url: https://helm.datadoghq.com
+  # https://github.com/jenkins-infra/helm-charts/
+  - name: jenkins-infra
+    url: https://jenkins-infra.github.io/helm-charts
+releases:
+  - name: docker-registry-secrets
+    # This helm chart doesn't create any resources within the namespace specified below.
+    # Specifying a namespace is required by the "needs" feature of helmfile (to allow referencing to this release from others)
+    namespace: default
+    chart: jenkins-infra/docker-registry-secrets
+    version: 0.1.0
+    values:
+      - "../config/docker-registry-secrets.yaml"
+    secrets:
+      - "../secrets/config/docker-registry-secrets/secrets.yaml"
+  - name: datadog
+    needs:
+      - default/docker-registry-secrets
+    namespace: datadog
+    chart: datadog/datadog
+    version: 3.62.0
+    values:
+      - "../config/datadog.yaml.gotmpl"
+      - "../config/datadog_cijioagents1.yaml"
+    secrets:
+      - "../secrets/config/datadog/cijioagents1-secrets.yaml"
+  - name: jenkins-agents
+    needs:
+      - default/docker-registry-secrets
+    namespace: jenkins-agents
+    chart: jenkins-infra/jenkins-kubernetes-agents
+    version: 1.0.0
+    values:
+      - "../config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents1.yaml"
+    secrets:
+      - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
+  - name: jenkins-agents-bom
+    namespace: jenkins-agents-bom
+    chart: jenkins-infra/jenkins-kubernetes-agents
+    version: 1.0.0
+    values:
+      - "../config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents1-bom.yaml"
+    secrets:
+      - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
+  ## TODO: uncomment once chart has tolerations support
+  # - name: artifact-caching-proxy
+  #   namespace: artifact-caching-proxy
+  #   chart: jenkins-infra/artifact-caching-proxy
+  #   version: 1.1.1
+  #   needs:
+  #     - public-nginx-ingress/public-nginx-ingress # Required to expose the proxy
+  #   values:
+  #     - "../config/artifact-caching-proxy__common.yaml"
+  #     - "../config/artifact-caching-proxy_azure-2.yaml"
+  #   secrets:
+  #     - "../secrets/config/artifact-caching-proxy/secrets.yaml"

--- a/config/datadog_cijioagents1.yaml
+++ b/config/datadog_cijioagents1.yaml
@@ -1,0 +1,49 @@
+providers:
+  aks:
+    enabled: true
+datadog:
+  clusterName: 'cijioagents1'
+  env:
+    - name: DD_HOSTNAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+  kubelet:
+    host:
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
+    # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
+    tlsVerify: false
+clusterAgent:
+  image:
+    pullSecrets:
+      - name: "dockerhub-credential"
+  nodeSelector:
+    kubernetes.io/arch: arm64
+    role: applications
+  tolerations:
+    - key: "ci.jenkins.io/applications"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+agents:
+  tolerations:
+    # These tolerations are needed to run the agents on the bom node pool
+    - key: "ci.jenkins.io/bom"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "ci.jenkins.io/applications"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "ci.jenkins.io/agents"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "CriticalAddonsOnly"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"

--- a/config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents1-bom.yaml
+++ b/config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents1-bom.yaml
@@ -1,0 +1,2 @@
+quotas:
+  pods: 150

--- a/config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents1.yaml
+++ b/config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents1.yaml
@@ -1,0 +1,2 @@
+quotas:
+  pods: 150


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3954#issuecomment-2107226189

This PR introduces a new cluster management for the AKS cluster `ci.jenkins.io-agents-1`).

Tested locally: worked once https://github.com/jenkins-infra/azure/pull/698 is applied.

Note: ACP is not yet uncommented as we want to implement tolerations in its chart to allow running in the node pool for arm64