### PR TITLE
feat(ci.jenkins.io-agents-1) initial installation of ACP

### DIFF
--- a/clusters/cijioagents1.yaml
+++ b/clusters/cijioagents1.yaml
@@ -50,15 +50,10 @@ releases:
       - "../config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents1-bom.yaml"
     secrets:
       - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
-  ## TODO: uncomment once chart has tolerations support
-  # - name: artifact-caching-proxy
-  #   namespace: artifact-caching-proxy
-  #   chart: jenkins-infra/artifact-caching-proxy
-  #   version: 1.1.1
-  #   needs:
-  #     - public-nginx-ingress/public-nginx-ingress # Required to expose the proxy
-  #   values:
-  #     - "../config/artifact-caching-proxy__common.yaml"
-  #     - "../config/artifact-caching-proxy_azure-2.yaml"
-  #   secrets:
-  #     - "../secrets/config/artifact-caching-proxy/secrets.yaml"
+  - name: artifact-caching-proxy
+    namespace: artifact-caching-proxy
+    chart: jenkins-infra/artifact-caching-proxy
+    version: 1.1.2
+    values:
+      - "../config/artifact-caching-proxy__common.yaml"
+      - "../config/artifact-caching-proxy_azure-aks.yaml"

--- a/config/artifact-caching-proxy_azure-aks.yaml
+++ b/config/artifact-caching-proxy_azure-aks.yaml
@@ -1,0 +1,24 @@
+persistence:
+  storageClass: managed-csi-premium
+
+nodeSelector:
+  kubernetes.io/arch: arm64
+  jenkins: ci.jenkins.io
+  role: applications
+
+tolerations:
+  - key: "ci.jenkins.io/applications"
+    operator: "Equal"
+    value: "true"
+    effect: "NoSchedule"
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: "app.kubernetes.io/name"
+              operator: In
+              values:
+                - accountapp
+        topologyKey: "kubernetes.io/hostname"

--- a/updatecli/updatecli.d/charts/artifact-caching-proxy.yaml
+++ b/updatecli/updatecli.d/charts/artifact-caching-proxy.yaml
@@ -30,6 +30,7 @@ targets:
         - clusters/doks-public.yaml
         - clusters/eks-public.yaml
         - clusters/publick8s.yaml
+        - clusters/cijioagents1.yaml
       matchpattern: 'chart: jenkins-infra\/artifact-caching-proxy((\r\n|\r|\n)(\s+))version: .*'
       replacepattern: 'chart: jenkins-infra/artifact-caching-proxy${1}version: {{ source "lastChartVersion" }}'
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3954

This PR adds an initial installation of ACP into the new AKS `ci.jenkins.io-agents-1` cluster with the following attributes:

- No ingress (and as such: no need for a secret used to protect external access) as usage is only internal
  - We might need an eventual network access from Azure VM in the near future: to be studied given we use CNI overlay
- ARM64 deployment
- Storage does NOT specify "retain" as we don't care to retain disk if the PV is deleted

Notes:

- Tested once and worked well in production. Cleaned up so this PR will be an auditable initial installation
- The expected internal URL for this service for agents is: `http://artifact-caching-proxy.artifact-caching-proxy:8080`
- Updatecli manifest amended: the check will fail until the PR merged (e.g. I'll be carefull to watch this to completion)