### PR TITLE
feat(privatek8s/infra.ci.jio) allow terraform jobs to publish on reports.jenkins.io

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -248,9 +248,9 @@ jobsDefinition:
     description: Folder hosting all the Terraform-related jobs
     kind: folder
     credentials:
-      infracost-api-key:
-        secret: "${INFRACOST_API_KEY}"
-        description: Infracost API key
+      azure-reports-access-key:
+        description: "Azure Storage Key used by infra-reports to publish to a storage bucket"
+        secret: "${AZURE_INFRA_REPORTS_STORAGE_KEY}"
     children:
       aws:
         name: Terraform AWS


### PR DESCRIPTION
Experiment related to https://github.com/jenkins-infra/helpdesk/issues/4114

Follow up of https://github.com/jenkins-infra/azure-net/pull/245 which fails on the `main` branch with the error `ERROR: Could not find credentials entry with ID 'azure-reports-access-key'` due to missing credential.

This PR  adds the expected credential but scoped to only the Terraform jobs. 
Note it replaces an unused infracost credential.

