### PR TITLE
chore(publick8s/privatek8s) update deprecated CRD configuration for cert-manager 1.15.x

### DIFF
--- a/config/cert-manager.yaml
+++ b/config/cert-manager.yaml
@@ -1,4 +1,8 @@
-installCRDs: true
+crds:
+  # Install CRD as part of the release
+  enabled: true
+  # Keep CRDs when the release is uninstalled (to keep the resources in cluster)
+  keep: true
 webhook:
   # need to be between 1 and 30 for Digital Ocean see https://github.com/jenkins-infra/helpdesk/issues/3948#issuecomment-1948206377
   timeoutSeconds: 25


### PR DESCRIPTION
As per https://github.com/cert-manager/cert-manager/releases/tag/v1.15.0, the value `installCRDs:` is still used but deprecated.

This PR updates our cert-manager configurations to use the new [`crds.enable` and `crds.keep`](https://github.com/cert-manager/cert-manager/pull/6760] values.