### PR TITLE
feat(infracijioagents1): add credential to kubernetes-management

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -114,6 +114,10 @@ jobsDefinition:
             fileName: "kubeconfig"
             description: "Kubeconfig file for cijioagents1"
             secretBytes: "${base64:${KUBECONFIG_CIJIOAGENTS1}}"
+          kubeconfig-infracijioagents1:
+            fileName: "kubeconfig"
+            description: "Kubeconfig file for infracijioagents1"
+            secretBytes: "${base64:${KUBECONFIG_INFRACIJIOAGENTS1}}"
   updatecli:
     name: Dependencies Management with Updatecli
     kind: folder


### PR DESCRIPTION
as per 
- https://github.com/jenkins-infra/helpdesk/issues/3923

adding the secret credential in the kubernetes-management (secrets already added in charts-secrets for infra.ci -- commit [2fcc66d]) 

must precede https://github.com/jenkins-infra/kubernetes-management/pull/5309
