### PR TITLE
feat(publick8s): add `stats.jenkins.io` service

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -265,3 +265,11 @@ releases:
       - "../config/docs.jenkins.io.yaml"
     secrets:
       - "../secrets/config/docs.jenkins.io/secrets.yaml"
+  - name: stats-jenkins-io
+    namespace: stats-jenkins-io
+    chart: jenkins-infra/nginx-website
+    version: 0.1.3
+    values:
+      - "../config/stats.jenkins.io.yaml"
+    secrets:
+      - "../secrets/config/stats.jenkins.io/secrets.yaml"

--- a/config/stats.jenkins.io.yaml
+++ b/config/stats.jenkins.io.yaml
@@ -1,0 +1,51 @@
+---
+ingress:
+  enabled: true
+  className: public-nginx
+  annotations:
+    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+    "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+  hosts:
+    - host: new.stats.jenkins.io
+      paths:
+        - path: /
+          serviceName: stats-jenkins-io
+  tls:
+    - secretName: stats-jenkins-io-tls
+      hosts:
+        - new.stats.jenkins.io
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+htmlVolume:
+  azureFile:
+    secretName: stats-jenkins-io-nginx-website
+    shareName: stats-jenkins-io
+    readOnly: true
+
+replicaCount: 2
+
+nodeSelector:
+  kubernetes.io/arch: arm64
+
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: "app.kubernetes.io/name"
+              operator: In
+              values:
+                - stats-jenkins-io
+        topologyKey: "kubernetes.io/hostname"


### PR DESCRIPTION
This PR adds the stats.jenkins.io service, served on new.stats.jenkins.io until the GSoC project completion, will be migrated to stats.jenkins.io after that.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2167717401