### PR TITLE
fix(pipeline, privatek8s/infra.ci): fix io timeout due to unauthorized network when accessing controlplanes

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -31,7 +31,7 @@ pipeline {
           }
         } // axes
         agent {
-          label 'linux-arm64'
+          label 'jnlp-linux-arm64'
         }
       environment {
         KUBECONFIG            = credentials("kubeconfig-${K8S_CLUSTER}")

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -289,8 +289,7 @@ controller:
             - kubernetes:
                 containerCapStr: "100"
                 credentialsId: "infraci.jenkins.io-agents-1-jenkins-agent-sa-token"
-                serverCertificate: |
-                  "${INFRACIJENKINSIO_AGENTS_1_CACRT}"
+                serverCertificate: "${decodeBase64:${INFRACIJENKINSIO_AGENTS_1_CACRT}}"
                 serverUrl: "https://infracijenkinsioagents1-ns1jeize.hcp.eastus2.azmk8s.io:443"
                 maxRequestsPerHostStr: "300"
                 webSocket: true

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -192,7 +192,7 @@ controller:
                         resourceRequestCpu: "500m"
                         resourceRequestMemory: "512Mi"
                         alwaysPullImage: true
-                    label: "linux-arm64 jnlp-linux-arm64"
+                    label: "jnlp-linux-arm64"
                     yamlMergeStrategy: "merge"
                     yaml: |-
                       apiVersion: v1
@@ -296,13 +296,8 @@ controller:
                 name: "kubernetes_infracijioagents1"
                 namespace: "jenkins-infra-agents"
                 podRetention: "Never"
-                podLabels:
-                  # Required to be jenkins/<helm-release>-jenkins-slave as defined here
-                  # https://github.com/helm/charts/blob/ef0d749132ecfa61b2ea47ccacafeaf5cf1d3d77/stable/jenkins/templates/jenkins-master-networkpolicy.yaml#L27
-                  - key: "jenkins/jenkins-infra-agent"
-                    value: "true"
                 templates:
-                  - name: jnlp-linux-arm64
+                  - name: jnlp-linux-arm64-infracijioagents1
                     nodeSelector: "kubernetes.io/arch=arm64"
                     containers:
                       - name: jnlp
@@ -321,7 +316,7 @@ controller:
                         resourceRequestCpu: "500m"
                         resourceRequestMemory: "512Mi"
                         alwaysPullImage: true
-                    label: "linux-arm64-infracijioagents1"
+                    label: "jnlp-linux-arm64-infracijioagents1"
                     yamlMergeStrategy: "merge"
                     yaml: |-
                       apiVersion: v1


### PR DESCRIPTION
since few weeks we sometime see timeout errors when the pipeline send request to AKS control planes. it appear that the VM agents of infra.ci are not allowed to reach these control planes. This PR is a short term fix to ensure that we are using pod agents on privatek8s only, which are allowed to reach control planes.
note: this PR cleans up labels on both sides: pipeline (requester) and VM agents templates (provider)