### PR TITLE
feat(privatek8s/infra.ci.jenkins.io): create azure service principal credentials for stats.jenkins.io

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -514,3 +514,12 @@ jobsDefinition:
         allowUntrustedChanges: false
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: true
+        credentials:
+          infraci-stats-jenkins-io-fileshare-service-principal-writer:
+            kind: azure-serviceprincipal
+            azureEnvironmentName: "Azure"
+            clientId: "${STATS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
+            clientSecret: "${STATS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET}"
+            description: "stats.jenkins.io File Share Service Principal Writer"
+            subscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
+            tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"


### PR DESCRIPTION
This PR creates an Azure Service Principal credentials in stats.jenkins.io job on infra.ci.jenkins.io so it can be used in pipeline to log in with `az`.

Note: using Service Principal Application ID as source.

Secrets added in https://github.com/jenkins-infra/charts-secrets/commit/67d0e595754f5d0acb991c70c20b4371f182b345 (private repo).

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2167717401