### PR TITLE
feat(infracijioagents1): removing temporarily from management to upgrade to kubernetes 1.28

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'privatek8s', 'publick8s', 'cijioagents1', 'infracijioagents1'
+            values 'privatek8s', 'publick8s', 'cijioagents1'
           }
         } // axes
         agent {


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4144#issuecomment-2178169723

we remove the cluster `infracijioagents1`from the kubenetes-management to handle is upgrade to kubernetes 1.28