### PR TITLE
Revert "feat(infracijioagents1): removing temporarily from management to upgrade to kubernetes 1.28"

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'privatek8s', 'publick8s', 'cijioagents1'
+            values 'privatek8s', 'publick8s', 'cijioagents1', 'infracijioagents1'
           }
         } // axes
         agent {


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#5337

putting back the cluster `infracijioagents1` within kubernetes-management now that it's upgraded to kubernetes 1.28