### PR TITLE
feat(privatek8s/infra.ci.jenkins.io) migrate container agents workload to infracijioagents1

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -126,24 +126,20 @@ controller:
           clouds:
             - kubernetes:
                 containerCapStr: "100"
-                # Controller URL to allow agent to connect to it. Prefers using the Kubernetes Service as an internal URL.
-                jenkinsUrl: "http://jenkins-infra.jenkins-infra.svc.cluster.local:8080"
+                credentialsId: "infraci.jenkins.io-agents-1-jenkins-agent-sa-token"
+                serverCertificate: "${decodeBase64:${INFRACIJENKINSIO_AGENTS_1_CACRT}}"
+                serverUrl: "https://infracijenkinsioagents1-ns1jeize.hcp.eastus2.azmk8s.io:443"
                 maxRequestsPerHostStr: "300"
                 webSocket: true
-                name: "kubernetes"
+                name: "kubernetes_infracijioagents1"
                 namespace: "jenkins-infra-agents"
                 podRetention: "Never"
-                podLabels:
-                  # Required to be jenkins/<helm-release>-jenkins-slave as defined here
-                  # https://github.com/helm/charts/blob/ef0d749132ecfa61b2ea47ccacafeaf5cf1d3d77/stable/jenkins/templates/jenkins-master-networkpolicy.yaml#L27
-                  - key: "jenkins/jenkins-infra-agent"
-                    value: "true"
                 templates:
-                  - name: jnlp-linux
-                    nodeSelector: "kubernetes.io/os=linux"
+                  - name: jnlp-linux-amd64
+                    nodeSelector: "kubernetes.io/arch=amd64"
                     containers:
                       - name: jnlp
-                        image: "jenkins/inbound-agent:latest-jdk17"
+                        image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.73.1"
                         command: "/usr/local/bin/jenkins-agent"
                         args: ""
                         envVars:
@@ -153,12 +149,15 @@ controller:
                         - envVar:
                             key: "JAVA_HOME"
                             value: "/opt/jdk-17"
+                        - envVar:
+                            key: "ARTIFACT_CACHING_PROXY_PROVIDER"
+                            value: "azure"
                         resourceLimitCpu: "500m"
-                        resourceLimitMemory: "512Mi"
+                        resourceLimitMemory: "1024Mi"
                         resourceRequestCpu: "500m"
                         resourceRequestMemory: "512Mi"
                         alwaysPullImage: true
-                    label: "linux jnlp-linux"
+                    label: "linux jnlp-linux jnlp-linux-amd64"
                     yamlMergeStrategy: "merge"
                     yaml: |-
                       apiVersion: v1
@@ -169,9 +168,9 @@ controller:
                           operator: "Equal"
                           value: "infra.ci.jenkins.io"
                           effect: "NoSchedule"
-                        - key: "kubernetes.azure.com/scalesetpriority"
+                        - key: "infra.ci.jenkins.io/agents"
                           operator: "Equal"
-                          value: "spot"
+                          value: "true"
                           effect: "NoSchedule"
                   - name: jnlp-linux-arm64
                     nodeSelector: "kubernetes.io/arch=arm64"
@@ -187,6 +186,9 @@ controller:
                         - envVar:
                             key: "JAVA_HOME"
                             value: "/opt/jdk-17"
+                        - envVar:
+                            key: "ARTIFACT_CACHING_PROXY_PROVIDER"
+                            value: "azure"
                         resourceLimitCpu: "500m"
                         resourceLimitMemory: "1024Mi"
                         resourceRequestCpu: "500m"
@@ -203,67 +205,21 @@ controller:
                           operator: "Equal"
                           value: "infra.ci.jenkins.io"
                           effect: "NoSchedule"
-                        - key: "kubernetes.azure.com/scalesetpriority"
-                          operator: "Equal"
-                          value: "spot"
-                          effect: "NoSchedule"
                         - key: "kubernetes.io/arch"
                           operator: "Equal"
                           value: "arm64"
                           effect: "NoSchedule"
-                  - name: jnlp-windows
-                    nodeSelector: "kubernetes.io/os=windows"
-                    instanceCap: 5 # Usual sizing is 2 pods per Windows node, and max 3 windows nodes
-                    instanceCapStr: "5"
+                        - key: "infra.ci.jenkins.io/agents"
+                          operator: "Equal"
+                          value: "true"
+                          effect: "NoSchedule"
+                  - name: jnlp-webbuilder
+                    nodeSelector: "kubernetes.io/arch=amd64"
                     containers:
                       - name: jnlp
-                        image: "jenkinsciinfra/inbound-agent:windowsservercore-1809"
-                        envVars:
-                        - envVar:
-                            key: "JENKINS_JAVA_BIN"
-                            value: "C:/openjdk-17"
-                        - envVar:
-                            key: "JAVA_HOME"
-                            value: "C:/openjdk-17"
-                        command: "powershell"
-                        args: "C:/ProgramData/Jenkins/jenkins-agent.ps1"
-                        resourceLimitCpu: "1"
-                        resourceLimitMemory: "1024Mi"
-                        resourceRequestCpu: "1"
-                        resourceRequestMemory: "1024Mi"
-                        alwaysPullImage: true
-                        workingDir: "C:\\Users\\jenkins"
-                    yamlMergeStrategy: "merge"
-                    label: "windows-2019-kubernetes"
-                    yaml: |-
-                      affinity:
-                        nodeAffinity:
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            nodeSelectorTerms:
-                            - matchExpressions:
-                              - key: kubernetes.io/os
-                                operator: In
-                                values:
-                                  - windows
-                  - name: "jnlp-webbuilder"
-                    nodeSelector: "kubernetes.io/os=linux"
-                    yaml: |-
-                      apiVersion: v1
-                      kind: Pod
-                      spec:
-                        tolerations:
-                        - key: "jenkins"
-                          operator: "Equal"
-                          value: "infra.ci.jenkins.io"
-                          effect: "NoSchedule"
-                        - key: "kubernetes.azure.com/scalesetpriority"
-                          operator: "Equal"
-                          value: "spot"
-                          effect: "NoSchedule"
-                    containers:
-                      - name: "jnlp"
                         image: "jenkinsciinfra/builder@sha256:7150f769249c071fec7ee18338183193c36d489dc9a2fb2d211242fcc89350cd"
                         command: "/usr/local/bin/jenkins-agent"
+                        args: ""
                         envVars:
                         - envVar:
                             key: "JENKINS_JAVA_OPTS"
@@ -284,39 +240,8 @@ controller:
                         resourceLimitMemory: "8G"
                         resourceRequestCpu: "4"
                         resourceRequestMemory: "8G"
-                    label: "container kubernetes node ruby webbuilder"
-                    yamlMergeStrategy: "merge"
-            - kubernetes:
-                containerCapStr: "100"
-                credentialsId: "infraci.jenkins.io-agents-1-jenkins-agent-sa-token"
-                serverCertificate: "${decodeBase64:${INFRACIJENKINSIO_AGENTS_1_CACRT}}"
-                serverUrl: "https://infracijenkinsioagents1-ns1jeize.hcp.eastus2.azmk8s.io:443"
-                maxRequestsPerHostStr: "300"
-                webSocket: true
-                name: "kubernetes_infracijioagents1"
-                namespace: "jenkins-infra-agents"
-                podRetention: "Never"
-                templates:
-                  - name: jnlp-linux-arm64-infracijioagents1
-                    nodeSelector: "kubernetes.io/arch=arm64"
-                    containers:
-                      - name: jnlp
-                        image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.73.1"
-                        command: "/usr/local/bin/jenkins-agent"
-                        args: ""
-                        envVars:
-                        - envVar:
-                            key: "JENKINS_JAVA_BIN"
-                            value: "/opt/jdk-17/bin/java"
-                        - envVar:
-                            key: "JAVA_HOME"
-                            value: "/opt/jdk-17"
-                        resourceLimitCpu: "500m"
-                        resourceLimitMemory: "1024Mi"
-                        resourceRequestCpu: "500m"
-                        resourceRequestMemory: "512Mi"
                         alwaysPullImage: true
-                    label: "jnlp-linux-arm64-infracijioagents1"
+                    label: "container kubernetes node ruby webbuilder"
                     yamlMergeStrategy: "merge"
                     yaml: |-
                       apiVersion: v1
@@ -326,10 +251,6 @@ controller:
                         - key: "jenkins"
                           operator: "Equal"
                           value: "infra.ci.jenkins.io"
-                          effect: "NoSchedule"
-                        - key: "kubernetes.io/arch"
-                          operator: "Equal"
-                          value: "arm64"
                           effect: "NoSchedule"
                         - key: "infra.ci.jenkins.io/agents"
                           operator: "Equal"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3923

This PR migrates the container agents workloads of infra.ci.jenkins.io to the new `infracijio-agent-1` cluster

Note: 

- The agent pod template `jnlp-windows` is removed as we do not have Windows Node pool on the new cluster (and it is not used: we use Windows Azure VM if needed)
- The agent pod template `jnlp-linux` is renamed to `jnlp-linux-amd64`. It keeps the same labels as before + addition label `jnlp-linux-amd64`
- The env. var `ARTIFACT_CACHING_PROXY_PROVIDER` is added to `jnlp-linux-amd64` and `jnlp-linux-arm64`