### PR TITLE
cleanup(privatek8s) remove unused infra.ci agent setup

### DIFF
--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -61,14 +61,6 @@ releases:
       - "../config/jenkins_infra.ci.jenkins.io.yaml"
     secrets:
       - "../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml"
-  - name: jenkins-infra-agents
-    namespace: jenkins-infra-agents
-    chart: jenkins-infra/jenkins-kubernetes-agents
-    version: 1.0.0
-    values:
-      - "../config/jenkins-infra-agents-privatek8s.yaml"
-    secrets:
-      - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
   - name: jenkins-infra-jobs
     namespace: jenkins-infra
     chart: jenkins-infra/jenkins-jobs

--- a/config/datadog_infracijioagents1.yaml
+++ b/config/datadog_infracijioagents1.yaml
@@ -22,8 +22,9 @@ clusterAgent:
       - name: "dockerhub-credential"
   nodeSelector:
     kubernetes.io/arch: arm64
-    agentpool: systempool1 # select the system pool not on agent pools
-  tolerations: # allow to start on system nodepool
+    agentpool: systempool1
+  # allow to start on system nodepool
+  tolerations:
     - key: "CriticalAddonsOnly"
       operator: "Equal"
       value: "true"

--- a/config/jenkins-infra-agents-privatek8s.yaml
+++ b/config/jenkins-infra-agents-privatek8s.yaml
@@ -1,1 +1,0 @@
-existingServiceAccount: jenkins-infra:jenkins-infra-controller

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -109,12 +109,6 @@ controller:
                     password: "${AZURE_LOGIN_VM_PASS}"
                     scope: SYSTEM
                     username: "${AZURE_LOGIN_VM_USER}"
-                - file:
-                    fileName: "kubeconfig"
-                    id: "kubeconfig-controller"
-                    description: "Kubeconfig file for privatek8s"
-                    scope: SYSTEM
-                    secretBytes: "${base64:${KUBECONFIG_PRIVATEK8S}}"
                 - string:
                     description: "Token of the Service Account account 'jenkins-agent' on the Kubernetes cluster 'infraci.jenkins.io-agents-1'"
                     id: "infraci.jenkins.io-agents-1-jenkins-agent-sa-token"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3923

This PR removes the following elements:

- (now) unused namespace for infra.ci agents (as they moved to another cluster)
- A unused top-level credential for infra.ci
- lint warnings

Note: once applied, this PR will require the namespace to be deleted with: `kubectl delete ns jenkins-infra-agents`