### PR TITLE
feat: add dedicated `stats.jenkins.io` PR previews job

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -524,6 +524,7 @@ jobsDefinition:
         allowUntrustedChanges: false
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: false
+        branchIncludes: main
         credentials:
           infraci-stats-jenkins-io-fileshare-service-principal-writer:
             kind: azure-serviceprincipal

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -509,11 +509,21 @@ jobsDefinition:
             description: "docs.jenkins.io File Share Service Principal Writer"
             subscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
             tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
+      stats.jenkins.io_previews:
+        name: stats.jenkins.io PR previews
+        allowUntrustedChanges: true
+        jenkinsfilePath: Jenkinsfile_previews
+        enableGitHubChecks: true
+  website-production-jobs:
+    name: Website Production Jobs
+    description: "Folder hosting all the Website jobs dedicated to deployment in production"
+    kind: folder
+    children:
       stats.jenkins.io:
         name: stats.jenkins.io
         allowUntrustedChanges: false
         jenkinsfilePath: Jenkinsfile
-        enableGitHubChecks: true
+        enableGitHubChecks: false
         credentials:
           infraci-stats-jenkins-io-fileshare-service-principal-writer:
             kind: azure-serviceprincipal
@@ -523,8 +533,3 @@ jobsDefinition:
             description: "stats.jenkins.io File Share Service Principal Writer"
             subscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
             tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
-      stats.jenkins.io_previews:
-        name: stats.jenkins.io PR previews
-        allowUntrustedChanges: true
-        jenkinsfilePath: Jenkinsfile_previews
-        enableGitHubChecks: true

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -509,11 +509,12 @@ jobsDefinition:
             description: "docs.jenkins.io File Share Service Principal Writer"
             subscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
             tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
-      stats.jenkins.io_previews:
+      stats.jenkins.io:
         name: stats.jenkins.io PR previews
         allowUntrustedChanges: true
         jenkinsfilePath: Jenkinsfile_previews
         enableGitHubChecks: true
+        disableTagDiscovery: true
   website-production-jobs:
     name: Website Production Jobs
     description: "Folder hosting all the Website jobs dedicated to deployment in production"
@@ -525,6 +526,7 @@ jobsDefinition:
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: false
         branchIncludes: main
+        disableTagDiscovery: true
         credentials:
           infraci-stats-jenkins-io-fileshare-service-principal-writer:
             kind: azure-serviceprincipal

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -523,3 +523,8 @@ jobsDefinition:
             description: "stats.jenkins.io File Share Service Principal Writer"
             subscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
             tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
+      stats.jenkins.io_previews:
+        name: stats.jenkins.io PR previews
+        allowUntrustedChanges: true
+        jenkinsfilePath: Jenkinsfile_previews
+        enableGitHubChecks: true


### PR DESCRIPTION
This PR adds a stats.jenkins.io job dedicated to previews so it can be triggered by any contributor even if they don't have write permission on stats.jenkins.io repository.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2185272935