### PR TITLE
feat(cijioagents1): removing temporarily from management to upgrade to Kubernetes 1.28

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'privatek8s', 'publick8s', 'cijioagents1', 'infracijioagents1'
+            values 'privatek8s', 'publick8s', 'infracijioagents1'
           }
         } // axes
         agent {


### PR DESCRIPTION
Removing cjioagents1 cluster from kub management to proceed with kub 1.28 upgrade.