### PR TITLE
Revert "feat(cijioagents1): removing temporarily from management to upgrade to Kubernetes 1.28"

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'privatek8s', 'publick8s', 'infracijioagents1'
+            values 'privatek8s', 'publick8s', 'cijioagents1', 'infracijioagents1'
           }
         } // axes
         agent {


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#5348 as per https://github.com/jenkins-infra/helpdesk/issues/4144#issuecomment-2182701643

cijioagents1 cluster is added back to kubernetes management as it has been upgraded to kub 1.28.