### PR TITLE
chore(privatek8s/infra.ci.jenkins.io): exclude build from main for stats.jenkins.io PR previews job

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -515,6 +515,7 @@ jobsDefinition:
         jenkinsfilePath: Jenkinsfile_previews
         enableGitHubChecks: true
         disableTagDiscovery: true
+        branchExcludes: main
   website-production-jobs:
     name: Website Production Jobs
     description: "Folder hosting all the Website jobs dedicated to deployment in production"


### PR DESCRIPTION
This PR excludes build from main for stats.jenkins.io PR previews job.

Testing done:
`helmfile diff -f clusters/privatek8s.yaml -l name=jenkins-infra-jobs`
```diff
                        // Select branches and tags to build based on these filters
                        headWildcardFilterWithPR {
                          includes('main master PR-*') // only branches listed here
-                         excludes('')
+                         excludes('main')
                          tagIncludes('*')
                          tagExcludes('')
                        }
```

Follow-up of:
- #5345
- #5349

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2186365838