### PR TITLE
chore(privatek8s/infra.ci.jenkins.io): new websites File Share service principal writer credential names

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -441,7 +441,7 @@ jobsDefinition:
           algolia-plugins-write-key:
             secret: "${ALGOLIA_PLUGINS_JENKINS_IO_WRITE_KEY}"
             description: "Algolia credentials to write data for plugin site"
-          # TODO: remove after credentials renaming in contributor-spotlight pipeline
+          # TODO: remove after credentials renaming in plugin-site pipeline
           infraci-pluginsjenkinsio-fileshare-service-principal-writer:
             kind: azure-serviceprincipal
             azureEnvironmentName: "Azure"
@@ -516,7 +516,7 @@ jobsDefinition:
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: true
         credentials:
-          # TODO: remove after credentials renaming in contributor-spotlight pipeline
+          # TODO: remove after credentials renaming in docs.jenkins.io pipeline
           infraci-docs-jenkins-io-fileshare-service-principal-writer:
             kind: azure-serviceprincipal
             azureEnvironmentName: "Azure"
@@ -552,7 +552,7 @@ jobsDefinition:
         branchIncludes: main
         disableTagDiscovery: true
         credentials:
-          # TODO: remove after credentials renaming in contributor-spotlight pipeline
+          # TODO: remove after credentials renaming in stats.jenkins.io pipeline
           infraci-stats-jenkins-io-fileshare-service-principal-writer:
             kind: azure-serviceprincipal
             azureEnvironmentName: "Azure"

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -441,7 +441,7 @@ jobsDefinition:
           algolia-plugins-write-key:
             secret: "${ALGOLIA_PLUGINS_JENKINS_IO_WRITE_KEY}"
             description: "Algolia credentials to write data for plugin site"
-          infraci-pluginsjenkinsio-fileshare-service-principal-writer:
+          infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer:
             kind: azure-serviceprincipal
             azureEnvironmentName: "Azure"
             clientId: "${INFRACI_PLUGINSJENKINSIO_FILESHARE_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
@@ -487,7 +487,7 @@ jobsDefinition:
           contributors-jenkins-io-fileshare-sas-querystring:
             secret: "${CONTRIBUTORS_JENKINS_IO_FILESHARE_SAS_QUERYSTRING}"
             description: "File Share SAS query string to update contributors.jenkins.io content"
-          contributors-jenkins-io-fileshare-service-principal-writer:
+          infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer:
             kind: azure-serviceprincipal
             azureEnvironmentName: "Azure"
             clientId: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
@@ -501,7 +501,7 @@ jobsDefinition:
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: true
         credentials:
-          infraci-docs-jenkins-io-fileshare-service-principal-writer:
+          infraci_docsjenkinsio_fileshare_serviceprincipal_writer:
             kind: azure-serviceprincipal
             azureEnvironmentName: "Azure"
             clientId: "${DOCS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
@@ -528,7 +528,7 @@ jobsDefinition:
         branchIncludes: main
         disableTagDiscovery: true
         credentials:
-          infraci-stats-jenkins-io-fileshare-service-principal-writer:
+          infraci_statsjenkinsio_fileshare_serviceprincipal_writer:
             kind: azure-serviceprincipal
             azureEnvironmentName: "Azure"
             clientId: "${STATS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -441,6 +441,15 @@ jobsDefinition:
           algolia-plugins-write-key:
             secret: "${ALGOLIA_PLUGINS_JENKINS_IO_WRITE_KEY}"
             description: "Algolia credentials to write data for plugin site"
+          # TODO: remove after credentials renaming in contributor-spotlight pipeline
+          infraci-pluginsjenkinsio-fileshare-service-principal-writer:
+            kind: azure-serviceprincipal
+            azureEnvironmentName: "Azure"
+            clientId: "${INFRACI_PLUGINSJENKINSIO_FILESHARE_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
+            clientSecret: "${INFRACI_PLUGINSJENKINSIO_FILESHARE_SERVICE_PRINCIPAL_WRITER_PASSWORD}"
+            description: "plugins.jenkins.io File Share Service Principal Writer"
+            subscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
+            tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
           infraci_pluginsjenkinsio_fileshare_serviceprincipal_writer:
             kind: azure-serviceprincipal
             azureEnvironmentName: "Azure"
@@ -484,6 +493,15 @@ jobsDefinition:
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: true
         credentials:
+          # TODO: remove after credentials renaming in contributor-spotlight pipeline
+          contributors-jenkins-io-fileshare-service-principal-writer:
+            kind: azure-serviceprincipal
+            azureEnvironmentName: "Azure"
+            clientId: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
+            clientSecret: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET}"
+            description: "Contributors.jenkins.io File Share Service Principal Writer"
+            subscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
+            tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
           infraci_contributorsjenkinsio_fileshare_serviceprincipal_writer:
             kind: azure-serviceprincipal
             azureEnvironmentName: "Azure"
@@ -498,6 +516,15 @@ jobsDefinition:
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: true
         credentials:
+          # TODO: remove after credentials renaming in contributor-spotlight pipeline
+          infraci-docs-jenkins-io-fileshare-service-principal-writer:
+            kind: azure-serviceprincipal
+            azureEnvironmentName: "Azure"
+            clientId: "${DOCS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
+            clientSecret: "${DOCS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET}"
+            description: "docs.jenkins.io File Share Service Principal Writer"
+            subscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
+            tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
           infraci_docsjenkinsio_fileshare_serviceprincipal_writer:
             kind: azure-serviceprincipal
             azureEnvironmentName: "Azure"
@@ -525,6 +552,15 @@ jobsDefinition:
         branchIncludes: main
         disableTagDiscovery: true
         credentials:
+          # TODO: remove after credentials renaming in contributor-spotlight pipeline
+          infraci-stats-jenkins-io-fileshare-service-principal-writer:
+            kind: azure-serviceprincipal
+            azureEnvironmentName: "Azure"
+            clientId: "${STATS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
+            clientSecret: "${STATS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET}"
+            description: "stats.jenkins.io File Share Service Principal Writer"
+            subscriptionId: "${JENKINSINFRA_AZURE_PRIMARY_SUBSCRIPTION_ID}"
+            tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
           infraci_statsjenkinsio_fileshare_serviceprincipal_writer:
             kind: azure-serviceprincipal
             azureEnvironmentName: "Azure"


### PR DESCRIPTION
This PR renames website File Share service principal writer credentials so they're the same than the ones used in https://github.com/jenkins-infra/azure/blob/91b75632186a6ab529a858166de84456bf1e87dd/updatecli/values.yaml to ensure consistency and avoid mistakes.

EDIT: duplicating them as a first step, will remove duplicated credentials after updating consumers pipelines.

Follow-up of:
- https://github.com/jenkins-infra/azure/pull/754

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4149