### PR TITLE
cleanup(privatek8s/infra.ci.jenkins.io): remove unused contributors SAS querystring credentials

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -484,9 +484,6 @@ jobsDefinition:
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: true
         credentials:
-          contributors-jenkins-io-fileshare-sas-querystring:
-            secret: "${CONTRIBUTORS_JENKINS_IO_FILESHARE_SAS_QUERYSTRING}"
-            description: "File Share SAS query string to update contributors.jenkins.io content"
           contributors-jenkins-io-fileshare-service-principal-writer:
             kind: azure-serviceprincipal
             azureEnvironmentName: "Azure"


### PR DESCRIPTION
This PR removes a credentials replaced by https://github.com/jenkins-infra/kubernetes-management/pull/4894.

A follow-up pull request will be opened to cleanup this from charts-secrets repo too.