### PR TITLE
Revert "feat(privatek8s): Removing temporarily from management to upgrade to kub 1.28"

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'publick8s', 'cijioagents1', 'infracijioagents1'
+            values 'privatek8s', 'publick8s', 'cijioagents1', 'infracijioagents1'
           }
         } // axes
         agent {


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4144#issuecomment-2190936375

Reverts jenkins-infra/kubernetes-management#5353 as cluster is upgraded to kub 1.28