### PR TITLE
feat(privatek8s/infra.ci.jenkins.io) bump image version to `1.48.1-2.464`

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -28,7 +28,7 @@ controller:
     supplementalGroups: [1000]
   image:
     repository: jenkinsciinfra/jenkins-weekly
-    tag: 1.48.0-2.464
+    tag: 1.48.1-2.464
     pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux


### PR DESCRIPTION
Ref. https://www.jenkins.io/security/advisory/2024-06-26/

Manual apply as there are not automation