### PR TITLE
feat(jenkins-weekly) migrate from premium to standard ZRS volume already provisionned by terraform azure

### DIFF
--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -8,11 +8,7 @@ rbac:
   readSecrets: true
 persistence:
   enabled: true
-  size: 8Gi
-  storageClass: managed-csi-premium-zrs-retain
-  dataSource:
-    name: jenkins-weekly-snap
-    kind: PersistentVolumeClaim
+  existingClaim: jenkins-weekly-data
 agent:
   componentName: "agent"
 networkPolicy:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4044

this will follow the data migration done by temporary pod

the existingClaim is getting precedence with home-pvc.yaml creation 

see: 
	- https://github.com/jenkinsci/helm-charts/blob/fac862d10e311fda6c9df2b695754f482f7e4641/charts/jenkins/templates/jenkins-controller-statefulset.yaml#L395

and
	- https://github.com/jenkinsci/helm-charts/blob/fac862d10e311fda6c9df2b695754f482f7e4641/charts/jenkins/templates/home-pvc.yaml#L2

local diff looks good

```
jenkins-weekly, jenkins-weekly, Secret (v1) has changed:
+ Changes suppressed on sensitive content of type Secret
jenkins-weekly, jenkins-weekly, StatefulSet (apps) has changed:
...
        - name: jenkins-home
          persistentVolumeClaim:
-           claimName: jenkins-weekly
+           claimName: jenkins-weekly-data
        - name: sc-config-volume
          emptyDir: {}
...
jenkins-weekly, jenkins-weekly-additional-secrets, Secret (v1) has changed:
+ Changes suppressed on sensitive content of type Secret
jenkins-weekly, jenkins-weekly, PersistentVolumeClaim (v1) has been removed:
- # Source: jenkins/templates/home-pvc.yaml
- kind: PersistentVolumeClaim
- apiVersion: v1
- metadata:
-   name: jenkins-weekly
-   namespace: jenkins-weekly
-   labels:
-     "app.kubernetes.io/name": 'jenkins'
-     "helm.sh/chart": "jenkins-5.3.3"
-     "app.kubernetes.io/managed-by": "Helm"
-     "app.kubernetes.io/instance": "jenkins-weekly"
-     "app.kubernetes.io/component": "jenkins-controller"
- spec:
-   dataSource:
-     kind: PersistentVolumeClaim
-     name: jenkins-weekly-snap
-   accessModes:
-     - "ReadWriteOnce"
-   resources:
-     requests:
-       storage: "8Gi"
-   storageClassName: "managed-csi-premium-zrs-retain"
+
```