### PR TITLE
Revert "feat(publick8s): Removing temporarily from management to upgrade to kub 1.28"

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'privatek8s', 'cijioagents1', 'infracijioagents1'
+            values 'privatek8s', 'publick8s', 'cijioagents1', 'infracijioagents1'
           }
         } // axes
         agent {


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4144#issuecomment-2196274746:

Reverts jenkins-infra/kubernetes-management#5385, as cluster is upgraded to kub 1.28