### PR TITLE
feat(publick8s) decrease resource requests to pack more pods

### DIFF
--- a/config/accountapp.yaml
+++ b/config/accountapp.yaml
@@ -26,8 +26,8 @@ resources:
     cpu: 2000m
     memory: 1024Mi
   requests:
-    cpu: 500m
-    memory: 512Mi
+    cpu: 100m
+    memory: 256Mi
 smtp:
   server: smtp.mailgun.org
   sender: accounts@jenkins.io

--- a/config/contributors.jenkins.io.yaml
+++ b/config/contributors.jenkins.io.yaml
@@ -25,8 +25,8 @@ resources:
     cpu: 200m
     memory: 256Mi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 50m
+    memory: 32Mi
 htmlVolume:
   azureFile:
     secretName: contributors-jenkins-io-nginx-website

--- a/config/docs.jenkins.io.yaml
+++ b/config/docs.jenkins.io.yaml
@@ -25,8 +25,8 @@ resources:
     cpu: 200m
     memory: 256Mi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 50m
+    memory: 64Mi
 htmlVolume:
   azureFile:
     secretName: docs-jenkins-io-nginx-website

--- a/config/get-jenkins-io.yaml
+++ b/config/get-jenkins-io.yaml
@@ -71,7 +71,7 @@ mirrorbits:
       cpu: 2
       memory: 2048Mi
     requests:
-      cpu: 500m
+      cpu: 100m
       memory: 500Mi
   nodeSelector:
     kubernetes.io/arch: amd64

--- a/config/javadoc.yaml
+++ b/config/javadoc.yaml
@@ -22,7 +22,7 @@ resources:
     cpu: 200m
     memory: 256Mi
   requests:
-    cpu: 100m
+    cpu: 50m
     memory: 128Mi
 htmlVolume:
   azureFile:

--- a/config/jenkinsio.yaml
+++ b/config/jenkinsio.yaml
@@ -53,7 +53,7 @@ resources:
     cpu: 500m
     memory: 512Mi
   requests:
-    cpu: 100m
+    cpu: 50m
     memory: 128Mi
 
 htmlVolume:

--- a/config/reports.yaml
+++ b/config/reports.yaml
@@ -18,8 +18,8 @@ resources:
     cpu: 200m
     memory: 256Mi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 20m
+    memory: 32Mi
 htmlVolume:
   azureFile:
     secretName: reports

--- a/config/stats.jenkins.io.yaml
+++ b/config/stats.jenkins.io.yaml
@@ -20,8 +20,8 @@ resources:
     cpu: 200m
     memory: 256Mi
   requests:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 20m
+    memory: 32Mi
 htmlVolume:
   azureFile:
     secretName: stats-jenkins-io-nginx-website

--- a/config/updates.jenkins.io_httpd.yaml
+++ b/config/updates.jenkins.io_httpd.yaml
@@ -4,8 +4,8 @@ resources:
     cpu: 1000m
     memory: 2048Mi
   requests:
-    cpu: 200m
-    memory: 500Mi
+    cpu: 50m
+    memory: 400Mi
 nodeSelector:
   kubernetes.io/arch: arm64
 tolerations:


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/3837, we saw in datadog that the "real life" usage of most of the arm64 services is way below the resource requests.

This PR optimizes this to ensure we can pack more per nodes on arm64