### PR TITLE
feat(privatek8s/infra.ci) add docker-keycloak-theme job and remove (unused) docker-plugins-self-service

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -39,12 +39,12 @@ jobsDefinition:
       docker-inbound-agents:
       docker-jenkins-lts:
       docker-jenkins-weekly:
+      docker-keycloak-theme:
       docker-ldap:
       docker-mirrorbits:
       docker-openvpn:
       docker-packaging:
       docker-plugin-site-issues:
-      docker-plugins-self-service:
       docker-rsyncd:
       ircbot:
         jenkinsfilePath: Jenkinsfile


### PR DESCRIPTION
- https://github.com/jenkins-infra/helpdesk/issues/3837 requires the `docker-keycloak-theme` image to be built with `arm64`
- `docker-plugins-self-service` generates builds on infra.ci but is never used.