### PR TITLE
feat(publick8s/keycloak) migrate to arm64

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -71,7 +71,6 @@ releases:
     namespace: falco
     chart: falco/falco
     version: 4.6.0
-    timeout: 600
     values:
       - "../config/falco.yaml"
   - name: artifact-caching-proxy
@@ -120,7 +119,6 @@ releases:
     namespace: ldap
     chart: jenkins-infra/ldap
     version: 1.1.1
-    timeout: 600
     values:
       - "../config/ldap.yaml"
     secrets:
@@ -129,7 +127,6 @@ releases:
     namespace: keycloak
     chart: codecentric/keycloak
     version: 18.4.4
-    timeout: 600
     values:
       - "../config/keycloak.yaml"
     needs:
@@ -169,7 +166,6 @@ releases:
     namespace: uplink
     chart: jenkins-infra/uplink
     version: 0.3.3
-    timeout: 600
     values:
       - "../config/uplink.yaml"
     secrets:

--- a/config/keycloak.yaml
+++ b/config/keycloak.yaml
@@ -27,7 +27,7 @@ resources:
 replicas: 1
 
 nodeSelector:
-  kubernetes.io/arch: amd64
+  kubernetes.io/arch: arm64
 
 extraInitContainers: |
   - name: theme-provider

--- a/config/keycloak.yaml
+++ b/config/keycloak.yaml
@@ -76,8 +76,3 @@ extraEnvFrom: |
       name: '{{ include "keycloak.fullname" . }}-db'
   - secretRef:
       name: '{{ include "keycloak.fullname" . }}-http'
-
-service:
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9990"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3837

This PR migrates Keycloak to `arm64` nodes.

- Both container images are availabe in `arm64`:
  - https://quay.io/repository/keycloak/keycloak?tab=tags&tag=17.0.1-legacy
  - https://hub.docker.com/layers/jenkinsciinfra/keycloak-theme/0.1.1/images/sha256-eb982ad10e437c95e837d0035afb3c0e9212c39564fb54e2ba68d0131dd4fda5?context=explore