### PR TITLE
chore: add `aws` as updatecli job children

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -157,6 +157,9 @@ jobsDefinition:
       stats.jenkins.io:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
+      aws:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
   other-jobs:
     name: Other Jobs
     description: Folder hosting all the jobs not fitting any category


### PR DESCRIPTION
This PR complements (and needs) https://github.com/jenkins-infra/aws/pull/558.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2778