### PR TITLE
chore: add all jenkins-infra repositories containing an updatecli folder to `updatecli` jobs on infra.ci.jenkins.io

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -188,6 +188,7 @@ jobsDefinition:
       helm-charts:
         name: Helm Charts
         description: Custom Helm Charts of the Jenkins Infra
+        jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
       infra-reports:
         jenkinsfilePath: Jenkinsfile_updatecli

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -232,9 +232,6 @@ jobsDefinition:
       status:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
-      terraform-states:
-        jenkinsfilePath: Jenkinsfile_updatecli
-        disableTagDiscovery: true
   other-jobs:
     name: Other Jobs
     description: Folder hosting all the jobs not fitting any category

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -155,6 +155,15 @@ jobsDefinition:
       docker-inbound-agents:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
+      docker-jenkins-infraci:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      docker-jenkins-lts:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      docker-jenkins-weeklyci:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
       docker-ldap:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -122,10 +122,80 @@ jobsDefinition:
     name: Dependencies Management with Updatecli
     kind: folder
     children:
+      aws:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      azure:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      azure-net:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      contributor-spotlight:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      cloudflare:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      datadog:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      digitalocean:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      docker-404:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      docker-builder:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      docker-confluence-data:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      docker-inbound-agents:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      docker-ldap:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      docker-matomo:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      docker-mirrorbits:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      docker-openvpn:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      docker-packaging:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      docker-rsyncd:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      fastly:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      helm-charts:
+        name: Helm Charts
+        description: Custom Helm Charts of the Jenkins Infra
+        disableTagDiscovery: true
+      infra-reports:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      jenkins-contribution-stats:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
       jenkins-infra:
         name: Puppet (jenkins-infra)
         jenkinsfilePath: Jenkinsfile_updatecli
         branchIncludes: "production staging updatecli_* PR-* main"
+        disableTagDiscovery: true
+      jenkins-version:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      jenkins.io:
+        jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
       kubernetes-management:
         jenkinsfilePath: Jenkinsfile_updatecli
@@ -141,20 +211,19 @@ jobsDefinition:
       packer-images:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
-      helm-charts:
-        name: Helm Charts
-        description: Custom Helm Charts of the Jenkins Infra
-        disableTagDiscovery: true
-      azure:
+      release:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
-      infra-reports:
-        jenkinsfilePath: Jenkinsfile_updatecli
-        disableTagDiscovery: true
-      contributor-spotlight:
+      shared-tools:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
       stats.jenkins.io:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      status:
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
+      terraform-states:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
   other-jobs:


### PR DESCRIPTION
This PR adds all jenkins-infra repositories containing an updatecli folder to `updatecli` jobs on infra.ci.jenkins.io.

Supersedes:
- #5413
- #5415

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2778