### PR TITLE
fix(privatek8s) use the correct 'splitted' images for infra.ci and weekly.ci

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -23,8 +23,8 @@ controller:
     runAsNonRoot: true
     supplementalGroups: [1000]
   image:
-    repository: jenkinsciinfra/jenkins-weekly
-    tag: 1.49.0-2.466
+    repository: jenkinsciinfra/jenkins-infraci
+    tag: 2.0.0-2.466
     pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux

--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -19,8 +19,8 @@ networkPolicy:
       name: "jenkins-weekly"
 controller:
   image:
-    repository: jenkinsciinfra/jenkins-weekly
-    tag: 1.49.1-2.466-weeklyci
+    repository: jenkinsciinfra/jenkins-weeklyci
+    tag: 2.0.0-2.466
     pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/arch: arm64

--- a/updatecli/updatecli.d/docker-images/jenkins-weekly_infra.ci.jenkins.io.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-weekly_infra.ci.jenkins.io.yaml
@@ -17,17 +17,17 @@ sources:
     name: "Get latest jenkins-weekly version"
     kind: githubrelease
     spec:
-      owner: "jenkins-infra"
-      repository: "docker-jenkins-weekly"
+      owner: jenkins-infra
+      repository: docker-jenkins-infraci
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
 
 conditions:
   checkDockerImagePublished:
-    name: "Test jenkinsciinfra/jenkins-weekly:<latest_version> docker image tag"
+    name: "Test jenkinsciinfra/jenkins-infraci:<latest_version> docker image tag"
     kind: dockerimage
     spec:
-      image: "jenkinsciinfra/jenkins-weekly"
+      image: jenkinsciinfra/jenkins-infraci
       ## Tag from source
       architecture: amd64
 
@@ -37,8 +37,8 @@ targets:
     name: "Update jenkinsciinfra/jenkins-weekly docker image tag on infra.ci.jenkins.io"
     kind: yaml
     spec:
-      file: "config/jenkins_infra.ci.jenkins.io.yaml"
-      key: "$.controller.image.tag"
+      file: config/jenkins_infra.ci.jenkins.io.yaml
+      key: $.controller.image.tag
     scmid: default
 
 actions:
@@ -49,5 +49,5 @@ actions:
     spec:
       labels:
         - dependencies
-        - docker-jenkins-weekly
+        - docker-jenkins-infraci
         - infra.ci.jenkins.io

--- a/updatecli/updatecli.d/docker-images/jenkins-weekly_weekly.ci.jenkins.io.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-weekly_weekly.ci.jenkins.io.yaml
@@ -17,19 +17,17 @@ sources:
     name: "Get latest jenkins-weekly version"
     kind: githubrelease
     spec:
-      owner: "jenkins-infra"
-      repository: "docker-jenkins-weekly"
+      owner: jenkins-infra
+      repository: docker-jenkins-weeklyci
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
-    transformers:
-      - addsuffix: "-weeklyci"
 
 conditions:
   checkDockerImagePublished:
-    name: "Test jenkinsciinfra/jenkins-weekly:<latest_version> docker image tag with '-weeklyci' suffix"
+    name: "Test jenkinsciinfra/jenkins-weeklyci:<latest_version> docker image tag is published"
     kind: dockerimage
     spec:
-      image: "jenkinsciinfra/jenkins-weekly"
+      image: jenkinsciinfra/jenkins-weeklyci
       ## Tag from source
       architectures:
       - arm64
@@ -40,8 +38,8 @@ targets:
     name: "Update jenkinsciinfra/jenkins-weekly docker image tag on weekly.ci.jenkins.io"
     kind: yaml
     spec:
-      file: "config/jenkins_weekly.ci.jenkins.io.yaml"
-      key: "$.controller.image.tag"
+      file: config/jenkins_weekly.ci.jenkins.io.yaml
+      key: $.controller.image.tag
     scmid: default
 
 actions:
@@ -52,5 +50,5 @@ actions:
     spec:
       labels:
         - dependencies
-        - docker-jenkins-weekly
+        - docker-jenkins-weeklyci
         - weekly.ci.jenkins.io


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4171, this PR updates manually to the "new" images.

No core of plugins changes expected (incoming subseuquent PRs for this)