### PR TITLE
feat(all) enable gzip with default mime types for all public ingresses

### DIFF
--- a/config/public-nginx-ingress__common.yaml
+++ b/config/public-nginx-ingress__common.yaml
@@ -34,6 +34,7 @@ controller:
     hsts-include-subdomains: "true"
     # Strict-Transport-Security "max-age" directive recommended value is 2592000 (30 days).
     hsts-max-age: "2592000"
+    use-gzip: true # gzip types are the defaults: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#gzip-types
   replicaCount: 1
   ingressClassResource:
     enabled: true


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4177

It appears that we do not have gzip enabled on the ingress. This PR enables it for the following reasons:

- Even if we serve large files, clients will receive (if they can handle gzip) smaller files
- Less data to send back (less outbound bandwidth to pay for)
- Faster pages to load (https://github.com/jenkins-infra/helpdesk/issues/4177)
- Only downside: a bit more CPU usage for the nodes hosting the nginx ingress controllers. But we are fine on that matter:

<img width="1886" alt="Capture d’écran 2024-07-19 à 07 55 41" src="https://github.com/user-attachments/assets/491e5e18-a664-4033-bfb9-502b6359e520">
