### PR TITLE
feat(all) enable brotli with default mime types for all public ingresses

### DIFF
--- a/config/public-nginx-ingress__common.yaml
+++ b/config/public-nginx-ingress__common.yaml
@@ -34,7 +34,8 @@ controller:
     hsts-include-subdomains: "true"
     # Strict-Transport-Security "max-age" directive recommended value is 2592000 (30 days).
     hsts-max-age: "2592000"
-    use-gzip: true # gzip types are the defaults: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#gzip-types
+    use-gzip: true  # gzip types are the defaults: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#gzip-types
+    enable-brotli: true  # see default settings in https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-brotli
   replicaCount: 1
   ingressClassResource:
     enabled: true


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/kubernetes-management/pull/5442#pullrequestreview-2187587850

Follow up of #5442 but with `brotli` compression in addition of `gzip`