### PR TITLE
feat(privatek8s/infra.ci) set up Terraform datadog job to use new backends

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -436,18 +436,27 @@ jobsDefinition:
         name: Terraform Datadog
         description: "Datadog resources managed by Terraform"
         credentials:
-          datadog-api-key:
+          production-datadog-api-key:
             secret: "${PRODUCTION_DATADOG_API_KEY}"
-            description: Datadog API key for infra.ci
-          datadog-app-key:
+            description: Production Datadog API key for infra.ci
+          production-datadog-app-key:
             secret: "${PRODUCTION_DATADOG_APP_KEY}"
-            description: Datadog application key for infra.ci
+            description: Production Datadog application key for infra.ci
+          staging-datadog-api-key:
+            secret: "${STAGING_DATADOG_API_KEY}"
+            description: Production Datadog API key for infra.ci
+          staging-datadog-app-key:
+            secret: "${STAGING_DATADOG_APP_KEY}"
+            description: Production Datadog application key for infra.ci
           datadog-jenkinsuser-password:
-            secret: "${PRODUCTION_DATADOG_JENKINSUSER_PASSWORD}"
+            secret: "${DATADOG_JENKINSUSER_PASSWORD}"
             description: datadog_monitoring Jenkins technical user password
           production-terraform-datadog-backend-config:
             fileName: "backend-config"
             secretBytes: "${base64:${PRODUCTION_TERRAFORM_DATADOG_BACKEND_CONFIG}}"
+          staging-terraform-datadog-backend-config:
+            fileName: "backend-config"
+            secretBytes: "${base64:${STAGING_TERRAFORM_DATADOG_BACKEND_CONFIG}}"
       digitalocean:
         name: Terraform Digital Ocean
         description: "Digital Ocean resources managed by Terraform"

--- a/config/public-nginx-ingress__common.yaml
+++ b/config/public-nginx-ingress__common.yaml
@@ -34,8 +34,8 @@ controller:
     hsts-include-subdomains: "true"
     # Strict-Transport-Security "max-age" directive recommended value is 2592000 (30 days).
     hsts-max-age: "2592000"
-    use-gzip: true # gzip types are the defaults: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#gzip-types
-    enable-brotli: true # see default settings in https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-brotli
+    use-gzip: true  # gzip types are the defaults: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#gzip-types
+    enable-brotli: true  # see default settings in https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-brotli
   replicaCount: 1
   ingressClassResource:
     enabled: true


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4167

This PR sets the required credential on infra.ci.jenkins.io to:

- Use the new TF backend credentials
- Have a staging environment available for datadog


Associated secret change: https://github.com/jenkins-infra/charts-secrets/commit/e7cf3e23d47119706bb945a0bfe5ca4454ed55e6