### PR TITLE
Revert "Bump agent templates for infra.ci.jenkins.io (packer-image 1.82.0)"

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -129,7 +129,7 @@ controller:
                     nodeSelector: "kubernetes.io/arch=amd64"
                     containers:
                       - name: jnlp
-                        image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.82.0"
+                        image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.81.0"
                         command: "/usr/local/bin/jenkins-agent"
                         args: ""
                         envVars:
@@ -166,7 +166,7 @@ controller:
                     nodeSelector: "kubernetes.io/arch=arm64"
                     containers:
                       - name: jnlp
-                        image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.82.0"
+                        image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:1.81.0"
                         command: "/usr/local/bin/jenkins-agent"
                         args: ""
                         envVars:
@@ -264,7 +264,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-amd64"
-                    galleryImageVersion: "1.82.0"
+                    galleryImageVersion: "1.81.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
@@ -316,7 +316,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-windows-2019-amd64"
-                    galleryImageVersion: "1.82.0"
+                    galleryImageVersion: "1.81.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
@@ -355,7 +355,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-windows-2022-amd64"
-                    galleryImageVersion: "1.82.0"
+                    galleryImageVersion: "1.81.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
@@ -394,7 +394,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
-                    galleryImageVersion: "1.82.0"
+                    galleryImageVersion: "1.81.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#5472

because `updatecli` version 0.81.x are causing errors such as:

```
[2024-07-29T10:11:11.051Z] ERROR: non-fast-forward update
[2024-07-29T10:11:11.051Z] ERROR: push error: unpack error: index-pack failed
[2024-07-29T10:11:11.051Z] 
[2024-07-29T10:11:11.051Z] ERROR: something went wrong in target "updateHttpd" : "unpack error: index-pack failed"
[2024-07-29T10:11:11.051Z] ERROR: something went wrong in target "updateMirrorbits" : "unpack error: index-pack failed"
```

when applying changes.


