### PR TITLE
fix(publick8s/updates.jenkins.io) set HTTPD ServerName to `https://localhost` to ensure HTTP redirects keeps the HTTPS scheme

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -239,7 +239,7 @@ releases:
   - name: updates-jenkins-io-httpd
     namespace: updates-jenkins-io
     chart: jenkins-infra/httpd
-    version: 0.4.0
+    version: 1.0.0
     values:
       - "../config/updates.jenkins.io_httpd.yaml"
     secrets:

--- a/config/public-nginx-ingress__common.yaml
+++ b/config/public-nginx-ingress__common.yaml
@@ -34,8 +34,8 @@ controller:
     hsts-include-subdomains: "true"
     # Strict-Transport-Security "max-age" directive recommended value is 2592000 (30 days).
     hsts-max-age: "2592000"
-    use-gzip: true # gzip types are the defaults: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#gzip-types
-    enable-brotli: true # see default settings in https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-brotli
+    use-gzip: true  # gzip types are the defaults: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#gzip-types
+    enable-brotli: true  # see default settings in https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-brotli
   replicaCount: 1
   ingressClassResource:
     enabled: true

--- a/config/updates.jenkins.io_httpd.yaml
+++ b/config/updates.jenkins.io_httpd.yaml
@@ -84,3 +84,6 @@ ingress:
     - secretName: updates-jenkins-io-httpd-tls
       hosts:
         - azure.updates.jenkins.io
+
+httpdConf:
+  serverName: https://localhost

--- a/updatecli/updatecli.d/charts/httpd.yaml
+++ b/updatecli/updatecli.d/charts/httpd.yaml
@@ -1,0 +1,41 @@
+name: Bump httpd Helm Chart Version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastChartVersion:
+    kind: helmchart
+    name: get last chart version
+    spec:
+      url: https://jenkins-infra.github.io/helm-charts
+      name: httpd
+
+targets:
+  updateChartVersion:
+    name: Update httpd chart version
+    kind: yaml
+    spec:
+      engine: yamlpath
+      file: clusters/publick8s.yaml
+      key: $.releases[?(@.chart == 'jenkins-infra/httpd')].version
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump `httpd` Helm Chart Version to {{ source "lastChartVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - httpd


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2255522243

This PR ensures that the HTTP redirects from the HTTPD component of `updates-jenkins-io` keeps the HTTPS scheme in their redirection target.

- If there are any HTTP external request made to the service, the ingress upgrades it to HTTP so no impact:

```
$ curl --silent --show-error --output /dev/null --fail --write-out '%{redirect_url}' 'http://azure.updates.jenkins.io/update-center.json?id=default&version=2.469' 
https://azure.updates.jenkins.io/update-center.json?id=default&version=2.469%
```

- We do not expect the internal HTTPD to be requested by something else than the ingress

----

NOTE: 2 minor changes are part in this PR. I chose to add them as per the following:

- A new `updatecli` manifest tracks the HTTPD chart version. I tested it to bump the chart version to 1.0.0 (required to have the custom ServerName  - https://github.com/jenkins-infra/helm-charts/releases/tag/httpd-1.0.0)
- YamlLint was complaining about missing spaces before comments. It complains no more :)

----

Tested manually:

**Before**

```
$ curl --silent --show-error --output /dev/null --fail --write-out '%{redirect_url}' 'https://azure.updates.jenkins.io/update-center.json?id=default&version=2.469'
http://azure.updates.jenkins.io/dynamic-2.460/update-center.json
```

**After**

```
$ curl --silent --show-error --output /dev/null --fail --write-out '%{redirect_url}' 'https://azure.updates.jenkins.io/update-center.json?id=default&version=2.469'
https://azure.updates.jenkins.io/dynamic-2.460/update-center.json
```