### PR TITLE
chore(privatek8s/infra.ci) jenkins settings cleanup

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -52,11 +52,11 @@ controller:
       memory: "8Gi"
   probes:
     startupProbe:
-      initialDelaySeconds: 120
+      initialDelaySeconds: 60
     livenessProbe:
-      initialDelaySeconds: 120
+      initialDelaySeconds: 60
     readinessProbe:
-      initialDelaySeconds: 120
+      initialDelaySeconds: 60
   testEnabled: false
   overwritePlugins: true
   serviceType: "ClusterIP"

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -58,8 +58,8 @@ controller:
     readinessProbe:
       initialDelaySeconds: 60
   testEnabled: false
+  # This setting deletes the content of $ JENKINS_HOME/plugins on each pod restart to ensure only container image plugins are used
   overwritePlugins: true
-  serviceType: "ClusterIP"
   javaOpts: >-
     -XshowSettings:vm -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/ -XX:+UseG1GC -Djava.net.preferIPv4Stack=true
   JCasC:

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -555,6 +555,8 @@ controller:
             shell: "/bin/bash"
       system-settings: |
         unclassified:
+          gitHubConfiguration:
+            apiRateLimitChecker: NoThrottle
           lockableResourcesManager:
             declaredResources:
             - description: "first entry for packer image builder dev"

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -696,17 +696,6 @@ controller:
         unclassified:
           defaultDisplayUrlProvider:
             providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
-  sidecars:
-    configAutoReload:
-      env:
-        # https://github.com/kiwigrid/k8s-sidecar#configuration-environment-variables
-        - name: METHOD
-          # Polling mode (instead of watching kube API)
-          value: "SLEEP"
-        # https://github.com/kiwigrid/k8s-sidecar#configuration-environment-variables
-        - name: SLEEP_TIME
-          # Time in seconds between two polls
-          value: "60"
   installPlugins: false
   ingress:
     enabled: true


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/4165, it appeared we had some infra.ci.jenkins.io Helm chart settings to cleanup:

- Decreasing probes initial delay for faster restarts (cc @smerle33 for info : you will like it)
- Disable GitHub API throttling
- Use defaults for sidecar
- Document some values for the reader