### PR TITLE
feat(publick8s/updates.jio) set up HTTPD to answer requests using the `updates.jenkins.io` hostname

### DIFF
--- a/config/updates.jenkins.io_httpd.yaml
+++ b/config/updates.jenkins.io_httpd.yaml
@@ -80,10 +80,16 @@ ingress:
       paths:
         - path: /
           backendService: httpd
+    - host: updates.jenkins.io
+      paths:
+        - path: /
+          backendService: httpd
   tls:
     - secretName: updates-jenkins-io-httpd-tls
       hosts:
+        - updates.jenkins.io
         - azure.updates.jenkins.io
 
 httpdConf:
+  # Specifying https scheme allow proper HTTP rewriting when the pattern is not an FQDN
   serverName: https://localhost


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649

This PR sets up the HTTPD service to answer on requests with the Host set to `updates.jenkins.io` to:

- Allow testing while overriding the `updates.jenkins.io` DNS records to point to the cluster IP (`20.7.178.24`)
- Ensure that we have a valid TLS termination for this domain (anticipating the brwonouts)