### PR TITLE
fix(infra.ci-agents-1) correct datadog agent tolerations

### DIFF
--- a/config/datadog_infracijioagents1.yaml
+++ b/config/datadog_infracijioagents1.yaml
@@ -32,7 +32,7 @@ clusterAgent:
 agents:
   tolerations:
     # These tolerations are needed to run the agents on all the pools
-    - key: "infraci.jenkins.io/agents"
+    - key: "infra.ci.jenkins.io/agents"
       operator: "Equal"
       value: "true"
       effect: "NoSchedule"


### PR DESCRIPTION
Otherwise the datadog agents are not spawned on the infra.ci agent nodes (and we are missing metrics)