### PR TITLE
fix(publick8s/public-ingress) ensure external LBs are SingleStack to prevent errors trying to create unused IPv6s

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -223,7 +223,7 @@ releases:
   - name: ipv6-lb-service
     namespace: public-nginx-ingress
     chart: jenkins-infra/ipv6-lb-service
-    version: 1.0.0
+    version: 1.0.1
     needs:
       - public-nginx-ingress/public-nginx-ingress
     values:

--- a/config/public-nginx-ingress__common.yaml
+++ b/config/public-nginx-ingress__common.yaml
@@ -34,8 +34,8 @@ controller:
     hsts-include-subdomains: "true"
     # Strict-Transport-Security "max-age" directive recommended value is 2592000 (30 days).
     hsts-max-age: "2592000"
-    use-gzip: true # gzip types are the defaults: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#gzip-types
-    enable-brotli: true # see default settings in https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-brotli
+    use-gzip: true  # gzip types are the defaults: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#gzip-types
+    enable-brotli: true  # see default settings in https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-brotli
   replicaCount: 1
   ingressClassResource:
     enabled: true

--- a/config/public-nginx-ingress_publick8s.yaml
+++ b/config/public-nginx-ingress_publick8s.yaml
@@ -22,8 +22,7 @@ controller:
     externalTrafficPolicy: Local
     ipFamilies:
       - IPv4
-      - IPv6
-    ipFamilyPolicy: PreferDualStack
+    ipFamilyPolicy: SingleStack
   nodeSelector:
     kubernetes.io/arch: arm64
   tolerations:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4206

This PR fixes the 2 errors related to `Authorization Failures` with IPv6 Public IP deprecated and being reused (trying to) by the LB.

The root causes are the same: using DualStack LBs instead of 2 SingleStack LBs.

- Fixing the Nginx ingress LB  using helm chart values specifying the SingleStack `IPv4`
- Fixing the custom IPv6 LB using its new `1.0.1` (fixed) chart from https://github.com/jenkins-infra/helm-charts/pull/1251