### PR TITLE
feat(ci.jio-agents1/acp) use an Azure-internal LB to expose the service to another subnet

### DIFF
--- a/config/artifact-caching-proxy_azure-aks.yaml
+++ b/config/artifact-caching-proxy_azure-aks.yaml
@@ -25,6 +25,12 @@ affinity:
                 - artifact-caching-proxy
         topologyKey: "kubernetes.io/hostname"
 
+service:
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: true
+    service.beta.kubernetes.io/azure-load-balancer-internal-subnet: public-jenkins-sponsorship-vnet-ci_jenkins_io_agents
+    service.beta.kubernetes.io/azure-load-balancer-ipv4: 10.200.2.254
+
 resources:
   limits:
     cpu: 2

--- a/config/artifact-caching-proxy_azure-aks.yaml
+++ b/config/artifact-caching-proxy_azure-aks.yaml
@@ -27,9 +27,9 @@ affinity:
 
 service:
   annotations:
-    service.beta.kubernetes.io/azure-load-balancer-internal: true
-    service.beta.kubernetes.io/azure-load-balancer-internal-subnet: public-jenkins-sponsorship-vnet-ci_jenkins_io_agents
-    service.beta.kubernetes.io/azure-load-balancer-ipv4: 10.200.2.254
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    service.beta.kubernetes.io/azure-load-balancer-internal-subnet: "public-jenkins-sponsorship-vnet-ci_jenkins_io_agents"
+    service.beta.kubernetes.io/azure-load-balancer-ipv4: "10.200.2.254"
 
 resources:
   limits:

--- a/config/artifact-caching-proxy_azure-aks.yaml
+++ b/config/artifact-caching-proxy_azure-aks.yaml
@@ -26,6 +26,7 @@ affinity:
         topologyKey: "kubernetes.io/hostname"
 
 service:
+  type: LoadBalancer
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
     service.beta.kubernetes.io/azure-load-balancer-internal-subnet: "public-jenkins-sponsorship-vnet-ci_jenkins_io_agents"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4204#issuecomment-2278334260

This PR changes the ACP (of the `ci.jio-agents1` cluster) service from `ClusterIP` to an (Azure internal) `LoadBalancer` with a static IP in the ci.jenkins.io ephemeral agents network.