### PR TITLE
fix(ci.jio-agents1/acp) use a resolver chain and start with local kube-dns

### DIFF
--- a/config/artifact-caching-proxy_azure-aks.yaml
+++ b/config/artifact-caching-proxy_azure-aks.yaml
@@ -41,3 +41,6 @@ resources:
     memory: 2048Mi
 
 replicaCount: 2
+
+proxy:
+  dnsResolver: "kube-dns.kube-system.svc.cluster.local 9.9.9.9"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4204

While re-reading the [Nginx doc about `resolver`](http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver) I realized that:

- When the error `(110: Operation timed out) while connecting to upstream` happens it is mostly due to numerous DNS requests blocked. Since we try to resolve hostname every 60s, DNS caching could help (@timja mentioned https://github.com/Azure/AKS/issues/3673 for instance).
- But we are only using directly the [quad-9 DNS](https://www.quad9.net/) DNS server and not the local Kube DNS, bypassing the whole DNS chain


This PR specifies the local Kube DNS and then chain with the quad 9 DNS server as fallback:

- More efficient DNS resolution with local caching out of the box
- More resilient: if the first DNS times out (5s) then the second one will be requested