### PR TITLE
feat(infra.ci.jio): Added AZ VM templates for Ubuntu-22 AMD and ARM maven-17 and maven-21 agents

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -299,7 +299,7 @@ controller:
                     echo "END CLOUDINIT"
                   javaPath: "/opt/jdk-17/bin/java"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
-                  labels: "linux-amd64 linux-amd64-docker azure-vms-jenkins-sponsorship jdk11 maven-11"
+                  labels: "linux-amd64 linux-amd64-docker azure-vms-jenkins-sponsorship"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
                   existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
@@ -314,134 +314,6 @@ controller:
                   subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
                   templateDesc: "Dynamically provisioned Ubuntu 22.04 LTS x86_64 machine"
                   templateName: "ubuntu-22"
-                  usageMode: NORMAL
-                  usePrivateIP: true
-                  virtualMachineSize: "Standard_D4ads_v5" # 4 vCPUS / 16 Gb / Max 150 Gb local storage
-                  virtualNetworkName: "infra-ci-jenkins-io-sponsorship-vnet"
-                  virtualNetworkResourceGroupName: "infra-ci-jenkins-io-sponsorship"
-                - launcher: "ssh"
-                  agentWorkspace: "/home/jenkins"
-                  credentialsId: "azure-login"
-                  diskType: "managed"
-                  doNotUseMachineIfInitFails: false
-                  encryptionAtHost: true
-                  ephemeralOSDisk: true
-                  executeInitScriptAsRoot: true
-                  imageReference:
-                    galleryImageDefinition: "jenkins-agent-ubuntu-22.04-amd64"
-                    galleryImageVersion: "1.86.0"
-                    galleryName: "prod_packer_images"
-                    galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
-                  imageTopLevelType: "advanced"
-                  initScript: |-
-                    #!/bin/bash
-                    set -eux
-                    echo "START CLOUDINIT"
-                    systemctl stop datadog-agent.service
-                    mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
-                    sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
-                    chown -R dd-agent:dd-agent /etc/datadog-agent
-                    chmod 640 /etc/datadog-agent/datadog.yaml
-                    chown -R dd-agent:dd-agent /var/log/datadog
-                    chmod 770 /var/log/datadog
-                    systemctl start datadog-agent.service
-                    # Setup Docker Engine
-                    mkdir -p /etc/docker
-                    cat <<EOF >/etc/docker/daemon.json
-                    {
-                      "registry-mirrors": ["https://dockerhubmirror.azurecr.io"]
-                    }
-                    EOF
-                    systemctl daemon-reload
-                    systemctl restart docker
-                    export DEFAULT_JDK=/opt/jdk-17
-                    update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
-                    echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
-                    rm -f /etc/sudoers.d/90-cloud-init-users
-                    echo "END CLOUDINIT"
-                  javaPath: "/opt/jdk-17/bin/java"
-                  jvmOptions: "-XX:+PrintCommandLineFlags"
-                  labels: "linux-amd64-maven-17"
-                  location: "East US 2"
-                  maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
-                  noOfParallelJobs: 1
-                  osDiskSize: 150
-                  osDiskStorageAccountType: "Standard_LRS"
-                  osType: "Linux"
-                  retentionStrategy: "azureVMCloudOnce"
-                  spotInstance: false
-                  storageAccountNameReferenceType: "existing"
-                  storageAccountType: "Standard_LRS"
-                  subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
-                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-17 LTS x86_64 machine"
-                  templateName: "ubuntu-22-amd64-maven-17"
-                  usageMode: NORMAL
-                  usePrivateIP: true
-                  virtualMachineSize: "Standard_D4ads_v5" # 4 vCPUS / 16 Gb / Max 150 Gb local storage
-                  virtualNetworkName: "infra-ci-jenkins-io-sponsorship-vnet"
-                  virtualNetworkResourceGroupName: "infra-ci-jenkins-io-sponsorship"
-                - launcher: "ssh"
-                  agentWorkspace: "/home/jenkins"
-                  credentialsId: "azure-login"
-                  diskType: "managed"
-                  doNotUseMachineIfInitFails: false
-                  encryptionAtHost: true
-                  ephemeralOSDisk: true
-                  executeInitScriptAsRoot: true
-                  imageReference:
-                    galleryImageDefinition: "jenkins-agent-ubuntu-22.04-amd64"
-                    galleryImageVersion: "1.86.0"
-                    galleryName: "prod_packer_images"
-                    galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
-                  imageTopLevelType: "advanced"
-                  initScript: |-
-                    #!/bin/bash
-                    set -eux
-                    echo "START CLOUDINIT"
-                    systemctl stop datadog-agent.service
-                    mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
-                    sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
-                    chown -R dd-agent:dd-agent /etc/datadog-agent
-                    chmod 640 /etc/datadog-agent/datadog.yaml
-                    chown -R dd-agent:dd-agent /var/log/datadog
-                    chmod 770 /var/log/datadog
-                    systemctl start datadog-agent.service
-                    # Setup Docker Engine
-                    mkdir -p /etc/docker
-                    cat <<EOF >/etc/docker/daemon.json
-                    {
-                      "registry-mirrors": ["https://dockerhubmirror.azurecr.io"]
-                    }
-                    EOF
-                    systemctl daemon-reload
-                    systemctl restart docker
-                    export DEFAULT_JDK=/opt/jdk-21
-                    update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
-                    echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
-                    rm -f /etc/sudoers.d/90-cloud-init-users
-                    echo "END CLOUDINIT"
-                  javaPath: "/opt/jdk-17/bin/java"
-                  jvmOptions: "-XX:+PrintCommandLineFlags"
-                  labels: "linux-amd64-maven-21"
-                  location: "East US 2"
-                  maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
-                  noOfParallelJobs: 1
-                  osDiskSize: 150
-                  osDiskStorageAccountType: "Standard_LRS"
-                  osType: "Linux"
-                  retentionStrategy: "azureVMCloudOnce"
-                  spotInstance: false
-                  storageAccountNameReferenceType: "existing"
-                  storageAccountType: "Standard_LRS"
-                  subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
-                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-21 LTS x86_64 machine"
-                  templateName: "ubuntu-22-amd64-maven-21"
                   usageMode: NORMAL
                   usePrivateIP: true
                   virtualMachineSize: "Standard_D4ads_v5" # 4 vCPUS / 16 Gb / Max 150 Gb local storage
@@ -585,7 +457,7 @@ controller:
                     echo "END CLOUDINIT"
                   javaPath: "/opt/jdk-17/bin/java"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
-                  labels: "linux-arm64 linux-arm64-docker azure-vms-jenkins-sponsorship arm64linux jdk11-arm64 maven-11-arm64"
+                  labels: "linux-arm64 linux-arm64-docker azure-vms-jenkins-sponsorship arm64linux jdk11 maven-11 ubuntu-22-arm64 ubuntu-arm64"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
                   existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
@@ -649,7 +521,7 @@ controller:
                     echo "END CLOUDINIT"
                   javaPath: "/opt/jdk-17/bin/java"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
-                  labels: "linux-arm64-maven-17"
+                  labels: "linux-arm64-maven-17 jdk17 maven-17 ubuntu-22-arm64-maven-17 ubuntu-arm64-maven-17"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
                   existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
@@ -713,7 +585,7 @@ controller:
                     echo "END CLOUDINIT"
                   javaPath: "/opt/jdk-17/bin/java"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
-                  labels: "linux-arm64-maven-21"
+                  labels: "linux-arm64-maven-21 jdk21 maven-21 ubuntu-22-arm64-maven-21 ubuntu-arm64-maven-21"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
                   existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -292,11 +292,15 @@ controller:
                     EOF
                     systemctl daemon-reload
                     systemctl restart docker
+                    export DEFAULT_JDK=/opt/jdk-11
+                    update-alternatives --install /usr/bin/java java "${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=${DEFAULT_JDK}" >> /etc/environment
                     rm -f /etc/sudoers.d/90-cloud-init-users
                     echo "END CLOUDINIT"
                   javaPath: "/opt/jdk-17/bin/java"
+                  javaHome: "/opt/jdk-11"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
-                  labels: "linux-amd64 linux-amd64-docker azure-vms-jenkins-sponsorship"
+                  labels: "linux-amd64 linux-amd64-docker azure-vms-jenkins-sponsorship jdk11 maven-11"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
                   existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
@@ -309,8 +313,138 @@ controller:
                   storageAccountNameReferenceType: "existing"
                   storageAccountType: "Standard_LRS"
                   subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
-                  templateDesc: "Dynamically provisioned Ubuntu 22.04 LTS machine"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 LTS AMD machine"
                   templateName: "ubuntu-22"
+                  usageMode: NORMAL
+                  usePrivateIP: true
+                  virtualMachineSize: "Standard_D4ads_v5" # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+                  virtualNetworkName: "infra-ci-jenkins-io-sponsorship-vnet"
+                  virtualNetworkResourceGroupName: "infra-ci-jenkins-io-sponsorship"
+                - launcher: "ssh"
+                  agentWorkspace: "/home/jenkins"
+                  credentialsId: "azure-login"
+                  diskType: "managed"
+                  doNotUseMachineIfInitFails: false
+                  encryptionAtHost: true
+                  ephemeralOSDisk: true
+                  executeInitScriptAsRoot: true
+                  imageReference:
+                    galleryImageDefinition: "jenkins-agent-ubuntu-22.04-amd64"
+                    galleryImageVersion: "1.86.0"
+                    galleryName: "prod_packer_images"
+                    galleryResourceGroup: "prod-packer-images"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                  imageTopLevelType: "advanced"
+                  initScript: |-
+                    #!/bin/bash
+                    set -eux
+                    echo "START CLOUDINIT"
+                    systemctl stop datadog-agent.service
+                    mkdir -p /var/log/datadog /etc/datadog-agent
+                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+                    chown -R dd-agent:dd-agent /etc/datadog-agent
+                    chmod 640 /etc/datadog-agent/datadog.yaml
+                    chown -R dd-agent:dd-agent /var/log/datadog
+                    chmod 770 /var/log/datadog
+                    systemctl start datadog-agent.service
+                    # Setup Docker Engine
+                    mkdir -p /etc/docker
+                    cat <<EOF >/etc/docker/daemon.json
+                    {
+                      "registry-mirrors": ["https://dockerhubmirror.azurecr.io"]
+                    }
+                    EOF
+                    systemctl daemon-reload
+                    systemctl restart docker
+                    export DEFAULT_JDK=/opt/jdk-17
+                    update-alternatives --install /usr/bin/java java "${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=${DEFAULT_JDK}" >> /etc/environment
+                    rm -f /etc/sudoers.d/90-cloud-init-users
+                    echo "END CLOUDINIT"
+                  javaPath: "/opt/jdk-17/bin/java"
+                  javaHome: "/opt/jdk-17"
+                  jvmOptions: "-XX:+PrintCommandLineFlags"
+                  labels: "linux-amd64-maven-17"
+                  location: "East US 2"
+                  maxVirtualMachinesLimit: 50
+                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  noOfParallelJobs: 1
+                  osDiskSize: 150
+                  osDiskStorageAccountType: "Standard_LRS"
+                  osType: "Linux"
+                  retentionStrategy: "azureVMCloudOnce"
+                  spotInstance: false
+                  storageAccountNameReferenceType: "existing"
+                  storageAccountType: "Standard_LRS"
+                  subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-17 LTS AMD machine"
+                  templateName: "ubuntu-22-amd64-maven-17"
+                  usageMode: NORMAL
+                  usePrivateIP: true
+                  virtualMachineSize: "Standard_D4ads_v5" # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+                  virtualNetworkName: "infra-ci-jenkins-io-sponsorship-vnet"
+                  virtualNetworkResourceGroupName: "infra-ci-jenkins-io-sponsorship"
+                - launcher: "ssh"
+                  agentWorkspace: "/home/jenkins"
+                  credentialsId: "azure-login"
+                  diskType: "managed"
+                  doNotUseMachineIfInitFails: false
+                  encryptionAtHost: true
+                  ephemeralOSDisk: true
+                  executeInitScriptAsRoot: true
+                  imageReference:
+                    galleryImageDefinition: "jenkins-agent-ubuntu-22.04-amd64"
+                    galleryImageVersion: "1.86.0"
+                    galleryName: "prod_packer_images"
+                    galleryResourceGroup: "prod-packer-images"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                  imageTopLevelType: "advanced"
+                  initScript: |-
+                    #!/bin/bash
+                    set -eux
+                    echo "START CLOUDINIT"
+                    systemctl stop datadog-agent.service
+                    mkdir -p /var/log/datadog /etc/datadog-agent
+                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+                    chown -R dd-agent:dd-agent /etc/datadog-agent
+                    chmod 640 /etc/datadog-agent/datadog.yaml
+                    chown -R dd-agent:dd-agent /var/log/datadog
+                    chmod 770 /var/log/datadog
+                    systemctl start datadog-agent.service
+                    # Setup Docker Engine
+                    mkdir -p /etc/docker
+                    cat <<EOF >/etc/docker/daemon.json
+                    {
+                      "registry-mirrors": ["https://dockerhubmirror.azurecr.io"]
+                    }
+                    EOF
+                    systemctl daemon-reload
+                    systemctl restart docker
+                    export DEFAULT_JDK=/opt/jdk-21
+                    update-alternatives --install /usr/bin/java java "${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=${DEFAULT_JDK}" >> /etc/environment
+                    rm -f /etc/sudoers.d/90-cloud-init-users
+                    echo "END CLOUDINIT"
+                  javaPath: "/opt/jdk-17/bin/java"
+                  javaHome: "/opt/jdk-21"
+                  jvmOptions: "-XX:+PrintCommandLineFlags"
+                  labels: "linux-amd64-maven-21"
+                  location: "East US 2"
+                  maxVirtualMachinesLimit: 50
+                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  noOfParallelJobs: 1
+                  osDiskSize: 150
+                  osDiskStorageAccountType: "Standard_LRS"
+                  osType: "Linux"
+                  retentionStrategy: "azureVMCloudOnce"
+                  spotInstance: false
+                  storageAccountNameReferenceType: "existing"
+                  storageAccountType: "Standard_LRS"
+                  subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-21 LTS AMD machine"
+                  templateName: "ubuntu-22-amd64-maven-21"
                   usageMode: NORMAL
                   usePrivateIP: true
                   virtualMachineSize: "Standard_D4ads_v5" # 4 vCPUS / 16 Gb / Max 150 Gb local storage
@@ -447,11 +581,15 @@ controller:
                     EOF
                     systemctl daemon-reload
                     systemctl restart docker
+                    export DEFAULT_JDK=/opt/jdk-11
+                    update-alternatives --install /usr/bin/java java "${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=${DEFAULT_JDK}" >> /etc/environment
                     rm -f /etc/sudoers.d/90-cloud-init-users
                     echo "END CLOUDINIT"
                   javaPath: "/opt/jdk-17/bin/java"
+                  javaHome: "/opt/jdk-11"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
-                  labels: "linux-arm64 linux-arm64-docker azure-vms-jenkins-sponsorship arm64linux"
+                  labels: "linux-arm64 linux-arm64-docker azure-vms-jenkins-sponsorship arm64linux jdk11 maven-11"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
                   existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
@@ -466,6 +604,136 @@ controller:
                   subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
                   templateDesc: "Dynamically provisioned Ubuntu 22.04 LTS ARM machine"
                   templateName: "ubuntu-22-arm64"
+                  usageMode: NORMAL
+                  usePrivateIP: true
+                  virtualMachineSize: "Standard_D4pds_v5" # 4 vCPUS / 16 Gb / Max 100 Gb OsCacheDisk local storage (150 temp)
+                  virtualNetworkName: "infra-ci-jenkins-io-sponsorship-vnet"
+                  virtualNetworkResourceGroupName: "infra-ci-jenkins-io-sponsorship"
+                - launcher: "ssh"
+                  agentWorkspace: "/home/jenkins"
+                  credentialsId: "azure-login"
+                  diskType: "managed"
+                  doNotUseMachineIfInitFails: false
+                  encryptionAtHost: true
+                  ephemeralOSDisk: true
+                  executeInitScriptAsRoot: true
+                  imageReference:
+                    galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
+                    galleryImageVersion: "1.86.0"
+                    galleryName: "prod_packer_images"
+                    galleryResourceGroup: "prod-packer-images"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                  imageTopLevelType: "advanced"
+                  initScript: |-
+                    #!/bin/bash
+                    set -eux
+                    echo "START CLOUDINIT"
+                    systemctl stop datadog-agent.service
+                    mkdir -p /var/log/datadog /etc/datadog-agent
+                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+                    chown -R dd-agent:dd-agent /etc/datadog-agent
+                    chmod 640 /etc/datadog-agent/datadog.yaml
+                    chown -R dd-agent:dd-agent /var/log/datadog
+                    chmod 770 /var/log/datadog
+                    systemctl start datadog-agent.service
+                    # Setup Docker Engine
+                    mkdir -p /etc/docker
+                    cat <<EOF >/etc/docker/daemon.json
+                    {
+                      "registry-mirrors": ["https://dockerhubmirror.azurecr.io"]
+                    }
+                    EOF
+                    systemctl daemon-reload
+                    systemctl restart docker
+                    export DEFAULT_JDK=/opt/jdk-17
+                    update-alternatives --install /usr/bin/java java "${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=${DEFAULT_JDK}" >> /etc/environment
+                    rm -f /etc/sudoers.d/90-cloud-init-users
+                    echo "END CLOUDINIT"
+                  javaPath: "/opt/jdk-17/bin/java"
+                  javaHome: "/opt/jdk-17"
+                  jvmOptions: "-XX:+PrintCommandLineFlags"
+                  labels: "linux-arm64-maven-17"
+                  location: "East US 2"
+                  maxVirtualMachinesLimit: 50
+                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  noOfParallelJobs: 1
+                  osDiskSize: 100 # https://github.com/jenkins-infra/helpdesk/issues/3812
+                  osDiskStorageAccountType: "Standard_LRS"
+                  osType: "Linux"
+                  retentionStrategy: "azureVMCloudOnce"
+                  spotInstance: false
+                  storageAccountNameReferenceType: "existing"
+                  storageAccountType: "Standard_LRS"
+                  subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-17 LTS ARM machine"
+                  templateName: "ubuntu-22-arm64-maven-17"
+                  usageMode: NORMAL
+                  usePrivateIP: true
+                  virtualMachineSize: "Standard_D4pds_v5" # 4 vCPUS / 16 Gb / Max 100 Gb OsCacheDisk local storage (150 temp)
+                  virtualNetworkName: "infra-ci-jenkins-io-sponsorship-vnet"
+                  virtualNetworkResourceGroupName: "infra-ci-jenkins-io-sponsorship"
+                - launcher: "ssh"
+                  agentWorkspace: "/home/jenkins"
+                  credentialsId: "azure-login"
+                  diskType: "managed"
+                  doNotUseMachineIfInitFails: false
+                  encryptionAtHost: true
+                  ephemeralOSDisk: true
+                  executeInitScriptAsRoot: true
+                  imageReference:
+                    galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
+                    galleryImageVersion: "1.86.0"
+                    galleryName: "prod_packer_images"
+                    galleryResourceGroup: "prod-packer-images"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                  imageTopLevelType: "advanced"
+                  initScript: |-
+                    #!/bin/bash
+                    set -eux
+                    echo "START CLOUDINIT"
+                    systemctl stop datadog-agent.service
+                    mkdir -p /var/log/datadog /etc/datadog-agent
+                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+                    chown -R dd-agent:dd-agent /etc/datadog-agent
+                    chmod 640 /etc/datadog-agent/datadog.yaml
+                    chown -R dd-agent:dd-agent /var/log/datadog
+                    chmod 770 /var/log/datadog
+                    systemctl start datadog-agent.service
+                    # Setup Docker Engine
+                    mkdir -p /etc/docker
+                    cat <<EOF >/etc/docker/daemon.json
+                    {
+                      "registry-mirrors": ["https://dockerhubmirror.azurecr.io"]
+                    }
+                    EOF
+                    systemctl daemon-reload
+                    systemctl restart docker
+                    export DEFAULT_JDK=/opt/jdk-21
+                    update-alternatives --install /usr/bin/java java "${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=${DEFAULT_JDK}" >> /etc/environment
+                    rm -f /etc/sudoers.d/90-cloud-init-users
+                    echo "END CLOUDINIT"
+                  javaPath: "/opt/jdk-17/bin/java"
+                  javaHome: "/opt/jdk-21"
+                  jvmOptions: "-XX:+PrintCommandLineFlags"
+                  labels: "linux-arm64-maven-21"
+                  location: "East US 2"
+                  maxVirtualMachinesLimit: 50
+                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  noOfParallelJobs: 1
+                  osDiskSize: 100 # https://github.com/jenkins-infra/helpdesk/issues/3812
+                  osDiskStorageAccountType: "Standard_LRS"
+                  osType: "Linux"
+                  retentionStrategy: "azureVMCloudOnce"
+                  spotInstance: false
+                  storageAccountNameReferenceType: "existing"
+                  storageAccountType: "Standard_LRS"
+                  subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-21 LTS ARM machine"
+                  templateName: "ubuntu-22-arm64-maven-21"
                   usageMode: NORMAL
                   usePrivateIP: true
                   virtualMachineSize: "Standard_D4pds_v5" # 4 vCPUS / 16 Gb / Max 100 Gb OsCacheDisk local storage (150 temp)

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -268,7 +268,7 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     #!/bin/bash
@@ -276,7 +276,7 @@ controller:
                     echo "START CLOUDINIT"
                     systemctl stop datadog-agent.service
                     mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed 's/api_key:.*/api_key: ^${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
                     sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
                     chown -R dd-agent:dd-agent /etc/datadog-agent
                     chmod 640 /etc/datadog-agent/datadog.yaml
@@ -293,17 +293,16 @@ controller:
                     systemctl daemon-reload
                     systemctl restart docker
                     export DEFAULT_JDK=/opt/jdk-11
-                    update-alternatives --install /usr/bin/java java "${DEFAULT_JDK}/bin/java" 2000
-                    echo "JAVA_HOME=${DEFAULT_JDK}" >> /etc/environment
+                    update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
                     rm -f /etc/sudoers.d/90-cloud-init-users
                     echo "END CLOUDINIT"
                   javaPath: "/opt/jdk-17/bin/java"
-                  javaHome: "/opt/jdk-11"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
                   labels: "linux-amd64 linux-amd64-docker azure-vms-jenkins-sponsorship jdk11 maven-11"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 150
                   osDiskStorageAccountType: "Standard_LRS"
@@ -313,7 +312,7 @@ controller:
                   storageAccountNameReferenceType: "existing"
                   storageAccountType: "Standard_LRS"
                   subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
-                  templateDesc: "Dynamically provisioned Ubuntu 22.04 LTS AMD machine"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 LTS x86_64 machine"
                   templateName: "ubuntu-22"
                   usageMode: NORMAL
                   usePrivateIP: true
@@ -333,7 +332,7 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     #!/bin/bash
@@ -341,7 +340,7 @@ controller:
                     echo "START CLOUDINIT"
                     systemctl stop datadog-agent.service
                     mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed 's/api_key:.*/api_key: ^${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
                     sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
                     chown -R dd-agent:dd-agent /etc/datadog-agent
                     chmod 640 /etc/datadog-agent/datadog.yaml
@@ -358,17 +357,16 @@ controller:
                     systemctl daemon-reload
                     systemctl restart docker
                     export DEFAULT_JDK=/opt/jdk-17
-                    update-alternatives --install /usr/bin/java java "${DEFAULT_JDK}/bin/java" 2000
-                    echo "JAVA_HOME=${DEFAULT_JDK}" >> /etc/environment
+                    update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
                     rm -f /etc/sudoers.d/90-cloud-init-users
                     echo "END CLOUDINIT"
                   javaPath: "/opt/jdk-17/bin/java"
-                  javaHome: "/opt/jdk-17"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
                   labels: "linux-amd64-maven-17"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 150
                   osDiskStorageAccountType: "Standard_LRS"
@@ -378,7 +376,7 @@ controller:
                   storageAccountNameReferenceType: "existing"
                   storageAccountType: "Standard_LRS"
                   subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
-                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-17 LTS AMD machine"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-17 LTS x86_64 machine"
                   templateName: "ubuntu-22-amd64-maven-17"
                   usageMode: NORMAL
                   usePrivateIP: true
@@ -398,7 +396,7 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     #!/bin/bash
@@ -406,7 +404,7 @@ controller:
                     echo "START CLOUDINIT"
                     systemctl stop datadog-agent.service
                     mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed 's/api_key:.*/api_key: ^${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
                     sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
                     chown -R dd-agent:dd-agent /etc/datadog-agent
                     chmod 640 /etc/datadog-agent/datadog.yaml
@@ -423,17 +421,16 @@ controller:
                     systemctl daemon-reload
                     systemctl restart docker
                     export DEFAULT_JDK=/opt/jdk-21
-                    update-alternatives --install /usr/bin/java java "${DEFAULT_JDK}/bin/java" 2000
-                    echo "JAVA_HOME=${DEFAULT_JDK}" >> /etc/environment
+                    update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
                     rm -f /etc/sudoers.d/90-cloud-init-users
                     echo "END CLOUDINIT"
                   javaPath: "/opt/jdk-17/bin/java"
-                  javaHome: "/opt/jdk-21"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
                   labels: "linux-amd64-maven-21"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 150
                   osDiskStorageAccountType: "Standard_LRS"
@@ -443,7 +440,7 @@ controller:
                   storageAccountNameReferenceType: "existing"
                   storageAccountType: "Standard_LRS"
                   subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
-                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-21 LTS AMD machine"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-21 LTS x86_64 machine"
                   templateName: "ubuntu-22-amd64-maven-21"
                   usageMode: NORMAL
                   usePrivateIP: true
@@ -463,10 +460,10 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
-                    (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ${JENKINS_CI_DATADOG_API_KEY}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
+                    (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ^${JENKINS_CI_DATADOG_API_KEY}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
                     & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart
                     # Setup Docker Engine
                     @'
@@ -480,7 +477,7 @@ controller:
                   labels: "windows-2019 amd64 azure vm docker-windows docker-windows-2019 windows azure-vms-jenkins-sponsorship"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 150
                   osDiskStorageAccountType: "Standard_LRS"
@@ -510,10 +507,10 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
-                    (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ${JENKINS_CI_DATADOG_API_KEY}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
+                    (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ^${JENKINS_CI_DATADOG_API_KEY}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
                     & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart
                     # Setup Docker Engine
                     @'
@@ -527,7 +524,7 @@ controller:
                   labels: "windows-2022 amd64 azure vm docker-windows docker-windows-2022 windows azure-vms-jenkins-sponsorship"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 150
                   osDiskStorageAccountType: "Standard_LRS"
@@ -557,7 +554,7 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     #!/bin/bash
@@ -565,7 +562,7 @@ controller:
                     echo "START CLOUDINIT"
                     systemctl stop datadog-agent.service
                     mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed 's/api_key:.*/api_key: ^${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
                     sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
                     chown -R dd-agent:dd-agent /etc/datadog-agent
                     chmod 640 /etc/datadog-agent/datadog.yaml
@@ -582,17 +579,16 @@ controller:
                     systemctl daemon-reload
                     systemctl restart docker
                     export DEFAULT_JDK=/opt/jdk-11
-                    update-alternatives --install /usr/bin/java java "${DEFAULT_JDK}/bin/java" 2000
-                    echo "JAVA_HOME=${DEFAULT_JDK}" >> /etc/environment
+                    update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
                     rm -f /etc/sudoers.d/90-cloud-init-users
                     echo "END CLOUDINIT"
                   javaPath: "/opt/jdk-17/bin/java"
-                  javaHome: "/opt/jdk-11"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
-                  labels: "linux-arm64 linux-arm64-docker azure-vms-jenkins-sponsorship arm64linux jdk11 maven-11"
+                  labels: "linux-arm64 linux-arm64-docker azure-vms-jenkins-sponsorship arm64linux jdk11-arm64 maven-11-arm64"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 100 # https://github.com/jenkins-infra/helpdesk/issues/3812
                   osDiskStorageAccountType: "Standard_LRS"
@@ -602,7 +598,7 @@ controller:
                   storageAccountNameReferenceType: "existing"
                   storageAccountType: "Standard_LRS"
                   subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
-                  templateDesc: "Dynamically provisioned Ubuntu 22.04 LTS ARM machine"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 LTS arm64 machine"
                   templateName: "ubuntu-22-arm64"
                   usageMode: NORMAL
                   usePrivateIP: true
@@ -622,7 +618,7 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     #!/bin/bash
@@ -630,7 +626,7 @@ controller:
                     echo "START CLOUDINIT"
                     systemctl stop datadog-agent.service
                     mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed 's/api_key:.*/api_key: ^${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
                     sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
                     chown -R dd-agent:dd-agent /etc/datadog-agent
                     chmod 640 /etc/datadog-agent/datadog.yaml
@@ -647,17 +643,16 @@ controller:
                     systemctl daemon-reload
                     systemctl restart docker
                     export DEFAULT_JDK=/opt/jdk-17
-                    update-alternatives --install /usr/bin/java java "${DEFAULT_JDK}/bin/java" 2000
-                    echo "JAVA_HOME=${DEFAULT_JDK}" >> /etc/environment
+                    update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
                     rm -f /etc/sudoers.d/90-cloud-init-users
                     echo "END CLOUDINIT"
                   javaPath: "/opt/jdk-17/bin/java"
-                  javaHome: "/opt/jdk-17"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
                   labels: "linux-arm64-maven-17"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 100 # https://github.com/jenkins-infra/helpdesk/issues/3812
                   osDiskStorageAccountType: "Standard_LRS"
@@ -667,7 +662,7 @@ controller:
                   storageAccountNameReferenceType: "existing"
                   storageAccountType: "Standard_LRS"
                   subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
-                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-17 LTS ARM machine"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-17 LTS arm64 machine"
                   templateName: "ubuntu-22-arm64-maven-17"
                   usageMode: NORMAL
                   usePrivateIP: true
@@ -687,7 +682,7 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     #!/bin/bash
@@ -695,7 +690,7 @@ controller:
                     echo "START CLOUDINIT"
                     systemctl stop datadog-agent.service
                     mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed 's/api_key:.*/api_key: ^${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
                     sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
                     chown -R dd-agent:dd-agent /etc/datadog-agent
                     chmod 640 /etc/datadog-agent/datadog.yaml
@@ -712,17 +707,16 @@ controller:
                     systemctl daemon-reload
                     systemctl restart docker
                     export DEFAULT_JDK=/opt/jdk-21
-                    update-alternatives --install /usr/bin/java java "${DEFAULT_JDK}/bin/java" 2000
-                    echo "JAVA_HOME=${DEFAULT_JDK}" >> /etc/environment
+                    update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
                     rm -f /etc/sudoers.d/90-cloud-init-users
                     echo "END CLOUDINIT"
                   javaPath: "/opt/jdk-17/bin/java"
-                  javaHome: "/opt/jdk-21"
                   jvmOptions: "-XX:+PrintCommandLineFlags"
                   labels: "linux-arm64-maven-21"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 100 # https://github.com/jenkins-infra/helpdesk/issues/3812
                   osDiskStorageAccountType: "Standard_LRS"
@@ -732,7 +726,7 @@ controller:
                   storageAccountNameReferenceType: "existing"
                   storageAccountType: "Standard_LRS"
                   subnetName: "infra-ci-jenkins-io-sponsorship-vnet-ephemeral-agents"
-                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-21 LTS ARM machine"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-21 LTS arm64 machine"
                   templateName: "ubuntu-22-arm64-maven-21"
                   usageMode: NORMAL
                   usePrivateIP: true

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -268,7 +268,7 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     #!/bin/bash
@@ -276,7 +276,7 @@ controller:
                     echo "START CLOUDINIT"
                     systemctl stop datadog-agent.service
                     mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ^${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
                     sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
                     chown -R dd-agent:dd-agent /etc/datadog-agent
                     chmod 640 /etc/datadog-agent/datadog.yaml
@@ -302,7 +302,7 @@ controller:
                   labels: "linux-amd64 linux-amd64-docker azure-vms-jenkins-sponsorship jdk11 maven-11"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 150
                   osDiskStorageAccountType: "Standard_LRS"
@@ -332,7 +332,7 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     #!/bin/bash
@@ -340,7 +340,7 @@ controller:
                     echo "START CLOUDINIT"
                     systemctl stop datadog-agent.service
                     mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ^${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
                     sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
                     chown -R dd-agent:dd-agent /etc/datadog-agent
                     chmod 640 /etc/datadog-agent/datadog.yaml
@@ -366,7 +366,7 @@ controller:
                   labels: "linux-amd64-maven-17"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 150
                   osDiskStorageAccountType: "Standard_LRS"
@@ -396,7 +396,7 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     #!/bin/bash
@@ -404,7 +404,7 @@ controller:
                     echo "START CLOUDINIT"
                     systemctl stop datadog-agent.service
                     mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ^${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
                     sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
                     chown -R dd-agent:dd-agent /etc/datadog-agent
                     chmod 640 /etc/datadog-agent/datadog.yaml
@@ -430,7 +430,7 @@ controller:
                   labels: "linux-amd64-maven-21"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 150
                   osDiskStorageAccountType: "Standard_LRS"
@@ -460,10 +460,10 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
-                    (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ^${JENKINS_CI_DATADOG_API_KEY}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
+                    (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ${JENKINS_CI_DATADOG_API_KEY}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
                     & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart
                     # Setup Docker Engine
                     @'
@@ -477,7 +477,7 @@ controller:
                   labels: "windows-2019 amd64 azure vm docker-windows docker-windows-2019 windows azure-vms-jenkins-sponsorship"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 150
                   osDiskStorageAccountType: "Standard_LRS"
@@ -507,10 +507,10 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
-                    (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ^${JENKINS_CI_DATADOG_API_KEY}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
+                    (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ${JENKINS_CI_DATADOG_API_KEY}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
                     & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart
                     # Setup Docker Engine
                     @'
@@ -524,7 +524,7 @@ controller:
                   labels: "windows-2022 amd64 azure vm docker-windows docker-windows-2022 windows azure-vms-jenkins-sponsorship"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 150
                   osDiskStorageAccountType: "Standard_LRS"
@@ -554,7 +554,7 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     #!/bin/bash
@@ -562,7 +562,7 @@ controller:
                     echo "START CLOUDINIT"
                     systemctl stop datadog-agent.service
                     mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ^${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
                     sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
                     chown -R dd-agent:dd-agent /etc/datadog-agent
                     chmod 640 /etc/datadog-agent/datadog.yaml
@@ -588,7 +588,7 @@ controller:
                   labels: "linux-arm64 linux-arm64-docker azure-vms-jenkins-sponsorship arm64linux jdk11-arm64 maven-11-arm64"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 100 # https://github.com/jenkins-infra/helpdesk/issues/3812
                   osDiskStorageAccountType: "Standard_LRS"
@@ -618,7 +618,7 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     #!/bin/bash
@@ -626,7 +626,7 @@ controller:
                     echo "START CLOUDINIT"
                     systemctl stop datadog-agent.service
                     mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ^${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
                     sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
                     chown -R dd-agent:dd-agent /etc/datadog-agent
                     chmod 640 /etc/datadog-agent/datadog.yaml
@@ -652,7 +652,7 @@ controller:
                   labels: "linux-arm64-maven-17"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 100 # https://github.com/jenkins-infra/helpdesk/issues/3812
                   osDiskStorageAccountType: "Standard_LRS"
@@ -682,7 +682,7 @@ controller:
                     galleryImageVersion: "1.86.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
-                    gallerySubscriptionId: "^${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+                    gallerySubscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
                   imageTopLevelType: "advanced"
                   initScript: |-
                     #!/bin/bash
@@ -690,7 +690,7 @@ controller:
                     echo "START CLOUDINIT"
                     systemctl stop datadog-agent.service
                     mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ^${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
                     sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
                     chown -R dd-agent:dd-agent /etc/datadog-agent
                     chmod 640 /etc/datadog-agent/datadog.yaml
@@ -716,7 +716,7 @@ controller:
                   labels: "linux-arm64-maven-21"
                   location: "East US 2"
                   maxVirtualMachinesLimit: 50
-                  existingStorageAccountName: "^${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
+                  existingStorageAccountName: "${AZURE_VM_AGENTS_STORAGE_ACCOUNT_SECONDARY_SUBSCRIPTION}"
                   noOfParallelJobs: 1
                   osDiskSize: 100 # https://github.com/jenkins-infra/helpdesk/issues/3812
                   osDiskStorageAccountType: "Standard_LRS"


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4124#issuecomment-2275506395

Added jdk-17 and jdk-21 Ubuntu-22(AMD and ARM) ssh agents to infra.ci, Ubuntu-22 (AMD and ARM) template will have jdk-11 by default.