### PR TITLE
chore(privatek8s/infra.ci.jio) temporarily uses the new UC

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -113,6 +113,10 @@ controller:
       agent-settings: |
         jenkins:
           numExecutors: 0
+          updateCenter:
+            sites:
+              - id: "default"
+                url: "https://azure.updates.jenkins.io/update-center.json"
           clouds:
             - kubernetes:
                 containerCapStr: "100"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2283576911


This PR sets up infra.ci.jenkins.io to have a custom UC using the new UC's intermediate URL. It will test Jenkins can retrieve metadata from it, but won't test the "redirects" used to download plugins 