### PR TITLE
fix(publick8s/mirrors.updates.jio) redirect the app-root to `/index.html`

### DIFF
--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -5,6 +5,7 @@ global:
     annotations:
       "cert-manager.io/cluster-issuer": "letsencrypt-prod"
       "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+      "nginx.ingress.kubernetes.io/app-root": "/index.html"
     hosts:
       - host: mirrors.updates.jenkins.io
         paths:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2283801444

This PR fixes the "too much redirection" when hitting the app root (https://azure.updates.jenkins.io -> https://mirrors.updates.jenkins.io -> https://azure.updates.jenkins.io etc.).

It set up the ingress to immediately redirects any exact request on `/` to the `/index.html` file explicitly so the file is served by a mirror (instead of the Azure cluster).