### PR TITLE
feat(publick8s) install geoipdata chart

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -268,3 +268,11 @@ releases:
       - "../config/stats.jenkins.io.yaml"
     secrets:
       - "../secrets/config/stats.jenkins.io/secrets.yaml"
+  - name: geoipdata
+    namespace: geoip-data
+    chart: jenkins-infra/geoipupdates
+    version: 0.0.1
+    values:
+      - ../config/geoipdata.yaml
+    secrets:
+      - ../secrets/config/geoipdata/secrets.yaml

--- a/config/geoipdata.yaml
+++ b/config/geoipdata.yaml
@@ -1,0 +1,32 @@
+geoipupdate:
+  update_frequency: 72
+podSecurityContext:
+  runAsUser: 65534  # User 'nobody'
+  runAsGroup: 65534  # Group 'nogroup'
+  runAsNonRoot: true
+containerSecurityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 50m
+  #   memory: 64Mi
+
+nodeSelector:
+  kubernetes.io/arch: arm64
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+
+dataVolume:
+  persistentVolumeClaim:
+    claimName: geoip-data

--- a/config/geoipdata.yaml
+++ b/config/geoipdata.yaml
@@ -5,19 +5,19 @@ podSecurityContext:
   runAsGroup: 65534  # Group 'nogroup'
   runAsNonRoot: true
 containerSecurityContext:
-    readOnlyRootFilesystem: true
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 
-resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 50m
-  #   memory: 64Mi
+resources:
+  limits:
+    cpu: 500m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
 
 nodeSelector:
   kubernetes.io/arch: arm64

--- a/config/public-nginx-ingress__common.yaml
+++ b/config/public-nginx-ingress__common.yaml
@@ -34,8 +34,8 @@ controller:
     hsts-include-subdomains: "true"
     # Strict-Transport-Security "max-age" directive recommended value is 2592000 (30 days).
     hsts-max-age: "2592000"
-    use-gzip: true # gzip types are the defaults: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#gzip-types
-    enable-brotli: true # see default settings in https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-brotli
+    use-gzip: true  # gzip types are the defaults: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#gzip-types
+    enable-brotli: true  # see default settings in https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#enable-brotli
   replicaCount: 1
   ingressClassResource:
     enabled: true


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4240

This PR installs the new chart `geoipupdates` in a new namespace `geoipdata`.

Requires:

- https://github.com/jenkins-infra/azure/pull/803 to have a provisioned PVC in the namespace `geoipdata`
- https://github.com/jenkins-infra/helm-charts/releases/tag/geoipupdates-0.0.1 (first release of the chart)
- https://github.com/jenkins-infra/charts-secrets/commit/78d89c557a9863219d087023abf4fd180ed7add6 for the secrets