### PR TITLE
feat(publick8s/updates.jenkins.io) bump mirrorbits chart from 2.x to 4.x

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -231,7 +231,7 @@ releases:
   - name: updates-jenkins-io
     namespace: updates-jenkins-io
     chart: jenkins-infra/mirrorbits-parent
-    version: 2.1.1
+    version: 4.0.0
     values:
       - "../config/updates.jenkins.io.yaml"
     secrets:

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -72,6 +72,34 @@ mirrorbits:
       memory: 200Mi
   nodeSelector:
     kubernetes.io/arch: amd64
+  config:
+    gzip: true
+    traceFile: /TIME
+    redis:
+      address: updates-jenkins-io.redis.cache.windows.net:6379
+      # password is stored in SOPS secrets
+      dbId: 0
+    scanInterval: 10
+    repositoryScanInterval: 10
+    checkInterval: 1
+    disallowRedirects: true
+    disableOnMissingFile: false
+    # No fallbacks
+  geoipdata:
+    persistentData:
+      enabled: true
+      capacity: 1Gi
+      storageClassName: statically-provisionned
+      csi:
+        driver: file.csi.azure.com
+        fsType: ext4
+        nodeStageSecretRef:
+          name: geoip-data
+          namespace: geoip-data
+        volumeAttributes:
+          resourceGroup: publick8s
+          shareName: geoip-data
+        volumeHandle: https://publick8spvdata.file.core.windows.net/geoip-data
 
 httpd:
   enabled: false


### PR DESCRIPTION
Requires:
- The chart v4.x to be published - 
- Secrets to be updates: https://github.com/jenkins-infra/charts-secrets/commit/ca6c979ff887dce71fc2b67060aada3bf60e123e

Related to https://github.com/jenkins-infra/helpdesk/issues/4240 and https://github.com/jenkins-infra/helpdesk/issues/2649, this PR bumps the publick8s/updates.jenkins.io mirrorbits chart up to 2 major versions with configuration update to:

- 3.x:
  - Have a visible mirrorbits configuration through values to fine tune the scans compared to the updates center regular runs
  - Removing fallbacks to avoid URL rewrites with removal of the first `/` in URIs (https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2286023633)
  - Do not remove a mirror when it responds a 404 or 3xx to avoid errors when scanning
- 4.x: remove GeoIP containers (rely on a centralized PVC) to avoid blocking errors - https://github.com/jenkins-infra/helpdesk/issues/4240