### PR TITLE
feat(publick8s/get.jenkins.io) bump mirrorbits chart from 2.x to 4.x

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -181,7 +181,7 @@ releases:
   - name: get-jenkins-io
     namespace: get-jenkins-io
     chart: jenkins-infra/mirrorbits-parent
-    version: 2.1.1
+    version: 4.0.0
     values:
       - "../config/get-jenkins-io.yaml"
     secrets:

--- a/config/get-jenkins-io.yaml
+++ b/config/get-jenkins-io.yaml
@@ -85,6 +85,38 @@ mirrorbits:
                 values:
                   - mirrorbits
           topologyKey: "kubernetes.io/hostname"
+  config:
+    gzip: true
+    traceFile: /TIME
+    redis:
+      address: jenkins-mirrorbits.redis.cache.windows.net:6379
+      # password is stored in SOPS secrets
+      ## RedisDB - Use 1 for staging and 0 for production
+      dbId: 0
+    scanInterval: 10
+    repositoryScanInterval: 5
+    checkInterval: 1
+    disallowRedirects: true
+    disableOnMissingFile: true
+    fallbacks:
+      - url: https://archives.jenkins.io/
+        countryCode: DE
+        continentCode: EU
+  geoipdata:
+    persistentData:
+      enabled: true
+      capacity: 1Gi
+      storageClassName: statically-provisionned
+      csi:
+        driver: file.csi.azure.com
+        fsType: ext4
+        nodeStageSecretRef:
+          name: geoip-data
+          namespace: geoip-data
+        volumeAttributes:
+          resourceGroup: publick8s
+          shareName: geoip-data
+        volumeHandle: https://publick8spvdata.file.core.windows.net/geoip-data
 
 httpd:
   enabled: true


### PR DESCRIPTION
Same as https://github.com/jenkins-infra/kubernetes-management/pull/5565, related to https://github.com/jenkins-infra/helpdesk/issues/4240

This PR updates the mirrorbits chart to 4.0.0 with the associated configuration.

Requires https://github.com/jenkins-infra/charts-secrets/commit/95657f9458ff57157663bb20a7e71afed1e7e6c7