### PR TITLE
fix(publick8s) ensure enforced security for both get.jenkins.io and azure.updates.jenkins.io

### DIFF
--- a/config/get-jenkins-io.yaml
+++ b/config/get-jenkins-io.yaml
@@ -75,6 +75,16 @@ mirrorbits:
       memory: 400Mi
   nodeSelector:
     kubernetes.io/arch: amd64
+  podSecurityContext:
+    runAsUser: 1000  # User 'mirrorbits'
+    runAsGroup: 1000  # Group 'mirrorbits'
+    runAsNonRoot: true
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -72,6 +72,16 @@ mirrorbits:
       memory: 200Mi
   nodeSelector:
     kubernetes.io/arch: amd64
+  podSecurityContext:
+    runAsUser: 1000  # User 'mirrorbits'
+    runAsGroup: 1000  # Group 'mirrorbits'
+    runAsNonRoot: true
+  containerSecurityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
   config:
     gzip: true
     traceFile: /TIME


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649

Requires the version 5.0.1 of the mirrorbits chart (deployed with https://github.com/jenkins-infra/kubernetes-management/pull/5578)

This PR ensures that both mirrorbits systems have enforced security:

- No privilege escalation possible
- No capacilities
- Readonly rootFS
- non root user enforced