### PR TITLE
fix(publick8s/updates.jio) fine tune configuration: set up correct scan intervals, disable gzip and do not block mirrors when redirecting

### DIFF
--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -100,7 +100,10 @@ mirrorbits:
     checkInterval: 1
     disallowRedirects: false
     disableOnMissingFile: false
-    # No fallbacks
+    fallbacks:
+      - url: https://eastamerica.cloudflare.jenkins.io/
+        countryCode: US
+        continentCode: NA
   geoipdata:
     persistentData:
       enabled: true

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -83,16 +83,22 @@ mirrorbits:
       drop:
         - ALL
   config:
-    gzip: true
+    # Ingress already does gzip
+    gzip: false
     traceFile: /TIME
     redis:
       address: updates-jenkins-io.redis.cache.windows.net:6379
       # password is stored in SOPS secrets
       dbId: 0
-    scanInterval: 10
-    repositoryScanInterval: 10
+    ## Interval between two scans of the local repository.
+    ## This should, more or less, match the frequency where the local repo is updated.
+    ## TODO: set it once a day once the update-center2 would run a `mirrorbits refresh` command by itself
+    repositoryScanInterval: 5
+    ## Interval in minutes between mirror scan
+    ## Once a day is enough as jenkins-infra/update-center2 runs it every 5 min.
+    scanInterval: 1440
     checkInterval: 1
-    disallowRedirects: true
+    disallowRedirects: false
     disableOnMissingFile: false
     # No fallbacks
   geoipdata:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649

This PR fines tunes the mirrors.updates.jio mirrorbits service:
- Disable Gzip (as the ingress already uses gzip or brotli: https://github.com/jenkins-infra/kubernetes-management/blob/e7ce1aa86f72571e29762bb105ada0c6ad65d425/config/public-nginx-ingress__common.yaml#L37-L38) so mirrorbits will use less CPU and will have better latency
- Only scan mirrors once a day since update center already scans every 5 min
- Scan the local repository at the same frequency as the UC script (e.g. 5 min)
- Do NOT disable a mirror if it triggers a redirect
- Set the US East mirror as fallback to handle the 10-15s window every 5 min where local repository is refreshed => this should fix the HTTP/503 errors