### PR TITLE
fix(publick8s/get.jio) disable gzip + comments

### DIFF
--- a/config/get-jenkins-io.yaml
+++ b/config/get-jenkins-io.yaml
@@ -96,19 +96,31 @@ mirrorbits:
                   - mirrorbits
           topologyKey: "kubernetes.io/hostname"
   config:
-    gzip: true
+    # Ingress already does gzip/brotli
+    gzip: false
     traceFile: /TIME
     redis:
       address: jenkins-mirrorbits.redis.cache.windows.net:6379
       # password is stored in SOPS secrets
       ## RedisDB - Use 1 for staging and 0 for production
       dbId: 0
+    ## Interval in minutes between mirrors scan
     scanInterval: 10
+    ## Interval between two scans of the local repository.
+    ## This should, more or less, match the frequency where the local repo is updated (e.g. update center)
     repositoryScanInterval: 5
     checkInterval: 1
+    # Disable a mirror if it triggers HTTP/3xx redirects on its own (safer for mirrors we do not control)
     disallowRedirects: true
+    # Disable a mirror if a missing file is requested (safer for mirrors we do not control)
     disableOnMissingFile: true
+    ## List of mirrors to use as fallback which will be used in case mirrorbits
+    ## is unable to answer a request because the database is unreachable.
+    ## Note: Mirrorbits will redirect to one of these mirrors based on the user
+    ## location but won't be able to know if the mirror has the requested file.
+    ## Therefore only put your most reliable and up-to-date mirrors here.
     fallbacks:
+      ## archives.jenkins.io has ALL the artefacts
       - url: https://archives.jenkins.io/
         countryCode: DE
         continentCode: EU

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -83,12 +83,13 @@ mirrorbits:
       drop:
         - ALL
   config:
-    # Ingress already does gzip
+    # Ingress already does gzip/brotli
     gzip: false
     traceFile: /TIME
     redis:
       address: updates-jenkins-io.redis.cache.windows.net:6379
       # password is stored in SOPS secrets
+      ## RedisDB - Use 1 for staging and 0 for production
       dbId: 0
     ## Interval between two scans of the local repository.
     ## This should, more or less, match the frequency where the local repo is updated.
@@ -100,7 +101,13 @@ mirrorbits:
     checkInterval: 1
     disallowRedirects: false
     disableOnMissingFile: false
+    ## List of mirrors to use as fallback which will be used in case mirrorbits
+    ## is unable to answer a request because the database is unreachable.
+    ## Note: Mirrorbits will redirect to one of these mirrors based on the user
+    ## location but won't be able to know if the mirror has the requested file.
+    ## Therefore only put your most reliable and up-to-date mirrors here.
     fallbacks:
+      # We always fall back to this mirror. Useful to serve stale file during a mirror scan
       - url: https://eastamerica.cloudflare.jenkins.io/
         countryCode: US
         continentCode: NA

--- a/yamllint.config
+++ b/yamllint.config
@@ -2,5 +2,6 @@ extends: default
 
 rules:
   line-length: disable
-
   document-start: disable
+  comments:
+    min-spaces-from-content: 1


### PR DESCRIPTION
This PR introduces the following changes:

- Disable gzip on the mirrorbits backends as [ingress is doing gzip now](https://github.com/jenkins-infra/kubernetes-management/pull/5442)
- chore: set up yamllint comments rule to avoid warning due to updatecli parser (see https://github.com/jenkins-infra/kubernetes-management/commit/7f68d6474b095ddc530d0a6613d31d2c63fe01e8)
- Add comments for get.jio and updates.jio values to help understand