### PR TITLE
feat(publick8s/get.jio + mirrors.updates.jio) switch to arm64 nodes

### DIFF
--- a/config/get-jenkins-io.yaml
+++ b/config/get-jenkins-io.yaml
@@ -74,7 +74,12 @@ mirrorbits:
       cpu: 100m
       memory: 400Mi
   nodeSelector:
-    kubernetes.io/arch: amd64
+    kubernetes.io/arch: arm64
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
   podSecurityContext:
     runAsUser: 1000  # User 'mirrorbits'
     runAsGroup: 1000  # Group 'mirrorbits'

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -71,7 +71,12 @@ mirrorbits:
       cpu: 100m
       memory: 200Mi
   nodeSelector:
-    kubernetes.io/arch: amd64
+    kubernetes.io/arch: arm64
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
   podSecurityContext:
     runAsUser: 1000  # User 'mirrorbits'
     runAsGroup: 1000  # Group 'mirrorbits'


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3837

This PR migrates the 4 mirrorbits pods (2 for get.jenkins.io and 2 for updates.jenkins.io) to `arm64` nodes.

Requires https://github.com/jenkins-infra/kubernetes-management/pull/5585 to ensure we have a mirrorbits image with full support for both CPU architectures
