### PR TITLE
fix(stats.jenkins.io): enable `try_files` directive to allow direct links

### DIFF
--- a/config/stats.jenkins.io.yaml
+++ b/config/stats.jenkins.io.yaml
@@ -49,3 +49,7 @@ affinity:
               values:
                 - stats-jenkins-io
         topologyKey: "kubernetes.io/hostname"
+
+nginx:
+  slashLocation:
+    tryFiles: $uri /index.html


### PR DESCRIPTION
This PR enables `try_files` nginx config directive to allow direct links for this React application.

Ref:
- https://github.com/jenkins-infra/stats.jenkins.io/issues/118
- https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2298635602
- https://github.com/jenkins-infra/helm-charts/pull/1297