### PR TITLE
fix(infra.ci.jio): init script fix for linux AZ agents

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -422,15 +422,20 @@ controller:
                     #!/bin/bash
                     set -eux
                     echo "START CLOUDINIT"
-                    systemctl stop datadog-agent.service
-                    mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
-                    sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
-                    chown -R dd-agent:dd-agent /etc/datadog-agent
-                    chmod 640 /etc/datadog-agent/datadog.yaml
-                    chown -R dd-agent:dd-agent /var/log/datadog
-                    chmod 770 /var/log/datadog
-                    systemctl start datadog-agent.service
+                    # Setup Datadog service
+                    (
+                      systemctl stop datadog-agent.service
+                      mkdir -p /var/log/datadog /etc/datadog-agent
+                      sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                      sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+                      chmod 640 /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /var/log/datadog
+                      chmod 770 /var/log/datadog
+                      systemctl daemon-reload
+                      systemctl enable datadog-agent.service
+                      systemctl start datadog-agent.service
+                    ) 2>&1 | tee /var/log/agent-init-datadog.log
                     # Setup Docker Engine
                     mkdir -p /etc/docker
                     cat <<EOF >/etc/docker/daemon.json
@@ -486,15 +491,20 @@ controller:
                     #!/bin/bash
                     set -eux
                     echo "START CLOUDINIT"
-                    systemctl stop datadog-agent.service
-                    mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
-                    sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
-                    chown -R dd-agent:dd-agent /etc/datadog-agent
-                    chmod 640 /etc/datadog-agent/datadog.yaml
-                    chown -R dd-agent:dd-agent /var/log/datadog
-                    chmod 770 /var/log/datadog
-                    systemctl start datadog-agent.service
+                    # Setup Datadog service
+                    (
+                      systemctl stop datadog-agent.service
+                      mkdir -p /var/log/datadog /etc/datadog-agent
+                      sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                      sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+                      chmod 640 /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /var/log/datadog
+                      chmod 770 /var/log/datadog
+                      systemctl daemon-reload
+                      systemctl enable datadog-agent.service
+                      systemctl start datadog-agent.service
+                    ) 2>&1 | tee /var/log/agent-init-datadog.log
                     # Setup Docker Engine
                     mkdir -p /etc/docker
                     cat <<EOF >/etc/docker/daemon.json
@@ -550,15 +560,20 @@ controller:
                     #!/bin/bash
                     set -eux
                     echo "START CLOUDINIT"
-                    systemctl stop datadog-agent.service
-                    mkdir -p /var/log/datadog /etc/datadog-agent
-                    sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
-                    sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
-                    chown -R dd-agent:dd-agent /etc/datadog-agent
-                    chmod 640 /etc/datadog-agent/datadog.yaml
-                    chown -R dd-agent:dd-agent /var/log/datadog
-                    chmod 770 /var/log/datadog
-                    systemctl start datadog-agent.service
+                    # Setup Datadog service
+                    (
+                      systemctl stop datadog-agent.service
+                      mkdir -p /var/log/datadog /etc/datadog-agent
+                      sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                      sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+                      chmod 640 /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /var/log/datadog
+                      chmod 770 /var/log/datadog
+                      systemctl daemon-reload
+                      systemctl enable datadog-agent.service
+                      systemctl start datadog-agent.service
+                    ) 2>&1 | tee /var/log/agent-init-datadog.log
                     # Setup Docker Engine
                     mkdir -p /etc/docker
                     cat <<EOF >/etc/docker/daemon.json


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4124#issuecomment-2295792812

init script while deploying AZ linux vms has been fixed thus the linux JDK agents can be added to infra.ci.

Changes made has been generalised to other linux agents as per https://github.com/jenkins-infra/helpdesk/issues/4244#issuecomment-2301394723