### PR TITLE
chore(infracijioagents1): removing temporarily from management to upgrade to kubernetes 1.29

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,8 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'privatek8s', 'publick8s', 'cijioagents1', 'infracijioagents1'
-          }
+            values 'privatek8s', 'publick8s', 'cijioagents1'
         } // axes
         agent {
           label 'jnlp-linux-arm64'

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -28,6 +28,7 @@ pipeline {
           axis {
             name 'K8S_CLUSTER'
             values 'privatek8s', 'publick8s', 'cijioagents1'
+          }
         } // axes
         agent {
           label 'jnlp-linux-arm64'


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4161#issuecomment-2299149540

`infracijioagents1` is removed from the kubenetes-management to upgrade to kubernetes 1.29