### PR TITLE
hotfix(privatek8s/infra.ci) use correct owner for docker-jobs GH app

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -21,7 +21,7 @@ jobsDefinition:
       github-app-infra.ci.jenkins.io-jenkins-jobs:
         description: "Github App infra.ci.jenkins.io-docker-jobs installed on jenkins-infra org"
         appId: "${GITHUB_APP_INFRA_CI_DOCKER_JOBS_ID}"
-        owner: "jenkinsci"
+        owner: "jenkins-infra"
         privateKey: "${GITHUB_APP_INFRA_CI_DOCKER_JOBS_PRIVATE_KEY}"
     children:
       acceptance-test-harness:


### PR DESCRIPTION
Fixup of #5559

Related to https://github.com/jenkins-infra/helpdesk/issues/4165

Fixes the following error:

```
[Wed Aug 21 16:56:38 UTC 2024] Starting branch indexing...
ERROR: [Wed Aug 21 16:56:38 UTC 2024] Could not update folder level actions from source docker-jobs/account-app
[Wed Aug 21 16:56:38 UTC 2024] Finished branch indexing. Indexing took 0 ms
FATAL: Failed to recompute children of Docker Jobs » account-app
java.lang.IllegalArgumentException: Owner mismatch: jenkinsci vs. jenkins-infra
```