### PR TITLE
feat(privatek8s/infra.ci) set up Terraform Jobs to use a new folder-scoped GHA

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -364,10 +364,16 @@ jobsDefinition:
       azure-reports-access-key:
         description: "Azure Storage Key used by infra-reports to publish to a storage bucket"
         secret: "${AZURE_INFRA_REPORTS_STORAGE_KEY}"
+      github-app-infra.ci.jenkins.io-terraform-jobs:
+        description: "Github App infra.ci.jenkins.io-docker-jobs installed on jenkins-infra org"
+        appId: "${GITHUB_APP_INFRA_CI_TERRAFORM_JOBS_ID}"
+        owner: "jenkins-infra"
+        privateKey: "${GITHUB_APP_INFRA_CI_TERRAFORM_JOBS_PRIVATE_KEY}"
     children:
       aws:
         name: Terraform AWS
         description: AWS resources managed by Terraform
+        githubCredentialsId: github-app-infra.ci.jenkins.io-terraform-jobs
         credentials:
           staging-terraform-aws-access-key:
             secret: "${STAGING_TERRAFORM_AWS_ACCESS_KEY_ID}"
@@ -391,6 +397,7 @@ jobsDefinition:
       azure:
         name: Terraform Azure
         description: "Azure resources managed by Terraform"
+        githubCredentialsId: github-app-infra.ci.jenkins.io-terraform-jobs
         credentials:
           production-terraform-azure-serviceprincipal:
             azureEnvironmentName: "Azure"
@@ -417,6 +424,7 @@ jobsDefinition:
       azure-net:
         name: Terraform Azure-net
         description: "Azure-net resources managed by Terraform"
+        githubCredentialsId: github-app-infra.ci.jenkins.io-terraform-jobs
         credentials:
           production-terraform-azure-net-serviceprincipal:
             azureEnvironmentName: "Azure-net"
@@ -443,6 +451,7 @@ jobsDefinition:
       cloudflare:
         name: Terraform CloudFlare
         description: "CloudFlare resources managed by Terraform"
+        githubCredentialsId: github-app-infra.ci.jenkins.io-terraform-jobs
         credentials:
           staging-cloudflare-api-token:
             secret: "${STAGING_CLOUDFLARE_API_TOKEN}"
@@ -461,6 +470,7 @@ jobsDefinition:
       datadog:
         name: Terraform Datadog
         description: "Datadog resources managed by Terraform"
+        githubCredentialsId: github-app-infra.ci.jenkins.io-terraform-jobs
         credentials:
           production-datadog-api-key:
             secret: "${PRODUCTION_DATADOG_API_KEY}"
@@ -486,6 +496,7 @@ jobsDefinition:
       digitalocean:
         name: Terraform Digital Ocean
         description: "Digital Ocean resources managed by Terraform"
+        githubCredentialsId: github-app-infra.ci.jenkins.io-terraform-jobs
         credentials:
           staging-terraform-digitalocean-pat:
             secret: "${STAGING_TERRAFORM_DIGITALOCEAN_PAT}"
@@ -503,6 +514,7 @@ jobsDefinition:
       fastly:
         name: Terraform Fastly
         description: "Fastly resources managed by Terraform"
+        githubCredentialsId: github-app-infra.ci.jenkins.io-terraform-jobs
         credentials:
           staging-terraform-fastly-api-key:
             secret: "${STAGING_TERRAFORM_FASTLY_API_KEY}"

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -18,7 +18,7 @@ jobsDefinition:
         description: Docker hub credential for jenkinsinfra organisation PULL
         username: infracijenkinsio
         password: "${DOCKER_HUB_TOKEN_INFRACIJENKINSIO_PULL}"
-      github-app-infra.ci.jenkins.io-jenkins-jobs:
+      github-app-infra.ci.jenkins.io-docker-jobs:
         description: "Github App infra.ci.jenkins.io-docker-jobs installed on jenkins-infra org"
         appId: "${GITHUB_APP_INFRA_CI_DOCKER_JOBS_ID}"
         owner: "jenkins-infra"
@@ -36,51 +36,51 @@ jobsDefinition:
             owner: "jenkinsci"
             privateKey: "${GITHUB_APP_JENKINSCI_PRIVATE_KEY}"
       account-app:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
         jenkinsfilePath: Jenkinsfile
       docker-404:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-builder:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-confluence-data:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-crond:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-inbound-agents:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-jenkins-lts:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-jenkins-weeklyci:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-jenkins-infraci:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-keycloak-theme:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-ldap:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-mirrorbits:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-openvpn:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-packaging:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-plugin-site-issues:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       docker-rsyncd:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       ircbot:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
         jenkinsfilePath: Jenkinsfile
       plugin-health-scoring:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
         jenkinsfilePath: Jenkinsfile
       plugin-site-api:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
         jenkinsfilePath: Jenkinsfile
       rating:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
       uplink:
-        githubCredentialsId: github-app-infra.ci.jenkins.io-jenkins-jobs
+        githubCredentialsId: github-app-infra.ci.jenkins.io-docker-jobs
         jenkinsfilePath: Jenkinsfile
   infra-tools:
     name: Infrastructure Tooling Jobs


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4165#issuecomment-2302520444

Requires https://github.com/jenkins-infra/charts-secrets/commit/af886926f77c8d9fe4a48fdf815892b782e3f04a

Twin of #5599 but for Terraform Jobs

This PR also fixes the credential ID to avoid confusion (fixup of #5599)

Applied to the 7 Terraform Jobs