### PR TITLE
feat(privatek8s/infra.ci) add GH app for Docker jobs (deployment only)

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -23,6 +23,11 @@ jobsDefinition:
         appId: "${GITHUB_APP_INFRA_CI_DOCKER_JOBS_ID}"
         owner: "jenkins-infra"
         privateKey: "${GITHUB_APP_INFRA_CI_DOCKER_JOBS_PRIVATE_KEY}"
+      github-app-infra.ci.jenkins.io-docker-deploy:
+        description: "Github App infra.ci.jenkins.io-docker-deploy (read and write permissions) installed on jenkins-infra org"
+        appId: "${GITHUB_APP_INFRA_CI_DOCKER_DEPLOY_ID}"
+        owner: "jenkins-infra"
+        privateKey: "${GITHUB_APP_INFRA_CI_DOCKER_DEPLOY_PRIVATE_KEY}"
     children:
       acceptance-test-harness:
         name: "Jenkins CI Acceptance Test Harness (ATH) Docker Image"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4256

Requires SOPS secrets to be added - https://github.com/jenkins-infra/charts-secrets/commit/9768641ff796c7f307f714f885c2bc308b8506a5