### PR TITLE
Revert "chore: exclude publick8s cluster while upgrading to 1.29"

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'privatek8s', 'cijioagents1', 'infracijioagents1'
+            values 'privatek8s', 'publick8s', 'cijioagents1', 'infracijioagents1'
           }
         } // axes
         agent {


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#5616

Related to https://github.com/jenkins-infra/helpdesk/issues/4161#issuecomment-2306560872