### PR TITLE
fix(privatek8s/infra.ci) ensure updatecli pipelines - wether olds (in Docker jobs) and news (in Update Cli jobs) have the correct GitHub app

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -28,6 +28,11 @@ jobsDefinition:
         appId: "${GITHUB_APP_INFRA_CI_DOCKER_DEPLOY_ID}"
         owner: "jenkins-infra"
         privateKey: "${GITHUB_APP_INFRA_CI_DOCKER_DEPLOY_PRIVATE_KEY}"
+      github-app-updatecli-on-jenkins-infra:
+        description: "GitHub App for updatecli tasks on jenkins-infra org"
+        appId: "${GITHUB_APP_JENKINS_INFRA_UPDATECLI_ID}"
+        owner: "jenkins-infra"
+        privateKey: "${GITHUB_APP_JENKINS_INFRA_UPDATECLI_PRIVATE_KEY}"
     childrenGithubCredential: github-app-infra.ci.jenkins.io-docker-jobs
     children:
       acceptance-test-harness:
@@ -133,6 +138,13 @@ jobsDefinition:
   updatecli:
     name: Dependencies Management with Updatecli
     kind: folder
+    credentials:
+      github-app-updatecli-on-jenkins-infra:
+        description: "GitHub App for updatecli tasks on jenkins-infra org"
+        appId: "${GITHUB_APP_JENKINS_INFRA_UPDATECLI_ID}"
+        owner: "jenkins-infra"
+        privateKey: "${GITHUB_APP_JENKINS_INFRA_UPDATECLI_PRIVATE_KEY}"
+    childrenGithubCredential: github-app-updatecli-on-jenkins-infra
     children:
       aws:
         jenkinsfilePath: Jenkinsfile_updatecli

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -77,13 +77,6 @@ controller:
                     id: "github-app-infra"
                     privateKey: "${GITHUB_APP_PRIVATE_KEY}"
                     scope: GLOBAL
-                - gitHubApp:
-                    appID: "${GITHUB_APP_JENKINS_INFRA_UPDATECLI_ID}"
-                    description: "GitHub App for updatecli tasks on jenkins-infra org"
-                    id: "github-app-updatecli-on-jenkins-infra"
-                    privateKey: "${GITHUB_APP_JENKINS_INFRA_UPDATECLI_PRIVATE_KEY}"
-                    owner: "jenkins-infra"
-                    scope: GLOBAL
                 - azure:
                     azureEnvironmentName: "Azure"
                     clientId: "${JENKINSINFRA_AZURE_CLIENT_ID}"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4165

This PR ensures that the Updatecli Gh App is only used where necessary:
- Top level credential removed
- Both UpdateCLI Jobs and Docker Jobs have the new credz

It will also fix the failing build of the new Updatecli Jobs

Search for this credential ID: https://github.com/search?q=org%3Ajenkins-infra%20github-app-updatecli-on-jenkins-infra&type=code