### PR TITLE
feat(publick8S/mirrors.updates.jio) switch to public-redis instance

### DIFF
--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -92,10 +92,10 @@ mirrorbits:
     gzip: false
     traceFile: /TIME
     redis:
-      address: updates-jenkins-io.redis.cache.windows.net:6379
+      address: public-redis.redis.cache.windows.net:6379
       # password is stored in SOPS secrets
-      ## RedisDB - Use 1 for staging and 0 for production
-      dbId: 0
+      ## RedisDB - Use 0 for staging and 1, get.jio production and 2 for update.jio production
+      dbId: 2
     ## Interval between two scans of the local repository.
     ## This should, more or less, match the frequency where the local repo is updated.
     ## TODO: set it once a day once the update-center2 would run a `mirrorbits refresh` command by itself


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4259

we switch mirrors.updates.jenkins.io mirrorbits to the public redis instance on azure.

need https://github.com/jenkins-infra/charts-secrets/commit/cb6bd65a3416a51f65f69c84931678ac97a2b48a before merging.

once merged, mirrorbits is expected to use fallback: no user impact expected except for geo-localization of requests.