### PR TITLE
feat(publick8s/mirrors.updates.jio) enable `mirrorbits` CLI

### DIFF
--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -116,6 +116,16 @@ mirrorbits:
       - url: https://eastamerica.cloudflare.jenkins.io/
         countryCode: US
         continentCode: NA
+  cli:
+    enabled: true
+    service:
+      type: LoadBalancer
+      annotations:
+        service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+        service.beta.kubernetes.io/azure-pls-create: "true"
+        service.beta.kubernetes.io/azure-pls-name: "updates.jenkins.io-cli"
+        service.beta.kubernetes.io/azure-pls-visibility: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+        service.beta.kubernetes.io/azure-pls-auto-approval: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
   geoipdata:
     persistentData:
       enabled: true

--- a/updatecli/updatecli.d/charts/jenkins-infra-tools-maven.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-infra-tools-maven.yaml
@@ -24,6 +24,7 @@ sources:
           pattern: 'galleryImageVersion:\s"(.*)"'
           captureindex: 1
   getMavenVersionFromPackerImages:
+    # Using a file with a transformer until https://github.com/updatecli/updatecli/issues/2275 is done
     kind: file
     name: Get the latest Maven version set in packer-images
     dependson:


### PR DESCRIPTION
This change enables the `mirrorbits` CLI and exposes the server gRPC protocol through a Kubernetes Service.

This service of `LoadBalancer` kind associated to an Azure Private Link service: it allows access through private networks without requiring any network peering of any kind.

Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2325103688

Requires:

- Helm chart support for the `mirrorbits` CLI: https://github.com/jenkins-infra/helm-charts/pull/1291
- Permission to be fixed to allow `publick8s` to manage the Azure PLS: https://github.com/jenkins-infra/azure/pull/819