### PR TITLE
feat(publick8s/updates.jenkins.io) switch PLS to the data tier subnet

### DIFF
--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -124,6 +124,7 @@ mirrorbits:
         service.beta.kubernetes.io/azure-load-balancer-internal: "true"
         service.beta.kubernetes.io/azure-pls-create: "true"
         service.beta.kubernetes.io/azure-pls-name: "updates.jenkins.io-cli"
+        service.beta.kubernetes.io/azure-pls-ip-configuration-subnet: "public-vnet-data-tier"
         service.beta.kubernetes.io/azure-pls-visibility: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
         service.beta.kubernetes.io/azure-pls-auto-approval: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
   geoipdata:


### PR DESCRIPTION
Follow up of #5648 : the PLS is not reachable as the AKS subnet has a custom routing table which create mayhem.

We also should be safer by having this resource with a con figuration as close as possible as another internal LB working (private Nginx ingress).

Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2325103688