### PR TITLE
Revert "Bump Jenkins Weekly docker image version on infra.ci.jenkins.io to 2.0.27-2.475"

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -24,7 +24,7 @@ controller:
     supplementalGroups: [1000]
   image:
     repository: jenkinsciinfra/jenkins-infraci
-    tag: 2.0.27-2.475
+    tag: 2.0.25-2.474
     pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#5651