### PR TITLE
feat(ALL/nginx ingresses): add namespace and ingress name to the access logs

### DIFF
--- a/config/private-nginx-ingress__common.yaml
+++ b/config/private-nginx-ingress__common.yaml
@@ -23,7 +23,7 @@ defaultBackend:
       emptyDir: {}
 controller:
   config:
-    log-format-upstream: '[$proxy_add_x_forwarded_for] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id'
+    log-format-upstream: '[$namespace:$ingress_name][$proxy_add_x_forwarded_for] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id'
     # In order to use geoIP from the ingress controller,
     # we need to provide a maxmind license key.
     # I doubt we need it at the moment, hence this comment.

--- a/config/public-nginx-ingress__common.yaml
+++ b/config/public-nginx-ingress__common.yaml
@@ -23,7 +23,7 @@ defaultBackend:
       emptyDir: {}
 controller:
   config:
-    log-format-upstream: '[$proxy_add_x_forwarded_for] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id'
+    log-format-upstream: '[$namespace:$ingress_name][$proxy_add_x_forwarded_for] - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" $request_length $request_time [$proxy_upstream_name] $upstream_addr $upstream_response_length $upstream_response_time $upstream_status $req_id'
     # In order to use geoIP from the ingress controller,
     # we need to provide a maxmind license key.
     # I doubt we need it at the moment, hence this comment.


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2330934069

The ingress (access) logs collected in datadog does not provide an easy way to discriminate between services.

This PR adds the namespace and name of the ingress for which a given access log line is meant to.

It follows the Nginx Ingress controller documentation which provides these 2 fields in addition to the usual Nginx fields: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/log-format/



Tested on a manual apply (and then roll backed) in pair with @smerle33 on the private Nginx of the private cluster, to ensure it does not fail the admission + the access logs format is changed with what we want 