### PR TITLE
feat(updatecli): Switch Helm Chart related manifest targets to native(YAML) queries

### DIFF
--- a/updatecli/updatecli.d/charts/accountapp.yaml
+++ b/updatecli/updatecli.d/charts/accountapp.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for accountapp"
-    kind: file
+    kind: yaml
     scmid: default
     spec:
       file: clusters/publick8s.yaml

--- a/updatecli/updatecli.d/charts/accountapp.yaml
+++ b/updatecli/updatecli.d/charts/accountapp.yaml
@@ -29,7 +29,6 @@ targets:
       file: clusters/publick8s.yaml
       engine: yamlpath
       key: $.releases[?(@.name == 'accountapp')].version
-    scmid: default
 
 actions:
   default:

--- a/updatecli/updatecli.d/charts/accountapp.yaml
+++ b/updatecli/updatecli.d/charts/accountapp.yaml
@@ -27,8 +27,9 @@ targets:
     scmid: default
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/accountapp((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/accountapp${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'accountapp')].version
+    scmid: default
 
 actions:
   default:

--- a/updatecli/updatecli.d/charts/acme.yaml
+++ b/updatecli/updatecli.d/charts/acme.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for acme"
-    kind: file
+    kind: yaml
     spec:
       files:
         - clusters/privatek8s.yaml

--- a/updatecli/updatecli.d/charts/acme.yaml
+++ b/updatecli/updatecli.d/charts/acme.yaml
@@ -28,8 +28,8 @@ targets:
       files:
         - clusters/privatek8s.yaml
         - clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/acme((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/acme${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'acme')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/cert-manager.yaml
+++ b/updatecli/updatecli.d/charts/cert-manager.yaml
@@ -28,8 +28,8 @@ targets:
       files:
         - clusters/privatek8s.yaml
         - clusters/publick8s.yaml
-      matchpattern: 'chart: jetstack\/cert-manager((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jetstack/cert-manager${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'cert-manager')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/cert-manager.yaml
+++ b/updatecli/updatecli.d/charts/cert-manager.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "jetstack/cert-manager Helm Chart"
-    kind: file
+    kind: yaml
     spec:
       files:
         - clusters/privatek8s.yaml

--- a/updatecli/updatecli.d/charts/codecentric-keycloak.yaml
+++ b/updatecli/updatecli.d/charts/codecentric-keycloak.yaml
@@ -27,8 +27,8 @@ targets:
     scmid: default
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: codecentric\/keycloak((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: codecentric/keycloak${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'keycloak')].version
 
 actions:
   default:

--- a/updatecli/updatecli.d/charts/codecentric-keycloak.yaml
+++ b/updatecli/updatecli.d/charts/codecentric-keycloak.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "codecentric/keycloak Helm Chart"
-    kind: file
+    kind: yaml
     scmid: default
     spec:
       file: clusters/publick8s.yaml

--- a/updatecli/updatecli.d/charts/datadog.yaml
+++ b/updatecli/updatecli.d/charts/datadog.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateClusters:
     name: "Datadog Helm Chart"
-    kind: file
+    kind: yaml
     scmid: default
     spec:
       files:

--- a/updatecli/updatecli.d/charts/datadog.yaml
+++ b/updatecli/updatecli.d/charts/datadog.yaml
@@ -29,8 +29,8 @@ targets:
       files:
         - clusters/privatek8s.yaml
         - clusters/publick8s.yaml
-      matchpattern: 'chart: datadog\/datadog((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: datadog/datadog${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'datadog')].version
 
 actions:
   default:

--- a/updatecli/updatecli.d/charts/env-jenkins-release.yaml
+++ b/updatecli/updatecli.d/charts/env-jenkins-release.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for env-jenkins-release"
-    kind: file
+    kind: yaml
     scmid: default
     spec:
       file: clusters/privatek8s.yaml

--- a/updatecli/updatecli.d/charts/env-jenkins-release.yaml
+++ b/updatecli/updatecli.d/charts/env-jenkins-release.yaml
@@ -27,8 +27,8 @@ targets:
     scmid: default
     spec:
       file: clusters/privatek8s.yaml
-      matchpattern: 'chart: jenkins-infra\/env-jenkins-release((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/env-jenkins-release${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'jenkins-release-core-package')].version
 
 actions:
   default:

--- a/updatecli/updatecli.d/charts/falco.yaml
+++ b/updatecli/updatecli.d/charts/falco.yaml
@@ -28,8 +28,8 @@ targets:
     spec:
       files:
        - clusters/publick8s.yaml
-      matchpattern: 'chart: falco\/falco((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: falco/falco${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'falco')].version
 
 actions:
   default:

--- a/updatecli/updatecli.d/charts/falco.yaml
+++ b/updatecli/updatecli.d/charts/falco.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "falco/falco Helm Chart"
-    kind: file
+    kind: yaml
     scmid: default
     spec:
       files:

--- a/updatecli/updatecli.d/charts/github-comment-ops.yaml
+++ b/updatecli/updatecli.d/charts/github-comment-ops.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for github-comment-ops"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/privatek8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/github-comment-ops.yaml
+++ b/updatecli/updatecli.d/charts/github-comment-ops.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/privatek8s.yaml
-      matchpattern: 'chart: github-comment-ops\/github-comment-ops((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: github-comment-ops/github-comment-ops${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'github-comment-ops')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/incrementals-publisher.yaml
+++ b/updatecli/updatecli.d/charts/incrementals-publisher.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for incrementals-publisher"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/publick8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/incrementals-publisher.yaml
+++ b/updatecli/updatecli.d/charts/incrementals-publisher.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/incrementals-publisher((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/incrementals-publisher${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'incrementals-publisher')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/ipv6-lb-service.yaml
+++ b/updatecli/updatecli.d/charts/ipv6-lb-service.yaml
@@ -27,8 +27,8 @@ targets:
     scmid: default
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/ipv6-lb-service((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/ipv6-lb-service${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'ipv6-lb-service')].version
 
 actions:
   default:

--- a/updatecli/updatecli.d/charts/ipv6-lb-service.yaml
+++ b/updatecli/updatecli.d/charts/ipv6-lb-service.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for ipv6-lb-service"
-    kind: file
+    kind: yaml
     scmid: default
     spec:
       file: clusters/publick8s.yaml

--- a/updatecli/updatecli.d/charts/ircbot.yaml
+++ b/updatecli/updatecli.d/charts/ircbot.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for ircbot"
-    kind: file
+    kind: yaml
     scmid: default
     spec:
       file: clusters/privatek8s.yaml

--- a/updatecli/updatecli.d/charts/ircbot.yaml
+++ b/updatecli/updatecli.d/charts/ircbot.yaml
@@ -27,8 +27,8 @@ targets:
     scmid: default
     spec:
       file: clusters/privatek8s.yaml
-      matchpattern: 'chart: jenkins-infra\/ircbot((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/ircbot${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'ircbot')].version
 
 actions:
   default:

--- a/updatecli/updatecli.d/charts/javadoc.yaml
+++ b/updatecli/updatecli.d/charts/javadoc.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for javadoc"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/publick8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/javadoc.yaml
+++ b/updatecli/updatecli.d/charts/javadoc.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/javadoc((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/javadoc${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'javadoc')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/jenkins-infra-jobs.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-infra-jobs.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersionPrivate:
     name: "Update the chart version for jenkins-jobs"
-    kind: file
+    kind: yaml
     spec:
       files:
         - clusters/privatek8s.yaml

--- a/updatecli/updatecli.d/charts/jenkins-infra-jobs.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-infra-jobs.yaml
@@ -27,8 +27,8 @@ targets:
     spec:
       files:
         - clusters/privatek8s.yaml
-      matchpattern: 'chart: jenkins-infra\/jenkins-jobs((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/jenkins-jobs${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'jenkins-infra-jobs')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for jenkins kubernetes agent"
-    kind: file
+    kind: yaml
     spec:
       files:
         - clusters/privatek8s.yaml

--- a/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
@@ -27,8 +27,8 @@ targets:
     spec:
       files:
         - clusters/privatek8s.yaml
-      matchpattern: 'chart: jenkins-infra\/jenkins-kubernetes-agents((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/jenkins-kubernetes-agents${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'jenkins-release-agents')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/jenkins.yaml
+++ b/updatecli/updatecli.d/charts/jenkins.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "jenkinsci/jenkins Helm Chart"
-    kind: file
+    kind: yaml
     spec:
       files:
         - clusters/privatek8s.yaml

--- a/updatecli/updatecli.d/charts/jenkins.yaml
+++ b/updatecli/updatecli.d/charts/jenkins.yaml
@@ -28,8 +28,8 @@ targets:
       files:
         - clusters/privatek8s.yaml
         - clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins\/jenkins((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins/jenkins${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.chart == 'jenkins/jenkins')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/jenkinsio.yaml
+++ b/updatecli/updatecli.d/charts/jenkinsio.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for jenkinsio"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/publick8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/jenkinsio.yaml
+++ b/updatecli/updatecli.d/charts/jenkinsio.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/jenkinsio((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/jenkinsio${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'jenkinsio')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/jenkinsisthewayio.yaml
+++ b/updatecli/updatecli.d/charts/jenkinsisthewayio.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/httpredirector((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/httpredirector${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'jenkinsisthewayio-redirect')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/jenkinsisthewayio.yaml
+++ b/updatecli/updatecli.d/charts/jenkinsisthewayio.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for jenkinsistheway.io redirection"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/publick8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/ldap.yaml
+++ b/updatecli/updatecli.d/charts/ldap.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/ldap((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/ldap${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'ldap')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/ldap.yaml
+++ b/updatecli/updatecli.d/charts/ldap.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for ldap"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/publick8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/mirrorbits-parent.yaml
+++ b/updatecli/updatecli.d/charts/mirrorbits-parent.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/mirrorbits-parent((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/mirrorbits-parent${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.chart == 'jenkins-infra/mirrorbits-parent')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/mirrorbits-parent.yaml
+++ b/updatecli/updatecli.d/charts/mirrorbits-parent.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for mirrorbits-parent"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/publick8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/nginx-ingress.yaml
+++ b/updatecli/updatecli.d/charts/nginx-ingress.yaml
@@ -28,8 +28,8 @@ targets:
       files:
         - clusters/privatek8s.yaml
         - clusters/publick8s.yaml
-      matchpattern: 'chart: ingress-nginx\/ingress-nginx((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: ingress-nginx/ingress-nginx${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.chart == 'ingress-nginx/ingress-nginx')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/nginx-ingress.yaml
+++ b/updatecli/updatecli.d/charts/nginx-ingress.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the version of the Helm chart ingress-nginx"
-    kind: file
+    kind: yaml
     spec:
       files:
         - clusters/privatek8s.yaml

--- a/updatecli/updatecli.d/charts/nginx-website.yaml
+++ b/updatecli/updatecli.d/charts/nginx-website.yaml
@@ -27,8 +27,8 @@ targets:
     kind: file
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/nginx-website((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/nginx-website${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.chart == 'jenkins-infra/nginx-website')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/nginx-website.yaml
+++ b/updatecli/updatecli.d/charts/nginx-website.yaml
@@ -24,7 +24,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for nginx-website"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/publick8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/plugin-health-scoring.yaml
+++ b/updatecli/updatecli.d/charts/plugin-health-scoring.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for plugin-health-scoring"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/publick8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/plugin-health-scoring.yaml
+++ b/updatecli/updatecli.d/charts/plugin-health-scoring.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/plugin-health-scoring((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/plugin-health-scoring${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'plugin-health-scoring')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/plugin-site-issues.yaml
+++ b/updatecli/updatecli.d/charts/plugin-site-issues.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for plugin-site-issues"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/publick8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/plugin-site-issues.yaml
+++ b/updatecli/updatecli.d/charts/plugin-site-issues.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/plugin-site-issues((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/plugin-site-issues${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'plugin-site-issues')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/plugin-site.yaml
+++ b/updatecli/updatecli.d/charts/plugin-site.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/plugin-site((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/plugin-site${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'plugin-site')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/plugin-site.yaml
+++ b/updatecli/updatecli.d/charts/plugin-site.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for plugin-site"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/publick8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/rating.yaml
+++ b/updatecli/updatecli.d/charts/rating.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for rating"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/publick8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/rating.yaml
+++ b/updatecli/updatecli.d/charts/rating.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/rating((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/rating${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'rating')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/reports.yaml
+++ b/updatecli/updatecli.d/charts/reports.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/reports((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/reports${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'reports')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/reports.yaml
+++ b/updatecli/updatecli.d/charts/reports.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for reports"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/publick8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/rss2twitter.yaml
+++ b/updatecli/updatecli.d/charts/rss2twitter.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for rss2twitter"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/privatek8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/rss2twitter.yaml
+++ b/updatecli/updatecli.d/charts/rss2twitter.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/privatek8s.yaml
-      matchpattern: 'chart: jenkins-infra\/rss2twitter((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/rss2twitter${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'rss2twitter')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/uplink.yaml
+++ b/updatecli/updatecli.d/charts/uplink.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for uplink"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/publick8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/uplink.yaml
+++ b/updatecli/updatecli.d/charts/uplink.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/uplink((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/uplink${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'uplink')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/wiki.yaml
+++ b/updatecli/updatecli.d/charts/wiki.yaml
@@ -23,7 +23,7 @@ sources:
 targets:
   updateChartVersion:
     name: "Update the chart version for wiki"
-    kind: file
+    kind: yaml
     spec:
       file: clusters/publick8s.yaml
       engine: yamlpath

--- a/updatecli/updatecli.d/charts/wiki.yaml
+++ b/updatecli/updatecli.d/charts/wiki.yaml
@@ -26,8 +26,8 @@ targets:
     kind: file
     spec:
       file: clusters/publick8s.yaml
-      matchpattern: 'chart: jenkins-infra\/wiki((\r\n|\r|\n)(\s+))version: .*'
-      replacepattern: 'chart: jenkins-infra/wiki${1}version: {{ source "lastChartVersion" }}'
+      engine: yamlpath
+      key: $.releases[?(@.name == 'wiki')].version
     scmid: default
 
 actions:


### PR DESCRIPTION
As per https://github.com/jenkins-infra/kubernetes-management/issues/5663#issue-2506884201:

We updated all manifest tracking Helm Charts versions to use YAML path targets instead of file targets.

It allows using YAML path queries to perform selection of the list object based on attribute filters which was the proposed solution.

