### PR TITLE
hotfix(publick8s/updates.jenkins.io) the hostname `updates.jenkins-ci.org` was missing leading to user errors during the Update Center brownout 1.

### DIFF
--- a/config/updates.jenkins.io_httpd.yaml
+++ b/config/updates.jenkins.io_httpd.yaml
@@ -84,11 +84,16 @@ ingress:
       paths:
         - path: /
           backendService: httpd
+    - host: updates.jenkins-ci.org
+      paths:
+        - path: /
+          backendService: httpd
   tls:
     - secretName: updates-jenkins-io-httpd-tls
       hosts:
         - updates.jenkins.io
         - azure.updates.jenkins.io
+        - updates.jenkins-ci.org
 
 httpdConf:
   # Specifying https scheme allow proper HTTP rewriting when the pattern is not an FQDN


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2330934069