### PR TITLE
hotfix(publick8s/stats.jenkins.io) add the new stats.jenkins.io hostname to ingress

### DIFF
--- a/config/stats.jenkins.io.yaml
+++ b/config/stats.jenkins.io.yaml
@@ -6,6 +6,10 @@ ingress:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
   hosts:
+    - host: stats.jenkins.io
+      paths:
+        - path: /
+          serviceName: stats-jenkins-io
     - host: new.stats.jenkins.io
       paths:
         - path: /
@@ -13,6 +17,7 @@ ingress:
   tls:
     - secretName: stats-jenkins-io-tls
       hosts:
+        - stats.jenkins.io
         - new.stats.jenkins.io
 
 resources:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4265#issuecomment-2342985525