### PR TITLE
fix(publick8s/updates.jenkins.io) force redirection on mirrorbits even if accept header is set to 'application/json'

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -221,7 +221,7 @@ releases:
   - name: updates-jenkins-io
     namespace: updates-jenkins-io
     chart: jenkins-infra/mirrorbits-parent
-    version: 6.0.0
+    version: 6.0.1
     values:
       - "../config/updates.jenkins.io.yaml"
     secrets:

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -91,6 +91,8 @@ mirrorbits:
     # Ingress already does gzip/brotli
     gzip: false
     traceFile: /TIME
+    # Do not answer mirrorbits API JSON content when accept header is set to application/json (behavior with default value "auto")
+    outputMode: redirect
     redis:
       address: public-redis.redis.cache.windows.net:6379
       # password is stored in SOPS secrets


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2345352162

Requires https://github.com/jenkins-infra/helm-charts/pull/1327 feature