### PR TITLE
feat(get.jenkins.io): force the outputMode to redirect

### DIFF
--- a/config/get-jenkins-io.yaml
+++ b/config/get-jenkins-io.yaml
@@ -104,6 +104,8 @@ mirrorbits:
     # Ingress already does gzip/brotli
     gzip: false
     traceFile: /TIME
+    # Do not answer mirrorbits API JSON content when accept header is set to application/json (behavior with default value "auto")
+    outputMode: redirect
     redis:
       address: public-redis.redis.cache.windows.net:6379
       # password is stored in SOPS secrets


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2345352162

to avoid confusion between a json call and a json provided by mirrorbits, we enforce the outputMode to redirect, this will ensure that the json delivered is the correct one, and not a generated one.

following https://github.com/jenkins-infra/kubernetes-management/pull/5680 for updates.jenkins.io