### PR TITLE
feat(updates.jio): enable rollout restart for httpd every hour

### DIFF
--- a/config/updates.jenkins.io_httpd.yaml
+++ b/config/updates.jenkins.io_httpd.yaml
@@ -98,3 +98,6 @@ ingress:
 httpdConf:
   # Specifying https scheme allow proper HTTP rewriting when the pattern is not an FQDN
   serverName: https://localhost
+
+httpdRestart:
+  enable: true


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2352782412

lets enable a rollout restart for the httpd pods to avoid `The .htaccess files mentioned in the errors were marked as "incomplete" in the Apache status monitor and were truncated on the file system.`