### PR TITLE
feat(publick8s/updates.jenkins.io) add an HTTP-only mirrorbits instance

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -227,6 +227,14 @@ releases:
       - "../config/updates.jenkins.io.yaml"
     secrets:
       - "../secrets/config/updates.jenkins.io/secrets.yaml"
+  - name: updates-jenkins-io-unsecured
+    namespace: updates-jenkins-io
+    chart: jenkins-infra/mirrorbits
+    version: 6.0.7
+    values:
+      - "../config/updates.jenkins.io-unsecured.yaml"
+    secrets:
+      - "../secrets/config/updates.jenkins.io/secrets-unsecured.yaml"
   - name: updates-jenkins-io-httpd
     namespace: updates-jenkins-io
     chart: jenkins-infra/httpd

--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -230,7 +230,7 @@ releases:
   - name: updates-jenkins-io-unsecured
     namespace: updates-jenkins-io
     chart: jenkins-infra/mirrorbits
-    version: 6.0.7
+    version: 5.4.0
     values:
       - "../config/updates.jenkins.io-unsecured.yaml"
     secrets:

--- a/config/updates.jenkins.io-unsecured.yaml
+++ b/config/updates.jenkins.io-unsecured.yaml
@@ -1,0 +1,104 @@
+enabled: true
+replicaCount: 1
+resources:
+  limits:
+    cpu: 2
+    memory: 2048Mi
+  requests:
+    cpu: 100m
+    memory: 200Mi
+nodeSelector:
+  kubernetes.io/arch: arm64
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+podSecurityContext:
+  runAsUser: 1000  # User 'mirrorbits'
+  runAsGroup: 1000  # Group 'mirrorbits'
+  runAsNonRoot: true
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+repository:
+  name: updates-jenkins-io-mirrorbits-parent-data
+  existingPVC: true
+config:
+  # Ingress already does gzip/brotli
+  gzip: false
+  traceFile: /TIME
+  # Do not answer mirrorbits API JSON content when accept header is set to application/json (behavior with default value "auto")
+  outputMode: redirect
+  redis:
+    address: public-redis.redis.cache.windows.net:6379
+    # password is stored in SOPS secrets
+    ## RedisDB - Use 0 for staging and 1, get.jio production and 2 (HTTPS) and 3 (HTTP) for update.jio productions
+    dbId: 3
+  ## Interval between two scans of the local repository.
+  ## This should, more or less, match the frequency where the local repo is updated.
+  ## TODO: set it once a day once the update-center2 would run a `mirrorbits refresh` command by itself
+  repositoryScanInterval: 5
+  ## Interval in minutes between mirror scan
+  ## Once a day is enough as jenkins-infra/update-center2 runs it every 5 min.
+  scanInterval: 1440
+  checkInterval: 1
+  disallowRedirects: false
+  disableOnMissingFile: false
+  ## List of mirrors to use as fallback which will be used in case mirrorbits
+  ## is unable to answer a request because the database is unreachable.
+  ## Note: Mirrorbits will redirect to one of these mirrors based on the user
+  ## location but won't be able to know if the mirror has the requested file.
+  ## Therefore only put your most reliable and up-to-date mirrors here.
+  fallbacks:
+    # We always fall back to this mirror. Useful to serve stale file during a mirror scan
+    - url: http://eastamerica.cloudflare.jenkins.io/
+      countryCode: US
+      continentCode: NA
+# cli:
+#   enabled: true
+#   service:
+#     type: LoadBalancer
+#     annotations:
+#       service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+#       service.beta.kubernetes.io/azure-pls-create: "true"
+#       service.beta.kubernetes.io/azure-pls-name: "updates.jenkins.io-unsecured-cli"
+#       service.beta.kubernetes.io/azure-pls-ip-configuration-subnet: "public-vnet-data-tier"
+#       service.beta.kubernetes.io/azure-pls-visibility: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+#       service.beta.kubernetes.io/azure-pls-auto-approval: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+geoipdata:
+  existingPVCName: updates-jenkins-io-mirrorbits-geoipdata
+# annotations:
+#   ad.datadoghq.com/mirrorbits.logs: |
+#     [{"source":"mirrorbits","service":"updates.jenkins.io"}]
+
+ingress:
+  enabled: true
+  className: public-nginx
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/use-regex: "true"  # Required to allow regexp path matching with Nginx
+    nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
+  hosts:
+    - host: mirrors.updates.jenkins.io
+      paths:
+        # Only send request to files with these extensions to mirrorbits
+        - path: /internal_http/(.*[.](html|json|txt|TIME))$  # Requires the regexp engine of Nginx to be enabled
+          pathType: ImplementationSpecific
+  additionalIngresses:
+    - className: public-nginx
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: "/$1$2/index.html"
+        nginx.ingress.kubernetes.io/ssl-redirect: "false"
+        nginx.ingress.kubernetes.io/use-regex: "true"  # Required to allow regexp path matching with Nginx
+        nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
+      hosts:
+        - host: mirrors.updates.jenkins.io
+          paths:
+            # Otherwise redirect with rewrite the request by appending `/index.html` as you want a directory listing
+            - path: /internal_http/(.*)(/|$)  # Requires the regexp engine of Nginx to be enabled
+              pathType: ImplementationSpecific

--- a/config/updates.jenkins.io.yaml
+++ b/config/updates.jenkins.io.yaml
@@ -3,9 +3,21 @@ global:
     enabled: true
     className: public-nginx
     annotations:
-      "cert-manager.io/cluster-issuer": "letsencrypt-prod"
-      "nginx.ingress.kubernetes.io/ssl-redirect": "true"
-      "nginx.ingress.kubernetes.io/use-regex": "true"  # Required to allow regexp path matching with Nginx
+      cert-manager.io/cluster-issuer: "letsencrypt-prod"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/use-regex: "true"  # Required to allow regexp path matching with Nginx
+      nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        set $HI 1;
+        if ($scheme != "http") {
+            set $HI 0;
+        }
+        if ($uri ~ "/internal_http") {
+            set $HI 0;
+        }
+        if ($HI) {
+          rewrite ^(.*)$ /internal_http$uri last;
+        }
     hosts:
       - host: mirrors.updates.jenkins.io
         paths:
@@ -20,10 +32,10 @@ global:
     additionalIngresses:
       - className: public-nginx
         annotations:
-          "cert-manager.io/cluster-issuer": "letsencrypt-prod"
-          "nginx.ingress.kubernetes.io/ssl-redirect": "true"
-          "nginx.ingress.kubernetes.io/use-regex": "true"  # Required to allow regexp path matching with Nginx
-          "nginx.ingress.kubernetes.io/rewrite-target": "/$1$2/index.html"
+          cert-manager.io/cluster-issuer: "letsencrypt-prod"
+          nginx.ingress.kubernetes.io/ssl-redirect: "false"
+          nginx.ingress.kubernetes.io/use-regex: "true"  # Required to allow regexp path matching with Nginx
+          nginx.ingress.kubernetes.io/rewrite-target: "/$1$2/index.html"
         hosts:
           - host: mirrors.updates.jenkins.io
             paths:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2352944136

Need the new (Redis) secret: https://github.com/jenkins-infra/charts-secrets/commit/66340f36ab34a678e4430a8aee36d203e3255075

This PR installs, in updates-jenkins-io, a new mirrorbits instance which uses the same data as the existing one but has different ingresses.

It relies on 2 new mirrorbits chart features:
- Ability to reuse the same PVCs: https://github.com/jenkins-infra/helm-charts/pull/1339
- Ability to specify additional ingresses: https://github.com/jenkins-infra/helm-charts/pull/1344


The support of ingress traffic split based on the protocol used (HTTP or HTTPS) utilizes the following techniques:

- The existing ingress for `mirrors.updates.jenkins.io`, which handles both HTTP and HTTPS (and will continue):
  - Does not force SSL redirection anymore (obviously)
  - Has a new configuration-snippet which rewrite internally (`rewrite <...> <...> last`) requests to `/internal_http` when the request scheme is `http` AND is not already `/internal_http` (to avoid infinite redirections)
- The new ingress rule:
  - Is set to only handle HTTP as it does not have any `tls` block (in real life, the Nginx Ingress controller will merge it with the previous one)
  - Only capture requests from `/internal_http` path and rewrite them before sending them to the new HTTP only SVC/Pods mirrorbits
  - Note we require a secondary HTTP-only ingress to manage the rewrite from `/` to `/index.html` in HTTP mode.

----

Notes:

- We use the `$uri` Nginx variable instead of `$request_uri` because the latter one is not updated in internal redirects
- We cannot use if with AND / OR operator. Instead we use a technique with a variable used to evaluate the condition.
- The mirrorbits database Redis is a new one. We've already enabled it during manual test.