### PR TITLE
chore(updatecli):Improve lengthy maven manifest

### DIFF
--- a/updatecli/updatecli.d/jenkins-infra-tools-maven.yaml
+++ b/updatecli/updatecli.d/jenkins-infra-tools-maven.yaml
@@ -19,10 +19,11 @@ sources:
     name: Retrieve the current version of the Packer images used in production
     spec:
       file: ./config/jenkins_infra.ci.jenkins.io.yaml
+      matchpattern: 'galleryImageVersion:\s"(.*)"'  # Match the line with galleryImageVersion
     transformers:
       - findsubmatch:
-          pattern: 'galleryImageVersion:\s"(.*)"'
-          captureindex: 1
+          pattern: 'galleryImageVersion:\s"(.*)"'  # Extract the version in quotes
+          captureindex: 1  # Capture only the version number (e.g., "1.2.3")
   getMavenVersionFromPackerImages:
     # Using a file with a transformer until https://github.com/updatecli/updatecli/issues/2275 is done
     kind: file

--- a/updatecli/updatecli.d/jenkins-infra-tools-maven.yaml
+++ b/updatecli/updatecli.d/jenkins-infra-tools-maven.yaml
@@ -19,11 +19,11 @@ sources:
     name: Retrieve the current version of the Packer images used in production
     spec:
       file: ./config/jenkins_infra.ci.jenkins.io.yaml
-      matchpattern: 'galleryImageVersion:\s"(.*)"'  # Match the line with galleryImageVersion
+      matchpattern: 'galleryImageVersion:\s"(.*)"'
     transformers:
       - findsubmatch:
-          pattern: 'galleryImageVersion:\s"(.*)"'  # Extract the version in quotes
-          captureindex: 1  # Capture only the version number (e.g., "1.2.3")
+          pattern: 'galleryImageVersion:\s"(.*)"'
+          captureindex: 1
   getMavenVersionFromPackerImages:
     # Using a file with a transformer until https://github.com/updatecli/updatecli/issues/2275 is done
     kind: file


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4283#issue-2514368763

The log for the updatecli diff has been cleaned up by using a better match pattern.

The manifest has been move to the top updatecli.d folder.


