### PR TITLE
feat(stats.jenkins.io): override the locations to avoid 200 for 404 errors

### DIFF
--- a/config/stats.jenkins.io.yaml
+++ b/config/stats.jenkins.io.yaml
@@ -57,32 +57,24 @@ affinity:
 
 nginx:
   overrideLocations: |
-    location /statistics {
+    location /pluginversions {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         autoindex on;
-        try_files $uri /index.html;
     }
-    location /plugin-trends {
+    location /plugin-installation-trend {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         autoindex on;
-        try_files $uri /index.html;
     }
-    location /plugin-versions {
+    location /jenkins-stats {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         autoindex on;
-        try_files $uri /index.html;
-    }
-    location /dep-graph {
-        root   /usr/share/nginx/html;
-        index  index.html index.htm;
-        autoindex on;
-        try_files $uri /index.html;
     }
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         autoindex on;
+        try_files $uri /index.html;
     }

--- a/config/stats.jenkins.io.yaml
+++ b/config/stats.jenkins.io.yaml
@@ -56,5 +56,33 @@ affinity:
         topologyKey: "kubernetes.io/hostname"
 
 nginx:
-  slashLocation:
-    tryFiles: $uri /index.html
+  overrideLocations: |
+    location /statistics {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        autoindex on;
+        try_files $uri /index.html;
+    }
+    location /plugin-trends {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        autoindex on;
+        try_files $uri /index.html;
+    }
+    location /plugin-versions {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        autoindex on;
+        try_files $uri /index.html;
+    }
+    location /dep-graph {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        autoindex on;
+        try_files $uri /index.html;
+    }
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        autoindex on;
+    }


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4132#issuecomment-2352333521 and https://github.com/jenkins-infra/helpdesk/issues/4291

lets defined manual locations to avoid 200 errorcode for 404