### PR TITLE
Revert "Bump `plugin-health-scoring` helm chart version to 3.0.0"

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -130,7 +130,7 @@ releases:
   - name: plugin-health-scoring
     namespace: plugin-health-scoring
     chart: jenkins-infra/plugin-health-scoring
-    version: 3.0.0
+    version: 2.3.14
     needs:
       - public-nginx-ingress/public-nginx-ingress # Required to expose the service
     values:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#5721