### PR TITLE
feat(publick8s/updates.jenkins.io) installs an httpd HTTP-only component

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -243,6 +243,12 @@ releases:
       - "../config/updates.jenkins.io_httpd.yaml"
     secrets:
       - "../secrets/config/updates.jenkins.io/httpd-secrets.yaml"
+  - name: updates-jenkins-io-httpd-unsecured
+    namespace: updates-jenkins-io
+    chart: jenkins-infra/httpd
+    version: 1.3.0
+    values:
+      - "../config/updates.jenkins.io_httpd-unsecured.yaml"
   - name: contributors-jenkins-io
     namespace: contributors-jenkins-io
     chart: jenkins-infra/nginx-website

--- a/config/updates.jenkins.io_httpd-unsecured.yaml
+++ b/config/updates.jenkins.io_httpd-unsecured.yaml
@@ -1,0 +1,45 @@
+replicaCount: 2
+resources:
+  limits:
+    cpu: 1000m
+    memory: 2048Mi
+  requests:
+    cpu: 50m
+    memory: 100Mi
+nodeSelector:
+  kubernetes.io/arch: arm64
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+repository:
+  name: updates-jenkins-io-redirects
+  reuseExistingPersistentVolumeClaim: true
+  subDir: ./unsecured/
+
+ingress:
+  enabled: true
+  className: public-nginx
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2 # Removes the '/internal_http' path
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/use-regex: "true"  # Required to allow regexp path matching with Nginx
+    nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
+  hosts:
+    - host: azure.updates.jenkins.io
+      paths:
+        - path: /internal_http(/|$)(.*)
+          pathType: ImplementationSpecific # Requires nginx.ingress.kubernetes.io/use-regex annotation
+    - host: updates.jenkins.io
+      paths:
+        - path: /internal_http(/|$)(.*)
+          pathType: ImplementationSpecific # Requires nginx.ingress.kubernetes.io/use-regex annotation
+    - host: updates.jenkins-ci.org
+      paths:
+        - path: /internal_http(/|$)(.*)
+          pathType: ImplementationSpecific # Requires nginx.ingress.kubernetes.io/use-regex annotation
+
+httpdRestart:
+  # Disabled until we fixed the error "Invalid value: "updates-jenkins-io-httpd-unsecured-restart-deployment": must be no more than 52 characters"
+  enable: false

--- a/config/updates.jenkins.io_httpd.yaml
+++ b/config/updates.jenkins.io_httpd.yaml
@@ -79,15 +79,12 @@ ingress:
     - host: azure.updates.jenkins.io
       paths:
         - path: /
-          backendService: httpd
     - host: updates.jenkins.io
       paths:
         - path: /
-          backendService: httpd
     - host: updates.jenkins-ci.org
       paths:
         - path: /
-          backendService: httpd
   tls:
     - secretName: updates-jenkins-io-httpd-tls
       hosts:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2364054995

This PR introduces a new component for updates.jenkins.io: a httpd installation only for HTTP workflow.

- The persistent vollume has been provisioned (empty) in https://github.com/jenkins-infra/azure/pull/840
- Filled the PV with a copy of the data currently in `updates-jenkins-io-redirects` fileshare, with the top-level `.htaccess` updated:

```diff
- RedirectMatch 307 (.*)$ https://mirrors.updates.jenkins.io$1
+ RedirectMatch 307 (.*)$ http://mirrors.updates.jenkins.io$1
```
- Tested on production (and then deleted) with success:

```
$ curl --silent --show-error --output /dev/null --fail --write-out '%{redirect_url}' 'http://azure.updates.jenkins.io/internal_http/update-center.json?id=default&version=2.469'
http://azure.updates.jenkins.io/dynamic-2.463/update-center.json
$ curl --silent --show-error --output /dev/null --fail --write-out '%{redirect_url}' 'http://azure.updates.jenkins.io/internal_http/dynamic-2.463/update-center.json'
http://mirrors.updates.jenkins.io/dynamic-2.463/update-center.json
```

Notes:
- `httpRestart` is not enabled yet because https://github.com/jenkins-infra/helm-charts/issues/1356
- The subdir `unsecured` is used in the PV