### PR TITLE
feat(publick8s/updates.jenkins.io) enable HTTP traffic split

### DIFF
--- a/config/updates.jenkins.io_httpd-secured.yaml
+++ b/config/updates.jenkins.io_httpd-secured.yaml
@@ -22,8 +22,21 @@ ingress:
   enabled: true
   className: public-nginx
   annotations:
-    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
-    "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/use-regex: "true"  # Required to allow regexp path matching with Nginx
+    nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      set $HI 1;
+      if ($scheme != "http") {
+          set $HI 0;
+      }
+      if ($uri ~ "/internal_http") {
+          set $HI 0;
+      }
+      if ($HI) {
+        rewrite ^(.*)$ /internal_http$uri last;
+      }
   hosts:
     - host: azure.updates.jenkins.io
       paths:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2364054995

This PR enables the handling of HTTP traffic coming to `azure.updates.jenkins.io `(and `updates.jenkins.io` + `updates.jenkins-ci.org`) by using the same internal redirect trick as in #5708 for `mirrors.updates.jenkins.io` (but simpler as there are no need for the `index.html` redirect).