### PR TITLE
fix(poublick8s/mirrors.updates.jenkins) correct ingress rexgexp and remove unwanted rewrite

### DIFF
--- a/config/updates.jenkins.io-content-secured.yaml
+++ b/config/updates.jenkins.io-content-secured.yaml
@@ -79,7 +79,6 @@ ingress:
   enabled: true
   className: public-nginx
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/use-regex: "true"  # Required to allow regexp path matching with Nginx
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -97,7 +96,7 @@ ingress:
     - host: mirrors.updates.jenkins.io
       paths:
         # Only send request to files with these extensions to mirrorbits
-        - path: /.*[.](html|json|txt|TIME)$  # Requires the regexp engine of Nginx to be enabled
+        - path: /.*([.](html|json|txt)|TIME)$  # Requires the regexp engine of Nginx to be enabled
           pathType: ImplementationSpecific
   tls:
     - secretName: updates-jenkins-io-mirrorbits-tls

--- a/config/updates.jenkins.io-content-unsecured.yaml
+++ b/config/updates.jenkins.io-content-unsecured.yaml
@@ -87,7 +87,7 @@ ingress:
     - host: mirrors.updates.jenkins.io
       paths:
         # Only send request to files with these extensions to mirrorbits
-        - path: /internal_http/(.*[.](html|json|txt|TIME))$  # Requires the regexp engine of Nginx to be enabled
+        - path: /internal_http/.*([.](html|json|txt)|TIME)$  # Requires the regexp engine of Nginx to be enabled
           pathType: ImplementationSpecific
   additionalIngresses:
     - className: public-nginx


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2364054995
Fixup of #5749 

This PR corrects the ingresses introduces for mirrorbits only in #5749 with:

- Fixed regexp to support the file `TIME` (it was a bug present since months)
- Removed an unwanted rewrite leading to HTTP/404 errors for all requests