### PR TITLE
feat(publick8s/updates.jenkins.io) only scan mirrors on a 10 min basis instead of 5

### DIFF
--- a/config/updates.jenkins.io-content-secured.yaml
+++ b/config/updates.jenkins.io-content-secured.yaml
@@ -41,9 +41,9 @@ config:
   ## Interval between two scans of the local repository.
   ## This should, more or less, match the frequency where the local repo is updated.
   ## TODO: set it once a day once the update-center2 would run a `mirrorbits refresh` command by itself
-  repositoryScanInterval: 5
+  repositoryScanInterval: 10
   ## Interval in minutes between mirror scan
-  ## Once a day is enough as jenkins-infra/update-center2 runs it every 5 min.
+  ## Once a day is enough as jenkins-infra/update-center2 runs it every X min.
   scanInterval: 1440
   checkInterval: 1
   disallowRedirects: false

--- a/config/updates.jenkins.io-content-unsecured.yaml
+++ b/config/updates.jenkins.io-content-unsecured.yaml
@@ -41,9 +41,9 @@ config:
   ## Interval between two scans of the local repository.
   ## This should, more or less, match the frequency where the local repo is updated.
   ## TODO: set it once a day once the update-center2 would run a `mirrorbits refresh` command by itself
-  repositoryScanInterval: 5
+  repositoryScanInterval: 10
   ## Interval in minutes between mirror scan
-  ## Once a day is enough as jenkins-infra/update-center2 runs it every 5 min.
+  ## Once a day is enough as jenkins-infra/update-center2 runs it every X min.
   scanInterval: 1440
   checkInterval: 1
   disallowRedirects: false


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2364054995

Since the update center generator is now run every 10 min (instead of 5), we have to adapt the mirror scan to avoid too much activity