### PR TITLE
feat(publick8s/mirrors.updates.jio) enable CLI for the content-unsecured component

### DIFF
--- a/config/updates.jenkins.io-content-unsecured.yaml
+++ b/config/updates.jenkins.io-content-unsecured.yaml
@@ -58,17 +58,14 @@ config:
     - url: http://eastamerica.cloudflare.jenkins.io/
       countryCode: US
       continentCode: NA
-# cli:
-#   enabled: true
-#   service:
-#     type: LoadBalancer
-#     annotations:
-#       service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-#       service.beta.kubernetes.io/azure-pls-create: "true"
-#       service.beta.kubernetes.io/azure-pls-name: "updates.jenkins.io-unsecured-cli"
-#       service.beta.kubernetes.io/azure-pls-ip-configuration-subnet: "public-vnet-data-tier"
-#       service.beta.kubernetes.io/azure-pls-visibility: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
-#       service.beta.kubernetes.io/azure-pls-auto-approval: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+cli:
+  enabled: true
+  port: 3391
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+      service.beta.kubernetes.io/azure-load-balancer-ipv4: 10.245.0.15 # same Ip as the existing PLS
 geoipdata:
   existingPVCName: updates-jenkins-io-geoip-data
 # annotations:


### PR DESCRIPTION
This PR enables the CLI for `mirrorbits` on the `content-unsecured` mirrorbits component as per https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2364054995.

Notes:
- It utilizes the same Azure PLS but on another port to avoid spinning up other LBs or network routes (a technique found in https://dev.to/lastcoolnameleft/azure-private-link-service-load-balancer-aks-limitation-44db)
  - Note: the IPv4 used here forbids dualstack AND will have to be tracked. It is the loadbalancer's exposed IP, it is NOT the associated PLS IP!
- Same password for both instance (as it is the same content). Pushed in (private) https://github.com/jenkins-infra/charts-secrets/commit/5010730d4feae95cee8ab1995b5dc70e58e42200
