### PR TITLE
fix(publick8s) disable Datadog apache integration to avoid hammering our httpd with HTTP/404 errors on /server-status

### DIFF
--- a/config/datadog_publick8s.yaml
+++ b/config/datadog_publick8s.yaml
@@ -16,6 +16,8 @@ datadog:
     hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
     # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
     tlsVerify: false
+  ignoreAutoConfig:
+    - apache # Our Apache instances do not expose any /server-status endpoint. Let's avoid unneeded requests
 agents:
   tolerations:
     - key: "kubernetes.io/arch"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649#issuecomment-2364054995
