### PR TITLE
fix(publick8s/updates.jio) correct datadog httpd logs setup + fine tune httpd MPM events

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -245,13 +245,13 @@ releases:
   - name: updates-jenkins-io-httpd-secured
     namespace: updates-jenkins-io
     chart: jenkins-infra/httpd
-    version: 1.3.1
+    version: 1.4.0
     values:
       - "../config/updates.jenkins.io_httpd-secured.yaml"
   - name: updates-jenkins-io-httpd-unsecured
     namespace: updates-jenkins-io
     chart: jenkins-infra/httpd
-    version: 1.3.1
+    version: 1.4.0
     values:
       - "../config/updates.jenkins.io_httpd-unsecured.yaml"
   - name: contributors-jenkins-io

--- a/config/updates.jenkins.io-content-secured.yaml
+++ b/config/updates.jenkins.io-content-secured.yaml
@@ -73,7 +73,7 @@ geoipdata:
   existingPVCName: updates-jenkins-io-geoip-data
 annotations:
   ad.datadoghq.com/mirrorbits.logs: |
-    [{"source":"mirrorbits","service":"updates.jenkins.io", "tags":["component:content-secured"]}]
+    [{"source":"mirrorbits","service":"updates.jenkins.io", "tags":["component:secured"]}]
 
 ingress:
   enabled: true

--- a/config/updates.jenkins.io-content-unsecured.yaml
+++ b/config/updates.jenkins.io-content-unsecured.yaml
@@ -70,7 +70,7 @@ geoipdata:
   existingPVCName: updates-jenkins-io-geoip-data
 annotations:
   ad.datadoghq.com/mirrorbits.logs: |
-    [{"source":"mirrorbits","service":"updates.jenkins.io", "tags":["component:content-secured"]}]
+    [{"source":"mirrorbits","service":"updates.jenkins.io", "tags":["component:unsecured"]}]
 
 ingress:
   enabled: true

--- a/config/updates.jenkins.io_httpd-secured.yaml
+++ b/config/updates.jenkins.io_httpd-secured.yaml
@@ -19,7 +19,7 @@ repository:
   subDir: ./secured/
 annotations:
   ad.datadoghq.com/httpd.logs: |
-    [{"source":"httpd","service":"updates.jenkins.io", "tags":["component:content-secured"]}]
+    [{"source":"httpd","service":"updates.jenkins.io", "tags":["component:secured"]}]
 
 ingress:
   enabled: true
@@ -60,6 +60,9 @@ ingress:
 httpdConf:
   # Specifying https scheme allow proper HTTP rewriting when the pattern is not an FQDN
   serverName: https://localhost
+  serverLimit: 30
+  threadsPerChild: 25
+  maxRequestWorkers: 750 # serverLimit * threadsPerChild (MPM event)
 
 httpdRestart:
   enable: true

--- a/config/updates.jenkins.io_httpd-unsecured.yaml
+++ b/config/updates.jenkins.io_httpd-unsecured.yaml
@@ -19,7 +19,14 @@ repository:
   subDir: ./unsecured/
 annotations:
   ad.datadoghq.com/httpd.logs: |
-    [{"source":"httpd","service":"updates.jenkins.io", "tags":["component:content-secured"]}]
+    [{"source":"httpd","service":"updates.jenkins.io", "tags":["unsecured"]}]
+
+httpdConf:
+  # Specifying http scheme allow proper HTTP rewriting when the pattern is not an FQDN
+  serverName: http://localhost
+  serverLimit: 30
+  threadsPerChild: 25
+  maxRequestWorkers: 750 # serverLimit * threadsPerChild (MPM event)
 
 ingress:
   enabled: true


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2649

This PR:

- Fixes up #5759 by using proper components for mirrorbits and httpd
- Fine tune the httpd instances (requires https://github.com/jenkins-infra/helm-charts/pull/1368 to be deployed as the `1.4.0` version) to remove the error logs

```text
[mpm_event:error] [pid 1:tid 1] AH00484: server reached MaxRequestWorkers setting, consider raising the MaxRequestWorkers setting
[mpm_event:error] [pid 1:tid 1] AH10159: server is within MinSpareThreads of MaxRequestWorkers, consider raising the MaxRequestWorkers setting
```