### PR TITLE
feat(infra.ci):Add aws credentials for user 'packer'

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -80,6 +80,12 @@ jobsDefinition:
       packer-images:
         name: Packer Images
         credentials:
+          packer-aws-access-key-id:
+            description: AWS API key for the user 'packer'
+            secret: "${PACKER_AWS_ACCESS_KEY_ID}"
+          packer-aws-secret-access-key:
+            description: AWS Secret key for the user 'packer'
+            secret: "${PACKER_AWS_SECRET_ACCESS_KEY}"
           packer-azure-serviceprincipal-sponsorship:
             azureEnvironmentName: "Azure"
             clientId: "${PACKER_AZURE_CLIENT_ID}"


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4316:

We added the aws credentials required to create EC2 instances for the user 'packer'