### PR TITLE
feat(privatek8s/infra.ci): add an azure client credential for packer update images updatecli job

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -244,6 +244,14 @@ jobsDefinition:
       packer-images:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
+        credentials:
+          updatecli-azure-serviceprincipal:
+            azureEnvironmentName: "Azure"
+            clientId: "${UPDATECLI_AZURE_CLIENT_ID}"
+            clientSecret: "${UPDATECLI_AZURE_CLIENT_SECRET}"
+            description: "Azure Service Principal credential used by updatecli"
+            subscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+            tenant: "${UPDATECLI_AZURE_TENANT_ID}"
       release:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true


### PR DESCRIPTION
as per https://github.com/jenkins-infra/packer-images/pull/1443 ref https://github.com/jenkins-infra/packer-images/pull/1442
we need a dedicated credential to use with updatecli for az images