### PR TITLE
fix(publick8s/mirrors.updates.jio) also serve ICO files

### DIFF
--- a/config/updates.jenkins.io-content-secured.yaml
+++ b/config/updates.jenkins.io-content-secured.yaml
@@ -96,7 +96,7 @@ ingress:
     - host: mirrors.updates.jenkins.io
       paths:
         # Only send request to files with these extensions to mirrorbits
-        - path: /.*([.](html|json|txt)|TIME)$  # Requires the regexp engine of Nginx to be enabled
+        - path: /.*([.](html|json|txt|ico)|TIME)$  # Requires the regexp engine of Nginx to be enabled
           pathType: ImplementationSpecific
   tls:
     - secretName: updates-jenkins-io-mirrorbits-tls

--- a/config/updates.jenkins.io-content-unsecured.yaml
+++ b/config/updates.jenkins.io-content-unsecured.yaml
@@ -84,7 +84,7 @@ ingress:
     - host: mirrors.updates.jenkins.io
       paths:
         # Only send request to files with these extensions to mirrorbits
-        - path: /internal_http/(.*)([.](html|json|txt)|TIME)$  # Requires the regexp engine of Nginx to be enabled
+        - path: /internal_http/(.*)([.](html|json|txt|ico)|TIME)$  # Requires the regexp engine of Nginx to be enabled
           pathType: ImplementationSpecific
   additionalIngresses:
     - className: public-nginx


### PR DESCRIPTION
Goal: server the Jenkins favicon.ico from mirrors (added manually) to limit the amount of 4xx from Cloudflare