### PR TITLE
chore(updatecli):Add aws credentials for updatecli jobs

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -249,6 +249,12 @@ jobsDefinition:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
         credentials:
+          updaecli-aws-access-key-id:
+            description: AWS API key for the user updatecli
+            secret: "${UPDATECLI_AWS_ACCESS_KEY_ID}"
+          updatecli-aws-secret-access-key:
+            description: AWS Secret key for the user updatecli
+            secret: "${UPDATECLI_AWS_SECRET_ACCESS_KEY}"
           updatecli-azure-serviceprincipal:
             azureEnvironmentName: "Azure"
             clientId: "${UPDATECLI_AZURE_CLIENT_ID}"

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -249,7 +249,7 @@ jobsDefinition:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
         credentials:
-          updaecli-aws-access-key-id:
+          updatecli-aws-access-key-id:
             description: AWS API key for the user updatecli
             secret: "${UPDATECLI_AWS_ACCESS_KEY_ID}"
           updatecli-aws-secret-access-key:


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4365#issuecomment-2437105277

We need an IAM user 'updatecli' with it's `UPDATECLI_AWS_ACCESS_KEY_ID` and `UPDATECLI_AWS_SECRET_ACCESS_KEY`. 

Once credentials are created and available, we can merge this PR which will allow us to run aws related updatecli jobs