### PR TITLE
feat(privatek8s/infra.ci.jenkins.io) add a new credential (Datadog API key) in Cloudflare terraform job

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -504,6 +504,9 @@ jobsDefinition:
             fileName: "backend-config"
             description: "Terraform backend configuration for the staging environment of jenkins-infra/cloudflare"
             secretBytes: "${base64:${STAGING_TERRAFORM_CLOUDFLARE_BACKEND_CONFIG}}"
+          cloudflare-datadog-api-key:
+            secret: "${DATADOG_CLOUDFLARE_API_KEY}"
+            description: "Datadog API key used by cloudflare to push logs, metrics and traces"
       datadog:
         name: Terraform Datadog
         description: "Datadog resources managed by Terraform"


### PR DESCRIPTION
This PR unblocks https://github.com/jenkins-infra/cloudflare/pull/40


Requires secret to be pushed (https://github.com/jenkins-infra/charts-secrets/commit/779c0c03ec2c73146106df79fc97f81be688fbc3) and applied to infra.ci (https://infra.ci.jenkins.io/job/kubernetes-jobs/job/kubernetes-management/job/main/43579/)