### PR TITLE
chore(infra.ci) makes distinct job for garbage collector with required AZ credentials

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -101,6 +101,18 @@ jobsDefinition:
         branchIncludes: "production staging updatecli_* PR-* main"
       shared-tools:
         name: Shared Tools
+      garbage-collector:
+        name: Garbage collector (jenkins-infra)
+        repository: packer-images
+        jenkinsfilePath: Jenkinsfile_garbage_collector
+        credentials:
+          packer-azure-serviceprincipal-sponsorship:
+            azureEnvironmentName: "Azure"
+            clientId: "${PACKER_AZURE_CLIENT_ID}"
+            clientSecret: "${PACKER_AZURE_CLIENT_SECRET_VALUE}"
+            description: "Azure Service Principal credential used by packer on secondary subscription"
+            subscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
+            tenant: "${PACKER_AZURE_TENANT_ID}"
   kubernetes-jobs:
     name: Kubernetes Jobs
     description: Folder hosting all the Kubernetes-related jobs


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4355#issue-2586619289

This PR makes distinct job for garbage collector with required credentials (Azure SP for time being)