### PR TITLE
feat(publick8s) add the new aws.ci.jio controller outbound IP to allowed list for LDAP

### DIFF
--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -30,7 +30,7 @@ service:
     - '34.201.191.93/32'  # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
     - '34.233.58.83/32'  # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
     - '54.236.124.56/32'  # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
-
+    - '3.133.40.156/32' # Controller outbound IP for (AWS.)ci.jenkins.io
 resources:
   limits:
     cpu: 2


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4320 and required by https://github.com/jenkins-infra/helpdesk/issues/4315


Note: this IP will be exported in the future report for jenkins-infra/terraform-aws-sponsorship