### PR TITLE
chore(garbage-collector) Add aws credentials for aws garbage collection

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -113,6 +113,12 @@ jobsDefinition:
             description: "Azure Service Principal credential used by packer on secondary subscription"
             subscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
             tenant: "${PACKER_AZURE_TENANT_ID}"
+          packer-aws-access-key-id:
+            description: AWS API key for the user packer
+            secret: "${PACKER_AWS_ACCESS_KEY_ID}"
+          packer-aws-secret-access-key:
+            description: AWS Secret key for the user packer
+            secret: "${PACKER_AWS_SECRET_ACCESS_KEY}"
   kubernetes-jobs:
     name: Kubernetes Jobs
     description: Folder hosting all the Kubernetes-related jobs


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4355#issue-2586619289

As per https://github.com/jenkins-infra/packer-images/pull/1526#pullrequestreview-2438017043

aws credentials are required to include aws garbage collection in the `Jenkinsfile_gc` pipeline.

Further steps include adding aws garbage collector to the pipeline. 