### PR TITLE
chore(infra.ci) configures `Jenkinsfile_gc` to disable github checks and tag discorvery

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -105,6 +105,8 @@ jobsDefinition:
         name: Garbage collector for Packer Images
         repository: packer-images
         jenkinsfilePath: Jenkinsfile_gc
+        disableTagDiscovery: true
+        enableGitHubChecks: false
         credentials:
           packer-azure-serviceprincipal-sponsorship:
             azureEnvironmentName: "Azure"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4355#issue-2586619289

As per https://github.com/jenkins-infra/packer-images/pull/1526#pullrequestreview-2438017043

This PR configures `Jenkinsfile_gc` to disable github checks and tag discorvery on `infra.ci`