### PR TITLE
feat(update.jio) disable httpd Restart cronjob

### DIFF
--- a/config/updates.jenkins.io_httpd-secured.yaml
+++ b/config/updates.jenkins.io_httpd-secured.yaml
@@ -65,4 +65,4 @@ httpdConf:
   maxRequestWorkers: 750 # serverLimit * threadsPerChild (MPM event)
 
 httpdRestart:
-  enable: true
+  enable: false

--- a/config/updates.jenkins.io_httpd-unsecured.yaml
+++ b/config/updates.jenkins.io_httpd-unsecured.yaml
@@ -51,4 +51,4 @@ ingress:
           pathType: ImplementationSpecific # Requires nginx.ingress.kubernetes.io/use-regex annotation
 
 httpdRestart:
-  enable: true
+  enable: false


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4402
in order to solve the inconstancy and in parallel of dealing with azcopy, we choose to remove the rollout every hour as it tend to unmount/remount the volume and generate conflicts. 