### PR TITLE
feat(privatek8s/infra.ci) add missing credential for the updatecli job for jenkins-infra (puppet)

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -248,6 +248,13 @@ jobsDefinition:
         jenkinsfilePath: Jenkinsfile_updatecli
         branchIncludes: "production staging updatecli_* PR-* main"
         disableTagDiscovery: true
+        credentials:
+          packer-aws-access-key-id:
+            description: AWS API key for the user packer
+            secret: "${PACKER_AWS_ACCESS_KEY_ID}"
+          packer-aws-secret-access-key:
+            description: AWS Secret key for the user packer
+            secret: "${PACKER_AWS_SECRET_ACCESS_KEY}"
       jenkins-version:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4316

As noted in https://github.com/jenkins-infra/jenkins-infra/pull/3739, the PR https://github.com/jenkins-infra/jenkins-infra/pull/3737 did broke the updatecli builds for Puppet as it now requires and AWS credential.

This PR adds the packer credential (for now) to fix this issue