### PR TITLE
feat(privatek8s/infra.ci) disables GitHub notifications on the `packer-images` gc job

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -107,6 +107,7 @@ jobsDefinition:
         jenkinsfilePath: Jenkinsfile_gc
         disableTagDiscovery: true
         enableGitHubChecks: false
+        disableGitHubNotifications: true
         credentials:
           packer-azure-serviceprincipal-sponsorship:
             azureEnvironmentName: "Azure"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4355

Since https://github.com/jenkins-infra/helm-charts/pull/1429 includes the feature to disable Github notification, we apply the configuration to our garbage collector job on `packer-images`