### PR TITLE
feat(publick8s/updates.jenkins.io) bump rsync service to 2.0.0 (breaking) chart

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -231,7 +231,7 @@ releases:
   - name: updates-jenkins-io-rsync
     namespace: updates-jenkins-io
     chart: jenkins-infra/rsyncd
-    version: 1.4.49
+    version: 2.0.0
     values:
       - "../config/updates.jenkins.io-rsync.yaml"
   - name: updates-jenkins-io-content-unsecured

--- a/config/updates.jenkins.io-rsync.yaml
+++ b/config/updates.jenkins.io-rsync.yaml
@@ -5,9 +5,10 @@ configuration:
       path: /rsyncd/data/jenkins
       comment: "Jenkins Read-Only Mirror"
       volumeTpl: updates-jenkins-io
+      writeEnabled: false
 podSecurityContext:
-  runAsUser: 65534  # User 'nobody'
-  runAsGroup: 65534  # Group 'nogroup'
+  runAsUser: 1000  # User 'rsyncd'
+  runAsGroup: 1000  # Group 'rsyncd'
   runAsNonRoot: true
 containerSecurityContext:
   readOnlyRootFilesystem: true


### PR DESCRIPTION
Part of https://github.com/jenkins-infra/helpdesk/issues/4402

Deploys https://github.com/jenkins-infra/helm-charts/pull/1434 in `publick8s` for updates.jenkins.io

