### PR TITLE
feat(publick8s/updates.jenkins.io) restore the rsyncd-data service 

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -255,12 +255,12 @@ releases:
     values:
       - "../config/updates.jenkins.io_httpd-unsecured.yaml"
   # Service used to fill the shared Azure File PVC through rsync from trusted.ci
-  #- name: updates-jenkins-io-rsyncd-data
-  #  namespace: updates-jenkins-io
-  #  chart: jenkins-infra/rsyncd
-  #  version: 2.0.3
-  #  values:
-  #    - "../config/updates.jenkins.io-rsyncd-data.yaml"
+  - name: updates-jenkins-io-rsyncd-data
+    namespace: updates-jenkins-io
+    chart: jenkins-infra/rsyncd
+    version: 2.0.3
+    values:
+      - "../config/updates.jenkins.io-rsyncd-data.yaml"
   - name: contributors-jenkins-io
     namespace: contributors-jenkins-io
     chart: jenkins-infra/nginx-website

--- a/config/updates.jenkins.io-rsyncd-data.yaml
+++ b/config/updates.jenkins.io-rsyncd-data.yaml
@@ -6,7 +6,7 @@ configuration:
   components:
     - name: updates-jenkins-io-data
       path: /updates-jenkins-io-data
-      comment: "Updates Center Data Sharedf Persistence Volume"
+      comment: "Updates Center Data Shared Persistence Volume"
       volumeTpl: updates-jenkins-io-data
       writeEnabled: true
 podSecurityContext:


### PR DESCRIPTION
(on the new NFS PVC) introduced in #5933. Reverts c6d26f3c

Related to https://github.com/jenkins-infra/helpdesk/issues/4402

Requires https://github.com/jenkins-infra/azure/pull/887 to be merged and deployed with success