### PR TITLE
feat(publick8s/updates.jenkins.io) use the new NFS PVC with subdir mounts for HTTPD

### DIFF
--- a/config/updates.jenkins.io_httpd-secured.yaml
+++ b/config/updates.jenkins.io_httpd-secured.yaml
@@ -14,9 +14,9 @@ tolerations:
     value: "arm64"
     effect: "NoSchedule"
 repository:
-  name: updates-jenkins-io-redirects
+  name: updates-jenkins-io-data
   reuseExistingPersistentVolumeClaim: true
-  subDir: ./secured/
+  subDir: ./redirections-secured/
 annotations:
   ad.datadoghq.com/httpd.logs: |
     [{"source":"httpd","service":"updates.jenkins.io", "tags":["component:secured"]}]

--- a/config/updates.jenkins.io_httpd-unsecured.yaml
+++ b/config/updates.jenkins.io_httpd-unsecured.yaml
@@ -14,9 +14,9 @@ tolerations:
     value: "arm64"
     effect: "NoSchedule"
 repository:
-  name: updates-jenkins-io-redirects
+  name: updates-jenkins-io-data
   reuseExistingPersistentVolumeClaim: true
-  subDir: ./unsecured/
+  subDir: ./redirections-unsecured/
 annotations:
   ad.datadoghq.com/httpd.logs: |
     [{"source":"httpd","service":"updates.jenkins.io", "tags":["unsecured"]}]


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4402

This PR switches the Apache and Mirrorbits instances of updates.jenkins.io to use the new NFS PVC.

Requires https://github.com/jenkins-infra/update-center2/pull/829 to be merged and successfull at least twice (to have data filled into the PVC).