### PR TITLE
feat(publick8s/updates.jenkins.io) switch mirrorbits instances to the new NFS PVC

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -222,7 +222,7 @@ releases:
   - name: updates-jenkins-io-content-secured
     namespace: updates-jenkins-io
     chart: jenkins-infra/mirrorbits
-    version: 5.5.0
+    version: 5.5.1
     values:
       - "../config/updates.jenkins.io-content-secured.yaml"
     secrets:
@@ -237,7 +237,7 @@ releases:
   - name: updates-jenkins-io-content-unsecured
     namespace: updates-jenkins-io
     chart: jenkins-infra/mirrorbits
-    version: 5.5.0
+    version: 5.5.1
     values:
       - "../config/updates.jenkins.io-content-unsecured.yaml"
     secrets:

--- a/config/updates.jenkins.io-content-secured.yaml
+++ b/config/updates.jenkins.io-content-secured.yaml
@@ -25,8 +25,9 @@ containerSecurityContext:
     drop:
       - ALL
 repository:
-  name: updates-jenkins-io
+  name: updates-jenkins-io-data
   existingPVC: true
+  subDir: ./content/
 config:
   # Ingress already does gzip/brotli
   gzip: false

--- a/config/updates.jenkins.io-content-unsecured.yaml
+++ b/config/updates.jenkins.io-content-unsecured.yaml
@@ -25,8 +25,9 @@ containerSecurityContext:
     drop:
       - ALL
 repository:
-  name: updates-jenkins-io
+  name: updates-jenkins-io-data
   existingPVC: true
+  subDir: ./content/
 config:
   # Ingress already does gzip/brotli
   gzip: false


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4402#issuecomment-2506471357


Blocked by https://github.com/jenkins-infra/update-center2/pull/830 and https://github.com/jenkins-infra/crawler/pull/155