### PR TITLE
feat(publick8s/updates.jenkins.io) switch dummy-s3 rsync to NFS volume

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -231,7 +231,7 @@ releases:
   - name: updates-jenkins-io-rsync
     namespace: updates-jenkins-io
     chart: jenkins-infra/rsyncd
-    version: 2.1.0
+    version: 3.1.0
     values:
       - "../config/updates.jenkins.io-rsync.yaml"
   - name: updates-jenkins-io-content-unsecured

--- a/config/updates.jenkins.io-rsync.yaml
+++ b/config/updates.jenkins.io-rsync.yaml
@@ -4,7 +4,8 @@ configuration:
     - name: jenkins
       path: /rsyncd/data/jenkins
       comment: "Jenkins Read-Only Mirror"
-      volumeTpl: updates-jenkins-io
+      volumeTpl: updates-jenkins-io-data
+      volumeSubDir: ./content/
       writeEnabled: false
 podSecurityContext:
   runAsUser: 1000  # User 'rsyncd'


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4402#issuecomment-2507358896

Requires https://github.com/jenkins-infra/helm-charts/pull/1458

This PR updates the "dummy-s3" rsync service, used by updates.jenkins.io mirrorbit instances, to use the new PVC with NFS.

