### PR TITLE
fix(updates.jenkins.io) add resources to rsyncd-data

### DIFF
--- a/config/updates.jenkins.io-rsyncd-data.yaml
+++ b/config/updates.jenkins.io-rsyncd-data.yaml
@@ -21,11 +21,11 @@ containerSecurityContext:
       - ALL
 resources:
   limits:
-    cpu: 100m
-    memory: 128Mi
+    cpu: 200m
+    memory: 256Mi
   requests:
-    cpu: 50m
-    memory: 64Mi
+    cpu: 200m
+    memory: 256Mi
 nodeSelector:
   kubernetes.io/arch: arm64
 tolerations:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4402

Current usage of CPU is throttled. Adding more of it should help (if not we'll remove the whole CPU limit).

Also adding more memory to let rsync cache more data on the NFS mount