### PR TITLE
chore(updatecli) add untracked clusters for datadog manifest

### DIFF
--- a/updatecli/updatecli.d/charts/datadog.yaml
+++ b/updatecli/updatecli.d/charts/datadog.yaml
@@ -29,6 +29,8 @@ targets:
       files:
         - clusters/privatek8s.yaml
         - clusters/publick8s.yaml
+        - clusters/cijioagents1.yaml
+        - clusters/infracijioagents1.yaml
       engine: yamlpath
       key: $.releases[?(@.name == 'datadog')].version
 


### PR DESCRIPTION
While reviewing https://github.com/jenkins-infra/kubernetes-management/pull/5946, it appeared we were not tracking all clusters