### PR TITLE
feat(publick8s): add geoipupdater in dry-run mode for now

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -287,3 +287,11 @@ releases:
       - "../config/stats.jenkins.io.yaml"
     secrets:
       - "../secrets/config/stats.jenkins.io/secrets.yaml"
+  - name: geoipdata
+    namespace: geoip-data
+    chart: jenkins-infra/geoipupdates
+    version: 2.0.0
+    values:
+      - ../config/geoipdata.yaml
+    secrets:
+      - ../secrets/config/geoipdata/secrets.yaml

--- a/config/geoipdata.yaml
+++ b/config/geoipdata.yaml
@@ -4,6 +4,7 @@ geoipupdate:
   editions: "GeoLite2-ASN GeoLite2-City GeoLite2-Country"
   storage_name: "publick8spvdata"
   storage_fileshare: "geoip-data-staging" # test environement
+  cron: '2 * * * *' # every hour and 2 mn for testing
 podSecurityContext:
   runAsUser: 65534  # User 'nobody'
   runAsGroup: 65534  # Group 'nogroup'

--- a/config/geoipdata.yaml
+++ b/config/geoipdata.yaml
@@ -1,24 +1,26 @@
 geoipupdate:
+  dryrun: true # avoid calling geoipupdate and rate limiting during test
   update_frequency: 72
+  editions: "GeoLite2-ASN GeoLite2-City GeoLite2-Country"
+  storage_name: "publick8spvdata"
+  storage_fileshare: "geoip-data-staging" # test environement
 podSecurityContext:
   runAsUser: 65534  # User 'nobody'
   runAsGroup: 65534  # Group 'nogroup'
   runAsNonRoot: true
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi # minimum 256Mi to avoid OMM kill for `az login`
+  requests:
+    cpu: 100m
+    memory: 256Mi # minimum 256Mi to avoid OMM kill for `az login`
 containerSecurityContext:
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   capabilities:
     drop:
       - ALL
-
-resources:
-  limits:
-    cpu: 500m
-    memory: 128Mi
-  requests:
-    cpu: 50m
-    memory: 64Mi
-
 nodeSelector:
   kubernetes.io/arch: arm64
 tolerations:
@@ -26,7 +28,3 @@ tolerations:
     operator: "Equal"
     value: "arm64"
     effect: "NoSchedule"
-
-dataVolume:
-  persistentVolumeClaim:
-    claimName: geoip-data


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4278
deploying geoipupdater on a staging environement as a kubernetes cronjob.
kept in dry-run mode for now to check the cron
