### PR TITLE
feat(publick8s): geoipupdater on production

### DIFF
--- a/config/geoipdata.yaml
+++ b/config/geoipdata.yaml
@@ -4,7 +4,7 @@ geoipupdate:
   editions: "GeoLite2-ASN GeoLite2-City GeoLite2-Country"
   storage_name: "publick8spvdata"
   storage_fileshare: "geoip-data"
-  cron: '30 * * * *' # everyday at 00:30AM
+  cron: '30 0 * * *' # everyday at 00:30AM
 podSecurityContext:
   runAsUser: 65534  # User 'nobody'
   runAsGroup: 65534  # Group 'nogroup'

--- a/config/geoipdata.yaml
+++ b/config/geoipdata.yaml
@@ -3,8 +3,8 @@ geoipupdate:
   update_frequency: 72
   editions: "GeoLite2-ASN GeoLite2-City GeoLite2-Country"
   storage_name: "publick8spvdata"
-  storage_fileshare: "geoip-data-staging" # test environement
-  cron: '35 11 * * *'
+  storage_fileshare: "geoip-data"
+  cron: '30 * * * *' # everyday at 00:30AM
 podSecurityContext:
   runAsUser: 65534  # User 'nobody'
   runAsGroup: 65534  # Group 'nogroup'


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4278 and https://github.com/jenkins-infra/helpdesk/issues/4240

following #5982 this PR deploy the new cronjob in production, the geoip database from maxmind will be updated once a day at 00:30AM.

setting back the production accountid and licence within the secrets https://github.com/jenkins-infra/charts-secrets/commit/63d87ed6eea9e634e5efae6f1fce4daae90251fb