### PR TITLE
hotfix(publick8s) stop managing geoipupdate cronjob

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -287,11 +287,11 @@ releases:
       - "../config/stats.jenkins.io.yaml"
     secrets:
       - "../secrets/config/stats.jenkins.io/secrets.yaml"
-  - name: geoipdata
-    namespace: geoip-data
-    chart: jenkins-infra/geoipupdates
-    version: 2.0.0
-    values:
-      - ../config/geoipdata.yaml
-    secrets:
-      - ../secrets/config/geoipdata/secrets.yaml
+  # - name: geoipdata
+  #   namespace: geoip-data
+  #   chart: jenkins-infra/geoipupdates
+  #   version: 2.0.0
+  #   values:
+  #     - ../config/geoipdata.yaml
+  #   secrets:
+  #     - ../secrets/config/geoipdata/secrets.yaml


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4441

As usual, this PR is not sufficient: a manual operation is required to remove the cronjob and associated resources with (and un-commented code of course):

```
helmfile -f ./clusters/publick8s.yaml -l name=geoipdata delete
```