### PR TITLE
feat: add a new kubernetes cluster cijenkinsio-agents-2 with datadog as unique release

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'privatek8s', 'publick8s', 'cijioagents1', 'infracijioagents1'
+            values 'privatek8s', 'publick8s', 'cijioagents1', 'cijioagents2', 'infracijioagents1'
           }
         } // axes
         agent {

--- a/clusters/cijioagents2.yaml
+++ b/clusters/cijioagents2.yaml
@@ -1,0 +1,20 @@
+---
+helmDefaults:
+  atomic: true
+  force: false
+  timeout: 300
+  wait: true
+repositories:
+  # https://github.com/DataDog/helm-charts/
+  - name: datadog
+    url: https://helm.datadoghq.com
+releases:
+  - name: datadog
+    namespace: datadog
+    chart: datadog/datadog
+    version: 3.84.2 #todo update updatecli/updatecli.d/charts/datadog.yaml
+    values:
+      - "../config/datadog.yaml.gotmpl"
+      - "../config/datadog_cijenkinsio-agents-2.yaml"
+    secrets:
+      - "../secrets/config/datadog/cijenkinsio-agents-2-secrets.yaml"

--- a/config/datadog_cijenkinsio-agents-2.yaml
+++ b/config/datadog_cijenkinsio-agents-2.yaml
@@ -1,24 +1,13 @@
-providers:
-  aks:
-    enabled: true
 datadog:
-  clusterName: 'cijioagents1'
+  clusterName: cijenkinsio-agents-2
   env:
     - name: DD_HOSTNAME
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-  kubelet:
-    host:
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
-    hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
-    # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
-    tlsVerify: false
 clusterAgent:
   nodeSelector:
-    kubernetes.io/arch: arm64
+    jenkins: ci.jenkins.io
     role: applications
   tolerations:
     - key: "ci.jenkins.io/applications"

--- a/config/datadog_infracijioagents1.yaml
+++ b/config/datadog_infracijioagents1.yaml
@@ -17,9 +17,6 @@ datadog:
     # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
     tlsVerify: false
 clusterAgent:
-  image:
-    pullSecrets:
-      - name: "dockerhub-credential"
   nodeSelector:
     kubernetes.io/arch: arm64
     kubernetes.azure.com/mode: system


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4319#issuecomment-2539442223

starting adding the new EKS cluster to infra.ci kubernetes-management

kubeconfig added as secrets here https://github.com/jenkins-infra/charts-secrets/commit/a24b1ec79f738ab2b2d01b46ea3111feec1abcb0
and datadog api key here https://github.com/jenkins-infra/charts-secrets/commit/c7505e8517376fd712cea6673d06c0191e5d24a9

need https://github.com/jenkins-infra/kubernetes-management/pull/6021

⚠️ BEFORE merging this PR we need to create the `datadog` namespace
using : 

```
kubectl config use-context arn:aws:eks:us-east-2:326712726440:cluster/cijenkinsio-agents-2
kubectl create ns datadog
```
 

splitting in multiple PR:

this one is with the minimum release possible, so only datadog as a start

