### PR TITLE
cleanup(ci.jio-agents-1, infra.ci.jio-agents-1) remove Docker registry credential secret as unused anymore

### DIFF
--- a/clusters/cijioagents1.yaml
+++ b/clusters/cijioagents1.yaml
@@ -12,19 +12,7 @@ repositories:
   - name: jenkins-infra
     url: https://jenkins-infra.github.io/helm-charts
 releases:
-  - name: docker-registry-secrets
-    # This helm chart doesn't create any resources within the namespace specified below.
-    # Specifying a namespace is required by the "needs" feature of helmfile (to allow referencing to this release from others)
-    namespace: default
-    chart: jenkins-infra/docker-registry-secrets
-    version: 0.1.0
-    values:
-      - "../config/docker-registry-secrets.yaml"
-    secrets:
-      - "../secrets/config/docker-registry-secrets/secrets.yaml"
   - name: datadog
-    needs:
-      - default/docker-registry-secrets
     namespace: datadog
     chart: datadog/datadog
     version: 3.83.1
@@ -34,8 +22,6 @@ releases:
     secrets:
       - "../secrets/config/datadog/cijioagents1-secrets.yaml"
   - name: jenkins-agents
-    needs:
-      - default/docker-registry-secrets
     namespace: jenkins-agents
     chart: jenkins-infra/jenkins-kubernetes-agents
     version: 1.0.0

--- a/clusters/infracijioagents1.yaml
+++ b/clusters/infracijioagents1.yaml
@@ -12,20 +12,7 @@ repositories:
   - name: jenkins-infra
     url: https://jenkins-infra.github.io/helm-charts
 releases:
-  # require to boostrap namespace `datadog` creation manually
-  - name: docker-registry-secrets
-    # This helm chart doesn't create any resources within the namespace specified below.
-    # Specifying a namespace is required by the "needs" feature of helmfile (to allow referencing to this release from others)
-    namespace: default
-    chart: jenkins-infra/docker-registry-secrets
-    version: 0.1.0
-    values:
-      - "../config/docker-registry-secrets.yaml"
-    secrets:
-      - "../secrets/config/docker-registry-secrets/secrets.yaml"
   - name: datadog
-    needs:
-      - default/docker-registry-secrets
     namespace: datadog
     chart: datadog/datadog
     version: 3.83.1

--- a/config/docker-registry-secrets.yaml
+++ b/config/docker-registry-secrets.yaml
@@ -1,4 +1,0 @@
-imageCredentials:
-  enabled: true
-  namespaces:
-    - datadog


### PR DESCRIPTION
Datadog charts are the only last users of this chart and they use GCR Docker images (no auth, no rate limit).

So this chart release is unneeded. It will also simplify the bootstrap processed hen creating a new cluster.

Notes: 
- Requires a cleanup in SOPS chart secrets once applied successfully (not before)
- Requires a manual removal of the existing secrets once applied successfully (not before):

```text
ci.jio-agents-1:

$ kubectl get secrets -A  | grep dockerconfigjson
jenkins-agents-bom       dockerhub-credential                            kubernetes.io/dockerconfigjson        1      218d
jenkins-agents           dockerhub-credential                            kubernetes.io/dockerconfigjson        1      218d

$ kubectl get secrets -A  | grep dockerconfigjson     
datadog                dockerhub-credential                            kubernetes.io/dockerconfigjson        1      184d
jenkins-infra-agents   dockerhub-credential                            kubernetes.io/dockerconfigjson        1      176d

privatek8s:

$ kubectl get secrets -A  | grep dockerconfigjson
jenkins-release-agents   dockerhub-credential                                      kubernetes.io/dockerconfigjson        1      637d

publick8s (nothing):

$ kubectl get secrets -A  | grep dockerconfigjson
$
```