### PR TITLE
fix(publick8s) ensure cert-manager tracks the SSL certificate for mirrors.updates.jenkins.io

### DIFF
--- a/config/updates.jenkins.io-content-secured.yaml
+++ b/config/updates.jenkins.io-content-secured.yaml
@@ -80,6 +80,7 @@ ingress:
   enabled: true
   className: public-nginx
   annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/use-regex: "true"  # Required to allow regexp path matching with Nginx
     nginx.ingress.kubernetes.io/enable-rewrite-log: "false" # Only enabled if need to debug as it is resources-hungry (I/O)


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4481

This PR adds a missing annotation which allows Cert Manager to track the certificate and renew it