### PR TITLE
feat(privatek8s/infra.ci) adds aws credentials for updatecli used by `terraform-aws`sponsorship`

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -309,6 +309,13 @@ jobsDefinition:
       terraform-aws-sponsorship:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
+        credentials:
+          updatecli-aws-access-key-id:
+            description: AWS API key for the user updatecli
+            secret: "${UPDATECLI_AWS_ACCESS_KEY_ID}"
+          updatecli-aws-secret-access-key:
+            description: AWS Secret key for the user updatecli
+            secret: "${UPDATECLI_AWS_SECRET_ACCESS_KEY}"
   other-jobs:
     name: Other Jobs
     description: Folder hosting all the jobs not fitting any category


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4479

We require AWS credentials to use aws cli commands with updatecli to track and update cluster addons versions