### PR TITLE
feat(ci.jio-agents-2) enable internal LB for ACP

### DIFF
--- a/config/artifact-caching-proxy_azure-cijenkinsio-agents-2.yaml
+++ b/config/artifact-caching-proxy_azure-cijenkinsio-agents-2.yaml
@@ -29,7 +29,23 @@ affinity:
                 - artifact-caching-proxy
         topologyKey: "kubernetes.io/hostname"
 
-## TODO: enable LB with a private endpoint
+service:
+  type: LoadBalancer
+  annotations:
+    # Internal LB, with fixed IP in private subnet where EC2 VM agents are running
+    # https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/guide/service/annotations/
+    service.beta.kubernetes.io/aws-load-balancer-type: "internal"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+    # We want the LB to directly send requests to the Pod IPs (requires VPC-CNI)
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+    service.beta.kubernetes.io/aws-load-balancer-subnets: "subnet-0138ee90cd53d58f7,subnet-031fd3566ba47fd32,subnet-02682a98ef4081887"
+    # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+    service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses: "10.0.129.248,10.0.131.248,10.0.133.248"
+    service.beta.kubernetes.io/aws-load-balancer-ip-address-type: "ipv4"
+    # Misc.
+    service.beta.kubernetes.io/aws-load-balancer-alpn-policy: "HTTP2Preferred"
+
 
 resources:
   limits:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4319#issuecomment-2597798044

This PR sets up the Kubernetes Service for Artifact Caching Proxy in the new ci.jenkins.io-agents-2 cluster to be exposed through an AWS internal load balancer.

Tested with success locally.

Source documentations:

- https://docs.aws.amazon.com/eks/latest/userguide/auto-configure-nlb.html
- https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/guide/service/annotations/