### PR TITLE
chore(updatecli) track the ACP AWS LB configuration from Terraform Infra reports

### DIFF
--- a/config/artifact-caching-proxy_azure-cijenkinsio-agents-2.yaml
+++ b/config/artifact-caching-proxy_azure-cijenkinsio-agents-2.yaml
@@ -38,9 +38,7 @@ service:
     service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
     # We want the LB to directly send requests to the Pod IPs (requires VPC-CNI)
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
-    # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
     service.beta.kubernetes.io/aws-load-balancer-subnets: "subnet-0138ee90cd53d58f7,subnet-031fd3566ba47fd32,subnet-02682a98ef4081887"
-    # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
     service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses: "10.0.129.248,10.0.131.248,10.0.133.248"
     service.beta.kubernetes.io/aws-load-balancer-ip-address-type: "ipv4"
     # Misc.

--- a/updatecli/updatecli.d/acp-lb-aws.yaml
+++ b/updatecli/updatecli.d/acp-lb-aws.yaml
@@ -1,0 +1,83 @@
+---
+name: Update Artifact Caching Proxy AWS Settings
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  acpAwsVMSubnets:
+    kind: json
+    name: Retrieve the list of subnet IDS for the ACP AWS LB from infra report
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: aws\.ci\.jenkins\.io.ec2-agents.subnet_ids
+    transformers:
+      - trimprefix: '['
+      - trimsuffix: ']'
+      - replacer:
+          from: ' '
+          to: ','
+  acpAwsEksSubnets:
+    kind: json
+    name: Retrieve the list of subnet IDS for the ACP AWS LB from infra report
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: aws\.ci\.jenkins\.io.cijenkinsio-agents-2.subnet_ids
+    transformers:
+      - trimprefix: '['
+      - trimsuffix: ']'
+      - replacer:
+          from: ' '
+          to: ','
+  acpLbIps:
+    kind: json
+    name: Retrieve the list of subnet IDS for the ACP AWS LB from infra report
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: aws\.ci\.jenkins\.io.cijenkinsio-agents-2.artifact_caching_proxy.ips
+    transformers:
+      - trimprefix: '['
+      - trimsuffix: ']'
+      - replacer:
+          from: ' '
+          to: ','
+targets:
+  updateAcpLbIps:
+    name: Update ACP LB IPv4
+    sourceid: acpLbIps
+    kind: yaml
+    transformers:
+      - addprefix: '"'
+      - addsuffix: '"'
+    spec:
+      file: config/artifact-caching-proxy_azure-cijenkinsio-agents-2.yaml
+      key: $.service.annotations.'service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses'
+    scmid: default
+  updateAcpLbSubnets:
+    name: Update ACP LB Subnets
+    disablesourceinput: true # We need to combine 2 sources
+    kind: yaml
+    spec:
+      file: config/artifact-caching-proxy_azure-cijenkinsio-agents-2.yaml
+      key: $.service.annotations.'service.beta.kubernetes.io/aws-load-balancer-subnets'
+      value: '"{{ source `acpAwsVMSubnets` }},{{ source `acpAwsEksSubnets` }}"'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Update configuration of the Artifact Caching Proxy for AWS
+    spec:
+      labels:
+        - artifact-caching-proxy
+        - aws

--- a/updatecli/updatecli.d/acp-lb-azure.yaml
+++ b/updatecli/updatecli.d/acp-lb-azure.yaml
@@ -1,5 +1,5 @@
 ---
-name: Update Artifact Caching Proxy internal LB settings
+name: Update Artifact Caching Proxy Azure internal LB settings
 
 scms:
   default:
@@ -38,7 +38,8 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Update Artifact Caching Proxy internal LB IPv4
+    title: Update the LB IPv4 of the Artifact Caching Proxy for Azure
     spec:
       labels:
         - artifact-caching-proxy
+        - azure


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4317#issuecomment-2612017565,

This PR adds automatic tracking of the subnets and IP configurations for the AWS ACP LB.
Now, any changes in the subnets settings of https://github.com/jenkins-infra/terraform-aws-sponsorship will be tracked by `updatecli` and a PR will be created to pass these changes.

Note: we had to delete the SVC for https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/112 to succeed