### PR TITLE
fix(ci.jenkins.io-agents-2/ACP) enable passing SNI to backend upstreams

### DIFF
--- a/config/artifact-caching-proxy_azure-cijenkinsio-agents-2.yaml
+++ b/config/artifact-caching-proxy_azure-cijenkinsio-agents-2.yaml
@@ -56,3 +56,4 @@ replicaCount: 2
 
 proxy:
   dnsResolver: "kube-dns.kube-system.svc.cluster.local 9.9.9.9"
+  proxySslServerNameEnabled: true # Pass SNI to upstreams


### PR DESCRIPTION
This PR updates the ACP configuration in ci.jenkins.io-agents-2 cluster to avoid errors such as:

```
[error] 22#22: *336648 upstream timed out (110: Operation timed out) while SSL handshaking to upstream, <...>
```