### PR TITLE
chore(updatecli) fix ACP AWS LB manifest to ensure we only have 1 subnet per AZ (and 1 IP per subnet)

### DIFF
--- a/updatecli/updatecli.d/acp-lb-aws.yaml
+++ b/updatecli/updatecli.d/acp-lb-aws.yaml
@@ -14,19 +14,7 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  acpAwsVMSubnets:
-    kind: json
-    name: Retrieve the list of subnet IDS for the ACP AWS LB from infra report
-    spec:
-      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
-      key: aws\.ci\.jenkins\.io.ec2-agents.subnet_ids
-    transformers:
-      - trimprefix: '['
-      - trimsuffix: ']'
-      - replacer:
-          from: ' '
-          to: ','
-  acpAwsEksSubnets:
+  acpAwsSubnets:
     kind: json
     name: Retrieve the list of subnet IDS for the ACP AWS LB from infra report
     spec:
@@ -69,7 +57,7 @@ targets:
     spec:
       file: config/artifact-caching-proxy_azure-cijenkinsio-agents-2.yaml
       key: $.service.annotations.'service.beta.kubernetes.io/aws-load-balancer-subnets'
-      value: '"{{ source `acpAwsVMSubnets` }},{{ source `acpAwsEksSubnets` }}"'
+      value: '"{{ source `acpAwsSubnets` }}"'
     scmid: default
 
 actions:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/kubernetes-management/pull/6183#pullrequestreview-2593708639


Follow up of https://github.com/jenkins-infra/kubernetes-management/pull/6146 and https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/117

This PR fixes the updatecli manifest tracking the ACP AWS LB network settings to only retrieve data specified in the ACP part of the report.