### PR TITLE
feat(privatek8s/infra.ci) add DockerHub credential for new ECR pull-through cache in Terraform AWS

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -473,6 +473,7 @@ jobsDefinition:
           production-terraform-aws-sponsorship-backend-config:
             fileName: "backend-config"
             secretBytes: "${base64:${PRODUCTION_TERRAFORM_AWSSPONSORED_BACKEND_CONFIG}}"
+          infracijenkinsio-dockerhub-pull: *infracijenkinsio-dockerhub-pull-def
       azure:
         name: Terraform Azure
         description: "Azure resources managed by Terraform"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4321#issuecomment-2643226880

Blocks https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/122