### PR TITLE
feat(ci.jenkins.io-agents-2) add a Docker registry mirroring DockerHub

### DIFF
--- a/clusters/cijioagents2.yaml
+++ b/clusters/cijioagents2.yaml
@@ -11,6 +11,8 @@ repositories:
   # https://github.com/jenkins-infra/helm-charts/
   - name: jenkins-infra
     url: https://jenkins-infra.github.io/helm-charts
+  - name: twuni
+    url: https://helm.twun.io
 releases:
   - name: datadog
     namespace: datadog
@@ -28,6 +30,15 @@ releases:
     version: 1.6.2
     values:
       - "../config/artifact-caching-proxy_azure-cijenkinsio-agents-2.yaml"
+  - name: hub-mirror
+    namespace: hub-mirror
+    chart: twuni/docker-registry
+    # TODO: track with updatecli
+    version: v2.2.3
+    values:
+      - "../config/hub-mirror_cijioagents2.yaml"
+    secrets:
+      - "../secrets/config/hub-mirror/secrets.yaml"
   - name: jenkins-agents
     namespace: jenkins-agents
     chart: jenkins-infra/jenkins-kubernetes-agents

--- a/config/hub-mirror_cijioagents2.yaml
+++ b/config/hub-mirror_cijioagents2.yaml
@@ -1,9 +1,3 @@
-persistence:
-  enabled: true
-  size: 100
-  # TODO: track with updatecli (from https://github.com/jenkins-infra/terraform-aws-sponsorship/blob/47a0758f6f414fa12a2e8be54bd66e921f8a942a/eks-cijenkinsio-agents-2.tf#L217)
-  storageClass: ebs-csi-premium-retain-us-east-2a
-
 # TODO: track with updatecli (from https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json)
 nodeSelector:
   kubernetes.io/arch: arm64
@@ -17,17 +11,13 @@ tolerations:
     value: "true"
     effect: "NoSchedule"
 
-# We should never have 2 ACP replicas in the same host
-affinity:
-  podAntiAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      - labelSelector:
-          matchExpressions:
-            - key: "app.kubernetes.io/name"
-              operator: In
-              values:
-                - artifact-caching-proxy
-        topologyKey: "kubernetes.io/hostname"
+resources:
+  limits:
+    # No CPU limit to avoid throttling
+    memory: 4096Mi
+  requests:
+    cpu: 1.5
+    memory: 4096Mi
 
 service:
   type: LoadBalancer
@@ -38,22 +28,31 @@ service:
     service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
     # We want the LB to directly send requests to the Pod IPs (requires VPC-CNI)
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
     service.beta.kubernetes.io/aws-load-balancer-subnets: "subnet-031fd3566ba47fd32,subnet-0138ee90cd53d58f7,subnet-012e4bea8ebb3a5fb"
-    service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses: "10.0.131.248,10.0.129.248,10.0.151.248"
+    # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+    service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses: "10.0.131.246,10.0.129.246,10.0.151.246"
     service.beta.kubernetes.io/aws-load-balancer-ip-address-type: "ipv4"
     # Misc.
     service.beta.kubernetes.io/aws-load-balancer-alpn-policy: "HTTP2Preferred"
 
-resources:
-  limits:
-    # No CPU limit to avoid throttling
-    memory: 8192Mi
-  requests:
-    cpu: 1.5
-    memory: 8192Mi
-
-replicaCount: 2
-
 proxy:
-  dnsResolver: "kube-dns.kube-system.svc.cluster.local 9.9.9.9"
-  proxySslServerNameEnabled: true # Pass SNI to upstreams
+  enabled: true
+  remoteurl: "https://registry-1.docker.io"
+
+garbageCollect:
+  enabled: true
+
+persistence:
+  enabled: true
+  deleteEnabled: true
+  size: "250Gi"
+  # TODO: track with updatecli (from https://github.com/jenkins-infra/terraform-aws-sponsorship/blob/47a0758f6f414fa12a2e8be54bd66e921f8a942a/eks-cijenkinsio-agents-2.tf#L217)
+  # Same as ACP
+  storageClass: ebs-csi-premium-retain-us-east-2a
+
+# Required as we use a single PVC disk which needs to be unmounted/re-mounted
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 0


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4321#issuecomment-2645860911

Requires https://github.com/jenkins-infra/charts-secrets/commit/689f2c7e3babf8eab116031d240d1845e1b327a6

Tested once manually.