### PR TITLE
hotfix(ci.jenkins.io-agents-2/hub-mirror) add a ugly hack to set up volume permissions on init

### DIFF
--- a/config/hub-mirror_cijioagents2.yaml
+++ b/config/hub-mirror_cijioagents2.yaml
@@ -47,3 +47,15 @@ persistence:
   # TODO: track with updatecli (from https://github.com/jenkins-infra/terraform-aws-sponsorship/blob/47a0758f6f414fa12a2e8be54bd66e921f8a942a/eks-cijenkinsio-agents-2.tf#L217)
   # Same as ACP
   storageClass: ebs-csi-premium-retain-us-east-2a
+
+## Init containers to add to the Deployment
+# - name: init
+#   image: busybox
+#   command: []
+initContainers:
+  - name: permission-fix
+    image: "busybox"
+    command: ['chown', '-R', '1000:1000', '/var/lib/registry']
+    volumeMounts:
+      - mountPath: /var/lib/registry
+        name: data


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4321

Fixup of #6222 

When testing the new registry mirror, we ended with errors HTTP/500 responded to Docker Engine when trying to get images with the following log on Registry side:

```
time="2025-02-13T09:53:00.527942139Z" level=error msg="response completed with error" err.code=unknown err.detail="filesystem: mkdir /var/lib/registry/docker: permission denied" err.message="unknown error" go.version=go1.20.8 http.request.host="k8s-hubmirro-hubmirro-f5b8613a86-574b882e7a7e93d0.elb.us-east-2.amazonaws.com:5000" http.request.id=a88445fd-0208-4477-b353-84a5b7910e21 http.request.method=HEAD http.request.remoteaddr="10.0.131.247:29797" http.request.uri="/v2/library/busybox/manifests/latest" http.request.useragent="docker/27.5.1 go/go1.22.11 git-commit/4c9b3b0 kernel/6.8.0-1021-aws os/linux arch/amd64 UpstreamClient(Docker-Client/27.5.1 \(linux\))" http.response.contenttype="application/json; charset=utf-8" http.response.duration=321.168629ms http.response.status=500 http.response.written=164 vars.name="library/busybox" vars.reference=latest
```

This PR uses an init container, like ACP is doing, to fix permission on startup.

This is consider a ugly hack as the "init container" should be a feature of the `jenkins-infra/docker-registry` Helm Chart (to manage the UID, mount path, etc. as part of the templating)