### PR TITLE
hotfix(cijioagents2) increase BOM pods quota from `300` to `400`

### DIFF
--- a/config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents2-bom.yaml
+++ b/config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents2-bom.yaml
@@ -1,5 +1,5 @@
 quotas:
-  pods: 300
+  pods: 400
 
 ## TODO track with updatecli from https://github.com/smerle33/terraform-aws-sponsorship/blob/cfe8539244466353219445275c5248cdac63d11e/locals.tf#L24
 groups:


### PR DESCRIPTION
Following #6227, since we saw errors in ci.jenkins.io such as:

```
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://A5986B0920D06F1E0CABF431FF7678F9.yl4.us-east-2.eks.amazonaws.com/api/v1/namespaces/jenkins-agents-bom/pods. Message: pods "jnlp-maven-bom-xj5lm" is forbidden: exceeded quota: pods, requested: pods=1, used: pods=150, limited: pods=150. Received status: Status(apiVersion=v1, code=403, details=StatusDetails(causes=[], group=null, kind=pods, name=jnlp-maven-bom-xj5lm, retryAfterSeconds=null, uid=null, additionalProperties={}), kind=Status, message=pods "jnlp-maven-bom-xj5lm" is forbidden: exceeded quota: pods, requested: pods=1, used: pods=150, limited: pods=150, metadata=ListMeta(_continue=null, remainingItemCount=null, resourceVersion=null, selfLink=null, additionalProperties={}), reason=Forbidden, status=Failure, additionalProperties={}).
```

=> it means that, despite the Kubernetes plugin feature "Maximum Capacity", we hit the case were the client-side quota was not strictly enforced. By increasing the server-side quota (100 more than client side), we let the system allow adding more pods without blocking. Hope this will decrease the thread locks on client side