### PR TITLE
 chore(updatecli) correct AWS LB manifest and optimize pipeline on principal branch

### DIFF
--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -20,6 +20,9 @@ pipeline {
   }
   stages {
     stage('Check Configuration Update') {
+      when {
+        expression { not { env.BRANCH_IS_PRIMARY }}
+      }
       // Run updatecli's diff on both push and pull requests (in case a configuration change breaks updatecli)
       steps {
         catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {

--- a/updatecli/updatecli.d/acp-lb-aws.yaml
+++ b/updatecli/updatecli.d/acp-lb-aws.yaml
@@ -47,7 +47,7 @@ targets:
       - addprefix: '"'
       - addsuffix: '"'
     spec:
-      file: config/artifact-caching-proxy_azure-cijenkinsio-agents-2.yaml
+      file: config/artifact-caching-proxy_aws-cijenkinsio-agents-2.yaml
       key: $.service.annotations.'service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses'
     scmid: default
   updateAcpLbSubnets:
@@ -55,7 +55,7 @@ targets:
     disablesourceinput: true # We need to combine 2 sources
     kind: yaml
     spec:
-      file: config/artifact-caching-proxy_azure-cijenkinsio-agents-2.yaml
+      file: config/artifact-caching-proxy_aws-cijenkinsio-agents-2.yaml
       key: $.service.annotations.'service.beta.kubernetes.io/aws-load-balancer-subnets'
       value: '"{{ source `acpAwsSubnets` }}"'
     scmid: default


### PR DESCRIPTION
fixup of #6222

also, stop running `updatecli diff` on the `main` branch for faster runs