### PR TITLE
feat(cijioagents1) removed from the jenkinsfile for kub 1.30 upgrade

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'privatek8s', 'publick8s', 'cijioagents1', 'cijioagents2', 'infracijioagents1'
+            values 'privatek8s', 'publick8s', 'cijioagents2', 'infracijioagents1'
           }
         } // axes
         agent {


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4258#issuecomment-2663661996

remove `cijioagents1` from pipeline