### PR TITLE
chore(updatecli) track LDAP PVC names

### DIFF
--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -49,5 +49,5 @@ tolerations:
     effect: "NoSchedule"
 
 persistence:
-  # TODO: add link to where the disk/PV/PVC are defined (and automate syncing?)
-  customDataClaimName: ldap-jenkins-io-data
+  customDataClaimName: ldap-jenkins-io-data # Tracked by updatecli
+  customBackupClaimName: "" # Tracked by updatecli

--- a/updatecli/updatecli.d/pvc-ldap.yaml
+++ b/updatecli/updatecli.d/pvc-ldap.yaml
@@ -1,0 +1,55 @@
+---
+name: Update PVC names for ldap.jenkins.io
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getDataPvcName:
+    kind: json
+    name: Retrieve LDAP data PVC name
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      key: .ldap\.jenkins\.io.data.pvc_name
+  getBackupPvcName:
+    kind: json
+    name: Retrieve LDAP backup PVC name
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      key: .ldap\.jenkins\.io.backup.pvc_name
+
+targets:
+  updateDataPvcName:
+    sourceid: getDataPvcName
+    name: Set data PVC name in LDAP Helm configuration
+    kind: yaml
+    spec:
+      file: config/ldap.yaml
+      key: $.persistence.customDataClaimName
+    scmid: default
+  updatePvcNameUnsecured:
+    sourceid: getBackupPvcName
+    name: Set backup PVC name in LDAP Helm configuration
+    kind: yaml
+    spec:
+      file: config/ldap.yaml
+      key: $.persistence.customBackupClaimName
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Update PVC names for ldap.jenkins.io
+    spec:
+      labels:
+        - ldap


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4544#issuecomment-2671423226.

This PR tracks the LDAP PVC names: both data and backup which is possible since https://github.com/jenkins-infra/azure/pull/940

Tested locally:

```
target: target#updatePvcNameUnsecured
-----------------------------

**Dry Run enabled**

⚠ - change detected:
        * key "$.persistence.customBackupClaimName" should be updated from "\"\" # Tracked by updatecli" to "ldap-jenkins-io-backup", in file "config/ldap.yaml"

target: target#updateDataPvcName
------------------------

**Dry Run enabled**

✔ - no change detected:
        * key "$.persistence.customDataClaimName" already set to "ldap-jenkins-io-data", from file "config/ldap.yaml"
```