### PR TITLE
fix(datadog/windows): the datadog restart parameter is 'restart-service'

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -319,7 +319,7 @@ controller:
                   imageTopLevelType: "advanced"
                   initScript: |-
                     (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ${JENKINS_CI_DATADOG_API_KEY}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
-                    & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart
+                    & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart-service
                     # Setup Docker Engine
                     @'
                     {
@@ -366,7 +366,7 @@ controller:
                   imageTopLevelType: "advanced"
                   initScript: |-
                     (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ${JENKINS_CI_DATADOG_API_KEY}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
-                    & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart
+                    & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart-service
                     # Setup Docker Engine
                     @'
                     {


### PR DESCRIPTION
as seen in the logs of a windows agent on infra.ci: 

```
 Volume in drive C is Windows
 Volume Serial Number is 123B-47A8

 Directory of C:\

File Not Found
Error: unknown command "restart" for "agent.exe"

Did you mean this?
	restart-service
```

see https://github.com/jenkins-infra/jenkins-infra/pull/3809 for ci.jio