### PR TITLE
chore(jenkinsfile_updatecli): Use current node execution context for `kubernetes-management`

### DIFF
--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,42 +1,43 @@
 def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
 
-options {
-    buildDiscarder(logRotator(numToKeepStr: '10'))
-    timeout(time: 30, unit: 'MINUTES')
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '10')),
     disableConcurrentBuilds()
-  }
-  triggers {
-    cron (cronExpr)
-  }
+])
 
 node('jnlp-linux-arm64') {
-    // Set environment variable for Azure credentials (from Jenkins credentials)
-    env.UPDATECLI_AZURE = credentials('updatecli-azure-serviceprincipal')
+  timeout(time: 30, unit: 'MINUTES') {
+    if (cronExpr) {
+        properties([pipelineTriggers([cron(cronExpr)])])
+    } 
+      // Set environment variable for Azure credentials (from Jenkins credentials)
+      env.UPDATECLI_AZURE = credentials('updatecli-azure-serviceprincipal')
 
-    withCredentials([
-        usernamePassword(
-            credentialsId: 'github-app-updatecli-on-jenkins-infra', // needed for updatecli
-            usernameVariable: 'USERNAME_VALUE',
-            passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
-        )
-    ]) {
-        // Preliminary Azure login steps
-        sh 'az login --service-principal -u "$UPDATECLI_AZURE_CLIENT_ID" -p "$UPDATECLI_AZURE_CLIENT_SECRET" -t "$UPDATECLI_AZURE_TENANT_ID"'
-        sh 'az account set -s "$UPDATECLI_AZURE_SUBSCRIPTION_ID"'
+      withCredentials([
+          usernamePassword(
+              credentialsId: 'github-app-updatecli-on-jenkins-infra', // needed for updatecli
+              usernameVariable: 'USERNAME_VALUE',
+              passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
+          )
+      ]) {
+          // Preliminary Azure login steps
+          sh 'az login --service-principal -u "$UPDATECLI_AZURE_CLIENT_ID" -p "$UPDATECLI_AZURE_CLIENT_SECRET" -t "$UPDATECLI_AZURE_TENANT_ID"'
+          sh 'az account set -s "$UPDATECLI_AZURE_SUBSCRIPTION_ID"'
 
-        // Branch conditional: if not primary, run diff; otherwise, run apply
-        if (!env.BRANCH_IS_PRIMARY) {
-            stage('Check Configuration Update') {
-                script {
-                    updatecli(action: 'diff')
-                }
-            }
-        } else {
-            stage('Apply Configuration Update') {
-                script {
-                    updatecli(action: 'apply')
-                }
-            }
-        }
-    }
+          // Branch conditional: if not primary, run diff; otherwise, run apply
+          if (!env.BRANCH_IS_PRIMARY) {
+              stage('Check Configuration Update') {
+                  script {
+                      updatecli(action: 'diff')
+                  }
+              }
+          } else {
+              stage('Apply Configuration Update') {
+                  script {
+                      updatecli(action: 'apply')
+                  }
+              }
+          }
+      }
+  }
 }

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,9 +1,9 @@
-final String cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
+final String cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '10')),
     disableConcurrentBuilds(),
-    properties([pipelineTriggers([cron(cronExpr)])]),
+    pipelineTriggers([cron(cronExpr)]),
 ])
 
 node('jnlp-linux-arm64') {

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -2,11 +2,9 @@ def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '10')),
-    disableConcurrentBuilds()
-])
-if (cronExpr) {
+    disableConcurrentBuilds(),
     properties([pipelineTriggers([cron(cronExpr)])])
-}
+])
 
 node('jnlp-linux-arm64') {
     timeout(time: 30, unit: 'MINUTES') {
@@ -21,25 +19,21 @@ node('jnlp-linux-arm64') {
             // Preliminary Azure login steps
             sh 'az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" -t "$AZURE_TENANT_ID"'
             sh 'az account set -s "$AZURE_SUBSCRIPTION_ID"'
-
-            // Branch conditional: if not primary, run diff; otherwise, run apply
             if (!env.BRANCH_IS_PRIMARY) {
                 stage('Check Configuration Update') {
-                    script {
-                        updatecli(
-                                action: 'diff',
-                                runInCurrentAgent: true
-                            )
+                    updatecli(
+                            action: 'diff',
+                            runInCurrentAgent: true
+                        )
                     }
                 }
-            } else {
+            else {
                 stage('Apply Configuration Update') {
-                    script {
-                        updatecli(
-                                action: 'apply',
-                                runInCurrentAgent: true
-                            )
-                    }
+
+                    updatecli(
+                            action: 'apply',
+                            runInCurrentAgent: true
+                        )
                 }
             }
         }

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -11,13 +11,7 @@ if (cronExpr) {
 node('jnlp-linux-arm64') {
     timeout(time: 30, unit: 'MINUTES') {
         withCredentials([
-            usernamePassword(
-                credentialsId: 'updatecli-azure-serviceprincipal',
-                usernameVariable: 'UPDATECLI_AZURE_CLIENT_ID',
-                passwordVariable: 'UPDATECLI_AZURE_CLIENT_SECRET' // needed for Azure login
-            ),
-            string(credentialsId: 'updatecli-azure-tenant-id', variable: 'UPDATECLI_AZURE_TENANT_ID'),
-            string(credentialsId: 'updatecli-azure-subscription-id', variable: 'UPDATECLI_AZURE_SUBSCRIPTION_ID'),
+            azureServicePrincipal('updatecli-azure-serviceprincipal'), // needed for Azure login
             usernamePassword(
                 credentialsId: 'github-app-updatecli-on-jenkins-infra', // needed for updatecli
                 usernameVariable: 'USERNAME_VALUE',

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,9 +1,9 @@
-def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
+final String cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '10')),
     disableConcurrentBuilds(),
-    properties([pipelineTriggers([cron(cronExpr)])])
+    properties([pipelineTriggers([cron(cronExpr)])]),
 ])
 
 node('jnlp-linux-arm64') {
@@ -19,22 +19,12 @@ node('jnlp-linux-arm64') {
             // Preliminary Azure login steps
             sh 'az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" -t "$AZURE_TENANT_ID"'
             sh 'az account set -s "$AZURE_SUBSCRIPTION_ID"'
-            if (!env.BRANCH_IS_PRIMARY) {
-                stage('Check Configuration Update') {
-                    updatecli(
-                            action: 'diff',
-                            runInCurrentAgent: true
-                        )
-                    }
-                }
-            else {
-                stage('Apply Configuration Update') {
-
-                    updatecli(
-                            action: 'apply',
-                            runInCurrentAgent: true
-                        )
-                }
+            final String updatecliAction = env.BRANCH_IS_PRIMARY ? 'apply' : 'diff'
+            stage("Run updatecli action: ${updatecliAction}") {
+                updatecli(
+                    action: updatecliAction,
+                    runInCurrentAgent: true,
+                )
             }
         }
     }

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -19,8 +19,8 @@ node('jnlp-linux-arm64') {
             )
         ]) {
             // Preliminary Azure login steps
-            sh 'az login --service-principal -u "$UPDATECLI_AZURE_CLIENT_ID" -p "$UPDATECLI_AZURE_CLIENT_SECRET" -t "$UPDATECLI_AZURE_TENANT_ID"'
-            sh 'az account set -s "$UPDATECLI_AZURE_SUBSCRIPTION_ID"'
+            sh 'az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" -t "$AZURE_TENANT_ID"'
+            sh 'az account set -s "$AZURE_SUBSCRIPTION_ID"'
 
             // Branch conditional: if not primary, run diff; otherwise, run apply
             if (!env.BRANCH_IS_PRIMARY) {

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -4,40 +4,44 @@ properties([
     buildDiscarder(logRotator(numToKeepStr: '10')),
     disableConcurrentBuilds()
 ])
+if (cronExpr) {
+    properties([pipelineTriggers([cron(cronExpr)])])
+}
 
 node('jnlp-linux-arm64') {
-  timeout(time: 30, unit: 'MINUTES') {
-    if (cronExpr) {
-        properties([pipelineTriggers([cron(cronExpr)])])
-    } 
-      // Set environment variable for Azure credentials (from Jenkins credentials)
-      env.UPDATECLI_AZURE = credentials('updatecli-azure-serviceprincipal')
+    timeout(time: 30, unit: 'MINUTES') {
+        withCredentials([
+            usernamePassword(
+                credentialsId: 'updatecli-azure-serviceprincipal',
+                usernameVariable: 'UPDATECLI_AZURE_CLIENT_ID',
+                passwordVariable: 'UPDATECLI_AZURE_CLIENT_SECRET' // needed for Azure login
+            ),
+            string(credentialsId: 'updatecli-azure-tenant-id', variable: 'UPDATECLI_AZURE_TENANT_ID'),
+            string(credentialsId: 'updatecli-azure-subscription-id', variable: 'UPDATECLI_AZURE_SUBSCRIPTION_ID'),
+            usernamePassword(
+                credentialsId: 'github-app-updatecli-on-jenkins-infra', // needed for updatecli
+                usernameVariable: 'USERNAME_VALUE',
+                passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
+            )
+        ]) {
+            // Preliminary Azure login steps
+            sh 'az login --service-principal -u "$UPDATECLI_AZURE_CLIENT_ID" -p "$UPDATECLI_AZURE_CLIENT_SECRET" -t "$UPDATECLI_AZURE_TENANT_ID"'
+            sh 'az account set -s "$UPDATECLI_AZURE_SUBSCRIPTION_ID"'
 
-      withCredentials([
-          usernamePassword(
-              credentialsId: 'github-app-updatecli-on-jenkins-infra', // needed for updatecli
-              usernameVariable: 'USERNAME_VALUE',
-              passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
-          )
-      ]) {
-          // Preliminary Azure login steps
-          sh 'az login --service-principal -u "$UPDATECLI_AZURE_CLIENT_ID" -p "$UPDATECLI_AZURE_CLIENT_SECRET" -t "$UPDATECLI_AZURE_TENANT_ID"'
-          sh 'az account set -s "$UPDATECLI_AZURE_SUBSCRIPTION_ID"'
-
-          // Branch conditional: if not primary, run diff; otherwise, run apply
-          if (!env.BRANCH_IS_PRIMARY) {
-              stage('Check Configuration Update') {
-                  script {
-                      updatecli(action: 'diff')
-                  }
-              }
-          } else {
-              stage('Apply Configuration Update') {
-                  script {
-                      updatecli(action: 'apply')
-                  }
-              }
-          }
-      }
-  }
+            // Branch conditional: if not primary, run diff; otherwise, run apply
+            if (!env.BRANCH_IS_PRIMARY) {
+                stage('Check Configuration Update') {
+                    script {
+                        updatecli(action: 'diff')
+                    }
+                }
+            } else {
+                stage('Apply Configuration Update') {
+                    script {
+                        updatecli(action: 'apply')
+                    }
+                }
+            }
+        }
+    }
 }

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,68 +1,47 @@
-def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
+node('jnlp-linux-arm64') {
+    def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
 
-pipeline {
-  agent {
-    label 'jnlp-linux-arm64'
-  }
-
-  options {
-    buildDiscarder(logRotator(numToKeepStr: '10'))
-    timeout(time: 30, unit: 'MINUTES')
-    disableConcurrentBuilds()
-  }
-
-  triggers {
-    cron (cronExpr)
-  }
-
-  environment {
-    UPDATECLI_AZURE = credentials('updatecli-azure-serviceprincipal') //needed for az login
-  }
-  stages {
-    stage('Check Configuration Update') {
-      when {
-        expression { not { env.BRANCH_IS_PRIMARY }}
-      }
-      // Run updatecli's diff on both push and pull requests (in case a configuration change breaks updatecli)
-      steps {
-        catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-          script {
-            withCredentials([
-              usernamePassword(
-                credentialsId: 'github-app-updatecli-on-jenkins-infra', //needed for updatecli
-                usernameVariable: 'USERNAME_VALUE', // Setting this variable is mandatory, even if of not used when the credentials is a githubApp one
-                passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
-              )
-            ]) {
-              sh 'az login --service-principal -u "$UPDATECLI_AZURE_CLIENT_ID" -p "$UPDATECLI_AZURE_CLIENT_SECRET" -t "$UPDATECLI_AZURE_TENANT_ID"'
-              sh 'az account set -s "$UPDATECLI_AZURE_SUBSCRIPTION_ID"'
-              sh 'updatecli version'
-              sh 'updatecli diff --values ./updatecli/values.yaml --config ./updatecli/updatecli.d'
-            }
-          }
-        }
-      }
-    } // stage
-    stage('Apply Configuration Update') {
-      when {
-        expression { env.BRANCH_IS_PRIMARY }
-      }
-      steps {
-        script {
-            withCredentials([
-              usernamePassword(
-                credentialsId: 'github-app-updatecli-on-jenkins-infra', //needed for updatecli
-                usernameVariable: 'USERNAME_VALUE', // Setting this variable is mandatory, even if of not used when the credentials is a githubApp one
-                passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
-              )
-            ]) {
-              sh 'az login --service-principal -u "$UPDATECLI_AZURE_CLIENT_ID" -p "$UPDATECLI_AZURE_CLIENT_SECRET" -t "$UPDATECLI_AZURE_TENANT_ID"'
-              sh 'az account set -s "$UPDATECLI_AZURE_SUBSCRIPTION_ID"'
-              sh 'updatecli version'
-              sh 'updatecli apply --values ./updatecli/values.yaml --config ./updatecli/updatecli.d'
-            }
-          }
-      }
+    // Set pipeline options
+    properties([
+        buildDiscarder(logRotator(numToKeepStr: '10')),
+        timeout(time: 30, unit: 'MINUTES'),
+        disableConcurrentBuilds()
+    ])
+    if (cronExpr) {
+        properties([pipelineTriggers([cron(cronExpr)])])
     }
-  }
+
+    // Set environment variable for Azure credentials (from Jenkins credentials)
+    env.UPDATECLI_AZURE = credentials('updatecli-azure-serviceprincipal')
+
+    // Use a single withCredentials block for all required credentials.
+    withCredentials([
+        string(credentialsId: 'packer-aws-access-key-id', variable: 'AWS_ACCESS_KEY_ID'),
+        string(credentialsId: 'packer-aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY'),
+        usernamePassword(
+            credentialsId: 'github-app-updatecli-on-jenkins-infra', // needed for updatecli
+            usernameVariable: 'USERNAME_VALUE',
+            passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
+        )
+    ]) {
+        sh 'az login --service-principal -u "$UPDATECLI_AZURE_CLIENT_ID" -p "$UPDATECLI_AZURE_CLIENT_SECRET" -t "$UPDATECLI_AZURE_TENANT_ID"'
+        sh 'az account set -s "$UPDATECLI_AZURE_SUBSCRIPTION_ID"'
+
+        // Branch conditional: run diff on non-primary; apply on primary.
+        if (!env.BRANCH_IS_PRIMARY) {
+            stage('Check Configuration Update') {
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    script {
+                        updatecli(action: 'diff')
+                    }
+                }
+            }
+        } else {
+            stage('Apply Configuration Update') {
+                script {
+                    updatecli(action: 'apply')
+                }
+            }
+        }
+    }
 }

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,13 +1,13 @@
 def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
 
-properties([
-    buildDiscarder(logRotator(numToKeepStr: '10')),
-    timeout(time: 30, unit: 'MINUTES'),
+options {
+    buildDiscarder(logRotator(numToKeepStr: '10'))
+    timeout(time: 30, unit: 'MINUTES')
     disableConcurrentBuilds()
-])
-if (cronExpr) {
-    properties([pipelineTriggers([cron(cronExpr)])])
-}
+  }
+  triggers {
+    cron (cronExpr)
+  }
 
 node('jnlp-linux-arm64') {
     // Set environment variable for Azure credentials (from Jenkins credentials)

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,39 +1,34 @@
+def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
+
+properties([
+    buildDiscarder(logRotator(numToKeepStr: '10')),
+    timeout(time: 30, unit: 'MINUTES'),
+    disableConcurrentBuilds()
+])
+if (cronExpr) {
+    properties([pipelineTriggers([cron(cronExpr)])])
+}
+
 node('jnlp-linux-arm64') {
-    def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
-
-    // Set pipeline options
-    properties([
-        buildDiscarder(logRotator(numToKeepStr: '10')),
-        timeout(time: 30, unit: 'MINUTES'),
-        disableConcurrentBuilds()
-    ])
-    if (cronExpr) {
-        properties([pipelineTriggers([cron(cronExpr)])])
-    }
-
     // Set environment variable for Azure credentials (from Jenkins credentials)
     env.UPDATECLI_AZURE = credentials('updatecli-azure-serviceprincipal')
 
-    // Use a single withCredentials block for all required credentials.
     withCredentials([
-        string(credentialsId: 'packer-aws-access-key-id', variable: 'AWS_ACCESS_KEY_ID'),
-        string(credentialsId: 'packer-aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY'),
         usernamePassword(
             credentialsId: 'github-app-updatecli-on-jenkins-infra', // needed for updatecli
             usernameVariable: 'USERNAME_VALUE',
             passwordVariable: 'UPDATECLI_GITHUB_TOKEN'
         )
     ]) {
+        // Preliminary Azure login steps
         sh 'az login --service-principal -u "$UPDATECLI_AZURE_CLIENT_ID" -p "$UPDATECLI_AZURE_CLIENT_SECRET" -t "$UPDATECLI_AZURE_TENANT_ID"'
         sh 'az account set -s "$UPDATECLI_AZURE_SUBSCRIPTION_ID"'
 
-        // Branch conditional: run diff on non-primary; apply on primary.
+        // Branch conditional: if not primary, run diff; otherwise, run apply
         if (!env.BRANCH_IS_PRIMARY) {
             stage('Check Configuration Update') {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    script {
-                        updatecli(action: 'diff')
-                    }
+                script {
+                    updatecli(action: 'diff')
                 }
             }
         } else {

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,4 +1,4 @@
-final String cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
+final String cronExpr = env.BRANCH_IS_PRIMARY ? '@daily' : ''
 
 properties([
     buildDiscarder(logRotator(numToKeepStr: '10')),

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -26,13 +26,19 @@ node('jnlp-linux-arm64') {
             if (!env.BRANCH_IS_PRIMARY) {
                 stage('Check Configuration Update') {
                     script {
-                        updatecli(action: 'diff')
+                        updatecli(
+                                action: 'diff',
+                                runInCurrentAgent: true
+                            )
                     }
                 }
             } else {
                 stage('Apply Configuration Update') {
                     script {
-                        updatecli(action: 'apply')
+                        updatecli(
+                                action: 'apply',
+                                runInCurrentAgent: true
+                            )
                     }
                 }
             }


### PR DESCRIPTION
As per - https://github.com/jenkins-infra/helpdesk/issues/4539#issuecomment-2740495511

We now use scripted pipeline syntax