### PR TITLE
chore(updatecli) ping nginx-ingress to 4.11.x

### DIFF
--- a/updatecli/updatecli.d/charts/nginx-ingress.yaml
+++ b/updatecli/updatecli.d/charts/nginx-ingress.yaml
@@ -19,6 +19,9 @@ sources:
     spec:
       url: https://kubernetes.github.io/ingress-nginx
       name: ingress-nginx
+      versionfilter:
+        kind: semver
+        pattern: "~4.11"
 
 targets:
   updateChartVersion:


### PR DESCRIPTION
As 4.12.x breaks things for us: https://github.com/jenkins-infra/kubernetes-management/pull/6068#pullrequestreview-2527313501


Let's start with pinning to 4.11.x and getting new patches.

In particular, we have to check https://github.com/kubernetes/ingress-nginx/issues/13002