### PR TITLE
fix(ci.jenkins.io-agents-2) disable blob caching as a hack to avoid corrupted zero-sized blobs

### DIFF
--- a/config/hub-mirror_cijioagents2.yaml
+++ b/config/hub-mirror_cijioagents2.yaml
@@ -59,3 +59,8 @@ initContainers:
     volumeMounts:
       - mountPath: /var/lib/registry
         name: data
+
+extraEnvVars:
+  # Ref. https://github.com/distribution/distribution/issues/2367#issuecomment-1874449361
+  - name: REGISTRY_STORAGE_CACHE_BLOBDESCRIPTOR
+    value: dummyvalue


### PR DESCRIPTION
… - https://github.com/distribution/distribution/issues/2367\#issuecomment-1874449361