### PR TITLE
feat(privatek8s/infra.ci.jio) add updatecli multiubranch job for `jenkins-infra/pipeline-library`

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -101,9 +101,6 @@ jobsDefinition:
         branchIncludes: "production staging updatecli_* PR-* main"
       shared-tools:
         name: Shared Tools
-      pipeline-library:
-        name: Shared Pipeline Library
-        jenkinsfilePath: Jenkinsfile
       packer-images-gc:
         name: Garbage collector for Packer Images
         repository: packer-images

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -101,6 +101,9 @@ jobsDefinition:
         branchIncludes: "production staging updatecli_* PR-* main"
       shared-tools:
         name: Shared Tools
+      pipeline-library:
+        name: Shared Pipeline Library
+        jenkinsfilePath: Jenkinsfile
       packer-images-gc:
         name: Garbage collector for Packer Images
         repository: packer-images
@@ -290,6 +293,10 @@ jobsDefinition:
             description: "Azure Service Principal credential used by updatecli"
             subscriptionId: "${JENKINSINFRA_AZURE_SECONDARY_SUBSCRIPTION_ID}"
             tenant: "${UPDATECLI_AZURE_TENANT_ID}"
+      pipeline-library:
+        name: Shared Pipeline Library
+        jenkinsfilePath: Jenkinsfile_updatecli
+        disableTagDiscovery: true
       release:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true


### PR DESCRIPTION
as per https://github.com/jenkins-infra/pipeline-library/issues/906
and https://github.com/jenkins-infra/pipeline-library/pull/907

this provide jobs in infra.ci.jenkins.io to run the pipeline (already done by ci.jenkins.io: https://ci.jenkins.io/job/Infra/job/pipeline-library/job/master/744/ and also updatecli 