### PR TITLE
feat(publick8s/ldap) bump chart to 3.0.0 and adapt values (array -> map for LB source list)

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -109,7 +109,7 @@ releases:
   - name: ldap
     namespace: ldap
     chart: jenkins-infra/ldap
-    version: 2.0.5
+    version: 3.0.0
     values:
       - "../config/ldap.yaml"
     secrets:

--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -5,27 +5,34 @@ service:
   azurePip:
     name: ldap-jenkins-io-ipv4
     resourceGroup: prod-public-ips
-  whitelisted_sources:
-    - '20.85.71.108/32' # Accept inbound connections from publick8s public outbound IP (1/3 IPv4)
-    - '20.22.30.9/32' # Accept inbound connections from publick8s public outbound IP (2/3 IPv4)
-    - '20.22.30.74/32' # Accept inbound connections from publick8s public outbound IP (3/3 IPv4)
-    - '20.7.192.189/32' # Accept inbound connections from publick8s outbound NAT gateway
-    - '10.100.0.0/16' # Accept inbound connections from publick8s pods (internal IPs) for internal access
-    - '73.71.177.172/32' # Accept inbound LDAPS request from spambot
-    - '140.211.15.101/32' # Accept inbound LDAPS request from accounts.jenkins.io
-    - '20.12.27.65/32' # Accept inbound LDAPS request from puppet.jenkins.io
-    - '104.209.128.236/32' # Accept inbound LDAPS from trusted.ci.jenkins.io vnet (public IP for the outbound NAT gateway)
-    - '172.176.126.194/32' # Accept inbound LDAPS from private.vpn.jenkins.io
-    - '104.209.153.13/32' # Accept inbound LDAPS from cert.ci.jenkins.io vnet (public IP for the outbound NAT gateway)
-    - '34.211.101.61/32' # Accept inbound connections from Linux Foundation test machine
-    - '44.240.22.235/32' # Accept inbound connections from Linux Foundation prod machine
-    - '20.22.6.81/32' # Accept inbound connections from privatek8s outbound LB # TODO: find out how to retrieve this IP from terraform
-    - '20.65.63.127/32' # Accept inbound connections from privatek8s outbound NAT gateway
-    - '18.214.241.149/32' # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
-    - '34.201.191.93/32' # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
-    - '34.233.58.83/32' # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
-    - '54.236.124.56/32' # JFrog Public Nat IP for AWS us-east-1 (https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/)
-    - '3.146.166.108/32'
+  lbAllowSources:
+    publick8s-out-lb-1: '20.85.71.108/32'
+    publick8s-out-lb-2: '20.22.30.9/32'
+    publick8s-out-lb-3: '20.22.30.74/32'
+    publick8s-nat: '20.7.192.189/32'
+    publick8s-pods: '10.100.0.0/16'
+    # TODO: remove
+    spambot: '73.71.177.172/32'
+    # TODO: remove (old OSUOSL IP)
+    accounts.jenkins.io: '140.211.15.101/32'
+    puppet.jenkins.io: '20.12.27.65/32'
+    trusted.ci.jenkins.io: '104.209.128.236/32'
+    private.vpn.jenkins.io: '172.176.126.194/32'
+    cert.ci.jenkins.io: '104.209.153.13/32'
+    linuxfoundation-staging: '34.211.101.61/32'
+    linuxfoundation-prod: '44.240.22.235/32'
+    privatek8s-out-lb-1: '20.22.6.81/32'
+    privatek8s-nat: '20.65.63.127/32'
+    # https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/
+    jfrog-out-1: '18.214.241.149/32'
+    # https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/
+    jfrog-out-2: '34.201.191.93/32'
+    # https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/
+    jfrog-out-3: '34.233.58.83/32'
+    # https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/
+    jfrog-out-4: '54.236.124.56/32'
+    aws.ci.jenkins.io: '3.146.166.108/32'
+
 resources:
   limits:
     cpu: 2


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helm-charts/pull/1616 which deprecates the list `service.whitelisted_sources` in favor of a new map `service.lbAllowSources` for easier maintenance (updatecli can now track the keys instead of fragile array numeric indexes)