### PR TITLE
chore(publick8s/ldap) fix jfrog multi IP and updatecli manifest 

### DIFF
--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -24,13 +24,7 @@ service:
     privatek8s-out-lb-1: '20.22.6.81/32'
     privatek8s-nat: '20.65.63.127/32'
     # https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/
-    jfrog-out-1: '18.214.241.149/32'
-    # https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/
-    jfrog-out-2: '34.201.191.93/32'
-    # https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/
-    jfrog-out-3: '34.233.58.83/32'
-    # https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/
-    jfrog-out-4: '54.236.124.56/32'
+    jfrog-artifactory: '18.214.241.149/32,34.201.191.93/32,34.233.58.83/32,54.236.124.56/32'
     aws.ci.jenkins.io: '3.146.166.108/32'
 
 resources:

--- a/updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
+++ b/updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
@@ -20,19 +20,19 @@ sources:
       # Outbound IPs are also public "inbound" IPs for EC2 instances
       # The 2nd element is the IPv4 (1st is IPv6)
       key: .aws\.ci\.jenkins\.io.outbound_ips.controller.[1]
-
-targets:
-  ldap-config:
-    name: Update aws.ci.jenkins.io public IP in the YAML values for LDAP
-    kind: yaml
-    sourceid: aws-ci-jenkins-io
     transformers:
       - addprefix: "'"
       - addsuffix: "/32'"
+
+targets:
+  aws-ci-jenkins-io:
+    name: Update aws.ci.jenkins.io CIDR in the LDAP configuration
+    kind: yaml
+    sourceid: aws-ci-jenkins-io
     spec:
       file: config/ldap.yaml
       # That is a rather fragile pattern. TODO: improve helm chart to use map instead of array
-      key: $.service.whitelisted_sources[19]
+      key: $.service.lbAllowSources.'aws.ci.jenkins.io'
     scmid: default
 
 actions:


### PR DESCRIPTION
This change introduces 2 minors fixes on the publik8s's LDAP

- Since #6381 we can (and should) specify JFrog allowed CIDR as a single string (comma separated string list)
- Since #6379 we use a map instead of a list: the updatecli manifest needs fix