### PR TITLE
chore(updatecli) track all LDAP CIDR/IPs from terraform-azure and Jfrog API

### DIFF
--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -6,17 +6,17 @@ service:
     name: ldap-jenkins-io-ipv4
     resourceGroup: prod-public-ips
   lbAllowSources:
-    # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+    # Tracked by updatecli - updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
     publick8s-out-lb: '20.85.71.108/32,20.22.30.9/32,20.22.30.74/32'
     # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
     publick8s-nat: '20.7.192.189/32'
-    # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+    # Tracked by updatecli - updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
     publick8s-pods: '10.100.0.0/16'
     # TODO: remove
     spambot: '73.71.177.172/32'
     # TODO: remove (old OSUOSL IP)
     accounts.jenkins.io: '140.211.15.101/32'
-    # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+    # Tracked by updatecli - updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
     puppet.jenkins.io: '20.12.27.65/32'
     # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
     trusted.ci.jenkins.io: '104.209.128.236/32'
@@ -28,7 +28,7 @@ service:
     linuxfoundation-staging: '34.211.101.61/32'
     # Provided by LF
     linuxfoundation-prod: '44.240.22.235/32'
-    # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+    # Tracked by updatecli - updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
     privatek8s-out-lb: '20.22.6.81/32'
     # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
     privatek8s-nat: '20.65.63.127/32'

--- a/updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
+++ b/updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
@@ -13,6 +13,71 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
+  puppet.jenkins.io:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      key: .puppet\.jenkins\.io.outbound_ips
+    transformers:
+      - addprefix: "'"
+      - addsuffix: '/32'
+      - addsuffix: "'"
+
+  publick8s-lb:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      key: .publick8s.lb_outbound_ips.ipv4
+    transformers:
+      - trimprefix: '['
+      - trimsuffix: ']'
+      - replacer:
+          from: ' '
+          to: '/32,'
+      - addsuffix: '/32'
+      - addprefix: "'"
+      - addsuffix: "'"
+
+  publick8s-pods:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      # Ipv4 is always the first element
+      key: .publick8s.pod_cidrs.[0]
+    transformers:
+      - addprefix: "'"
+      - addsuffix: "'"
+
+  privatek8s-lb:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      key: .privatek8s.lb_outbound_ips.ipv4
+    transformers:
+      - trimprefix: '['
+      - trimsuffix: ']'
+      - replacer:
+          from: ' '
+          to: '/32,'
+      - addsuffix: '/32'
+      - addprefix: "'"
+      - addsuffix: "'"
+
+  # https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/
+  jfrog:
+    kind: json
+    spec:
+      file: https://my.jfrog.com/api/jmis/v1/ip-ranges
+      # Dasel v1 query
+      key: .(cloud=aws)(region=us-east-1)(service=jfrog_cloud_cidr).cidr
+    # Change the json list to a comma-separated list into a single string
+    transformers:
+      - trimprefix: '['
+      - trimsuffix: ']'
+      - replacer:
+          from: ' '
+          to: ','
+
   aws-ci-jenkins-io:
     kind: json
     spec:
@@ -25,14 +90,58 @@ sources:
       - addsuffix: "/32'"
 
 targets:
+  puppet.jenkins.io:
+    name: Update puppet.jenkins.io CIDR in the LDAP configuration
+    kind: yaml
+    sourceid: puppet.jenkins.io
+    spec:
+      file: config/ldap.yaml
+      key: $.service.lbAllowSources.'puppet.jenkins.io'
+    scmid: default
+
+  publick8s-pods:
+    name: Update publick8s pod CIDRs in the LDAP configuration
+    kind: yaml
+    sourceid: publick8s-pods
+    spec:
+      file: config/ldap.yaml
+      key: $.service.lbAllowSources.publick8s-pods
+    scmid: default
+
+  publick8s-lb:
+    name: Update publick8s outbound LB CIDRs in the LDAP configuration
+    kind: yaml
+    sourceid: publick8s-lb
+    spec:
+      file: config/ldap.yaml
+      key: $.service.lbAllowSources.publick8s-out-lb
+    scmid: default
+
+  privatek8s-lb:
+    name: Update privatek8s outbound LB CIDRs in the LDAP configuration
+    kind: yaml
+    sourceid: privatek8s-lb
+    spec:
+      file: config/ldap.yaml
+      key: $.service.lbAllowSources.privatek8s-out-lb
+    scmid: default
+
   aws-ci-jenkins-io:
     name: Update aws.ci.jenkins.io CIDR in the LDAP configuration
     kind: yaml
     sourceid: aws-ci-jenkins-io
     spec:
       file: config/ldap.yaml
-      # That is a rather fragile pattern. TODO: improve helm chart to use map instead of array
       key: $.service.lbAllowSources.'aws.ci.jenkins.io'
+    scmid: default
+
+  jfrog:
+    name: Update JFrog CIDRs in the LDAP configuration
+    kind: yaml
+    sourceid: jfrog
+    spec:
+      file: config/ldap.yaml
+      key: $.service.lbAllowSources.jfrog-artifactory
     scmid: default
 
 actions:


### PR DESCRIPTION
This change increase the amount of CIDR/public IPv4 tracked by `updatecli` to keep the LDAP allow-list up to date.

It tracks:

- All CIDR/IPs which are exported by the [Terraform Azure project](jenkins-infra/azure):
  - The LoadBalancer outbound IPs for `publick8s` and `privatek8s` (note: their NAT outbound IP are tracked in the Azure Net project, so not in the scope of this change) to allow access from infra.ci/release.ci (privatek8s) and for weekly.ci/accounts.jenkins.io (publick8s, when the private routing fails to use the NAT gateway and the outbound LB: recommended by Microsoft)
  - The Pods CIDR IPs for `publick8s` for weekly.ci/accounts.jenkins.io (default behavior through private network)
  - puppet.jenkins.io VM outbound IP (required by the Puppet master)
- All the JFrog outbound IPs from their API
  - Only on us-east-1, where our instance is running:
    
    ```bash
    $ dig +short jenkins.jfrog.io | grep amazonaws
    k8s-jfrogsaa-jfrogsaa-8be278388b-b43e78389344652b.elb.us-east-1.amazonaws.com.
    ```

  - We exclude the Jfrog build pipeline as we do not use them

----

Note: The Jfrog documentation at https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/ triggered the need for this change, as they have many more IPs than the 4 we have. This change should trigger an update on JFrog only, as we risk having error when logging in from repo.jenkins-ci.org.