### PR TITLE
cleanup(publick8s/ldap) remove 2 unused IPs from allow-list: spambot and legacy account-a))

### DIFF
--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -12,10 +12,6 @@ service:
     publick8s-nat: '20.7.192.189/32'
     # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
     publick8s-pods: '10.100.0.0/16'
-    # TODO: remove
-    spambot: '73.71.177.172/32'
-    # TODO: remove (old OSUOSL IP)
-    accounts.jenkins.io: '140.211.15.101/32'
     # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
     puppet.jenkins.io: '20.12.27.65/32'
     # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure.json


### PR DESCRIPTION
This PR removes 2 IPs from the LDAP allow-list for its inbound LoadBalancer:

- SpamBot (ref. https://github.com/jenkins-infra/backend-confluence-spam-remover/tree/master) was a service run along with the Confluence service in the Jenkins infra to remove spam bot users. It has been archived in November 2022 and is no longer needed
- Accounts.jenkins.io runs in the AKS cluster since 2020 and access LDAP through the private pod IP as it run in the same private network. The public IP referenced in the LDAP allow list is the former OSUOSL VM which used to run the account app