### PR TITLE
feat(privatek8s/infra.ci) add the cijenkinsio-agents-1 admin kubeconfig to the kubernetes-manegement job

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -148,6 +148,10 @@ jobsDefinition:
             fileName: "kubeconfig"
             description: "Kubeconfig file for publick8s"
             secretBytes: "${base64:${KUBECONFIG_PUBLICK8S}}"
+          kubeconfig-cijioagents1:
+            fileName: "kubeconfig"
+            description: "Kubeconfig file for cijioagents1"
+            secretBytes: "${base64:${KUBECONFIG_CIJIOAGENTS1}}"
           kubeconfig-cijioagents2:
             fileName: "kubeconfig"
             description: "Kubeconfig file for cijioagents2"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4619

Credential value pushed to SOPS in https://github.com/jenkins-infra/charts-secrets/commit/4d0bfc8fc9e4eca79f17d2649b85d8db63a51f14