### PR TITLE
feat(cijenkinsio-agents-1) install ACP with 1 replica and no CPU limits

### DIFF
--- a/clusters/cijioagents1.yaml
+++ b/clusters/cijioagents1.yaml
@@ -21,3 +21,10 @@ releases:
       - "../config/datadog_cijenkinsio-agents-1.yaml"
     secrets:
       - "../secrets/config/datadog/cijenkinsio-agents-1.yaml"
+  - name: artifact-caching-proxy
+    namespace: artifact-caching-proxy
+    chart: jenkins-infra/artifact-caching-proxy
+    # TODO: track with updatecli
+    version: 1.6.5
+    values:
+      - "../config/artifact-caching-proxy_azure-cijenkinsio-agents-1"

--- a/clusters/cijioagents1.yaml
+++ b/clusters/cijioagents1.yaml
@@ -27,4 +27,4 @@ releases:
     # TODO: track with updatecli
     version: 1.6.5
     values:
-      - "../config/artifact-caching-proxy_azure-cijenkinsio-agents-1"
+      - "../config/artifact-caching-proxy_azure-cijenkinsio-agents-1.yaml"

--- a/clusters/cijioagents2.yaml
+++ b/clusters/cijioagents2.yaml
@@ -24,7 +24,6 @@ releases:
   - name: artifact-caching-proxy
     namespace: artifact-caching-proxy
     chart: jenkins-infra/artifact-caching-proxy
-    # TODO: track with updatecli
     version: 1.6.5
     values:
       - "../config/artifact-caching-proxy_aws-cijenkinsio-agents-2.yaml"

--- a/config/artifact-caching-proxy_azure-cijenkinsio-agents-1.yaml
+++ b/config/artifact-caching-proxy_azure-cijenkinsio-agents-1.yaml
@@ -4,7 +4,7 @@ persistence:
   storageClass: managed-csi-premium
 
 nodeSelector:
-  kubernetes.io/arch: arm64
+  kubernetes.io/arch: amd64
   jenkins: ci.jenkins.io
   role: applications
 
@@ -29,19 +29,21 @@ service:
   type: LoadBalancer
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    # TODO: track with updatecli
     service.beta.kubernetes.io/azure-load-balancer-internal-subnet: "public-jenkins-sponsorship-vnet-ci_jenkins_io_agents"
+    # TODO: track with updatecli
     service.beta.kubernetes.io/azure-load-balancer-ipv4: "10.200.2.254"
     service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset: "true"
 
 resources:
   limits:
-    cpu: 4
+    # No CPU limit to avoid throttling
     memory: 8192Mi
   requests:
-    cpu: 2
-    memory: 4096Mi
+    cpu: 1.5
+    memory: 8192Mi
 
-replicaCount: 2
+replicaCount: 1
 
 proxy:
   dnsResolver: "kube-dns.kube-system.svc.cluster.local 9.9.9.9"

--- a/updatecli/updatecli.d/charts/artifact-caching-proxy.yaml
+++ b/updatecli/updatecli.d/charts/artifact-caching-proxy.yaml
@@ -25,7 +25,10 @@ targets:
     name: "Update the chart version for artifact-caching-proxy"
     kind: yaml
     spec:
-      file: clusters/cijioagents2.yaml
+      files:
+        # TODO: uncomment once ACP is installed here
+        # - clusters/cijioagents1.yaml
+        - clusters/cijioagents2.yaml
       engine: yamlpath
       key: $.releases[?(@.name == 'artifact-caching-proxy')].version
     scmid: default


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4619

The ACP settings have been extracted from the former Azure cluster, but adapted to what we learnt when running in AWS (ref. https://github.com/jenkins-infra/helpdesk/issues/4545):

- Only 1 replica
- No CPu limit to avoid throttling requests (it is safe to do this on non CI agents workloads when we have static workloads)