### PR TITLE
feat(cijenkinsio-agents-1) add maven-cacher release

### DIFF
--- a/clusters/cijioagents1.yaml
+++ b/clusters/cijioagents1.yaml
@@ -28,3 +28,11 @@ releases:
     version: 1.6.5
     values:
       - "../config/artifact-caching-proxy_azure-cijenkinsio-agents-1.yaml"
+  - name: maven-cacher
+    # TODO: track with updatecli
+    namespace: maven-cache
+    chart: jenkins-infra/maven-cacher
+    # TODO: track with updatecli
+    version: 0.0.2
+    values:
+      - "../config/cijioagents1-maven-cacher.yaml"

--- a/config/cijioagents1-maven-cacher.yaml
+++ b/config/cijioagents1-maven-cacher.yaml
@@ -39,7 +39,7 @@ javaHome: /opt/jdk-21
 mavenMirror:
   enable: true
   # TODO: track with updatecli
-  url: http://k8s-artifact-artifact-f340ad86c3-70787fedaeca6b4d.elb.us-east-2.amazonaws.com:8080/
+  url: http://artifact-caching-proxy.artifact-caching-proxy.svc.cluster.local:8080/
   # TODO: track with updatecli
   mirrorOf: "external:*,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io,!space-maven"
   mirrorId: artifact-caching-proxy

--- a/config/cijioagents1-maven-cacher.yaml
+++ b/config/cijioagents1-maven-cacher.yaml
@@ -1,0 +1,45 @@
+image:
+  #TODO: track with updatecli
+  tag: 2.34.0
+
+nodeSelector:
+  kubernetes.io/arch: amd64
+  jenkins: ci.jenkins.io
+  role: applications
+
+tolerations:
+  - key: "ci.jenkins.io/applications"
+    operator: "Equal"
+    value: "true"
+    effect: "NoSchedule"
+
+resources:
+  limits:
+    # No CPU limit to avoid throttling
+    memory: 1024Mi
+  requests:
+    cpu: 2
+    memory: 1024Mi
+
+podSecurityContext:
+  runAsUser: 1001 # User 'jenkins'
+  runAsGroup: 1001 # Group 'jenkins'
+  runAsNonRoot: true
+
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+#TODO: track with updatecli
+cachePvc: ci-jenkins-io-maven-cache
+javaHome: /opt/jdk-21
+mavenMirror:
+  enable: true
+  # TODO: track with updatecli
+  url: http://k8s-artifact-artifact-f340ad86c3-70787fedaeca6b4d.elb.us-east-2.amazonaws.com:8080/
+  # TODO: track with updatecli
+  mirrorOf: "external:*,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io,!space-maven"
+  mirrorId: artifact-caching-proxy


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4619#issuecomment-2775692473

Now that the "Maven Cacher" PVCs have been created, we can proceed.

Differences from the AWS EKS "Maven Cacher":

- `amd64` CPU
- Use internal ACP URL (might be cherry picked to EKS)