### PR TITLE
feat(publick8s/infra.ci.jenkins.io) Disable tag discovery for the job `docker-404`

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -49,6 +49,7 @@ jobsDefinition:
       account-app:
         jenkinsfilePath: Jenkinsfile
       docker-404:
+        disableTagDiscovery: true
       docker-builder:
       docker-confluence-data:
       docker-crond:


### PR DESCRIPTION
As per - https://github.com/jenkins-infra/pipeline-library/issues/918

We want to avoid building docker images on tag discovery.

This PR disables tag discovered builds for `docker-404`