### PR TITLE
chore(updatecli) fix ldap and ACP-azure IP tracking manifests

### DIFF
--- a/updatecli/updatecli.d/configs/acp-lb-azure.yaml
+++ b/updatecli/updatecli.d/configs/acp-lb-azure.yaml
@@ -30,7 +30,7 @@ targets:
     name: Update ACP LB IPv4
     kind: yaml
     spec:
-      file: config/artifact-caching-proxy_azure-aks.yaml
+      file: config/artifact-caching-proxy_azure-cijenkinsio-agents-1.yaml
       key: $.service.annotations.'service.beta.kubernetes.io/azure-load-balancer-ipv4'
     scmid: default
 

--- a/updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
+++ b/updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
@@ -92,13 +92,19 @@ sources:
   azure-ci-jenkins-io:
     kind: json
     spec:
-      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
       # Outbound IPs are also public "inbound" IPs for EC2 instances
       # The 2nd element is the IPv4 (1st is IPv6)
-      key: .azure\.ci\.jenkins\.io.service_ips.ipv4
+      key: .ci\.jenkins\.io.outbound_ips
+    # Change the json list to a comma-separated list into a single string
     transformers:
-      - addprefix: "'"
+      - trimprefix: '['
+      - trimsuffix: ']'
+      - replacer:
+          from: ' '
+          to: '/32,'
       - addsuffix: "/32'"
+      - addprefix: "'"
 
 targets:
   puppet.jenkins.io:


### PR DESCRIPTION
Fixup of #6403 and #6417 were the changes broke updatecli manifests.

This PR expects the LDAP IP to change as I used the inbound IP for azure.ci.jenkins.io in #6417 while LDAP expects the outbound IPs (from the NAT gateway) - https://github.com/jenkins-infra/helpdesk/issues/4620