### PR TITLE
cleanup(privatek8s,infraciagents1,cijenkinsio2) remove unused Docker pull credentials in the `jenkins-agents` namespaces

### DIFF
--- a/clusters/cijioagents2.yaml
+++ b/clusters/cijioagents2.yaml
@@ -43,9 +43,6 @@ releases:
     version: 1.1.0
     values:
       - "../config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents2.yaml"
-    # TODO: delete?
-    secrets:
-      - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
   - name: jenkins-agents-bom
     # TODO: track with updatecli
     namespace: jenkins-agents-bom
@@ -53,9 +50,6 @@ releases:
     version: 1.1.0
     values:
       - "../config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents2-bom.yaml"
-    # TODO: delete?
-    secrets:
-      - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
   - name: maven-cacher
     # TODO: track with updatecli
     namespace: maven-cache

--- a/clusters/infracijioagents1.yaml
+++ b/clusters/infracijioagents1.yaml
@@ -27,5 +27,3 @@ releases:
     version: 1.0.0
     values:
       - "../config/jenkins-infra-agents-infracijioagents1.yaml"
-    secrets:
-      - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"

--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -86,8 +86,6 @@ releases:
     version: 1.1.0
     values:
       - "../config/jenkins-kubernetes-agents_release.ci.jenkins.io.yaml"
-    secrets:
-      - "../secrets/config/jenkins-kubernetes-agents/secrets.yaml"
   - name: jenkins-release-core-package
     namespace: jenkins-release-agents
     chart: jenkins-infra/env-jenkins-release


### PR DESCRIPTION
Note: will need a cleanup (removal) of `config/jenkins-kubernetes-agents/secrets.yaml` in the private jenkins-infra/chart-secrets SOPS repositories once applied with success.