### PR TITLE
chore(privatek8s/infra.ci.io): Enable tag discovery for Plugin Health Scoring

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -87,7 +87,7 @@ jobsDefinition:
         disableTagDiscovery: true
       plugin-health-scoring:
         jenkinsfilePath: Jenkinsfile
-        disableTagDiscovery: true
+        disableTagDiscovery: false # PHS uses manual tags
       plugin-site-api:
         jenkinsfilePath: Jenkinsfile
         disableTagDiscovery: true


### PR DESCRIPTION
As per 

- https://github.com/jenkins-infra/helpdesk/issues/4638#issue-2993599829

We need to enable Tag discovery for PHS to deploy on manually created tags.