### PR TITLE
fix(jenkins_infra.ci.jenkins.io): remove hoverColor in header as it crash jcasc

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -829,7 +829,6 @@ controller:
             headerColor:
               backgroundColor: "linear-gradient(90deg, rgba(239,192,92,1) 0%, rgba(171,28,28,1) 100%);"
               color: "white"
-              hoverColor: "#D0763F"
             logo:
               image:
                 logoUrl: "https://infra.ci.jenkins.io/userContent/logos/beekeeper.png"


### PR DESCRIPTION
see https://github.com/jenkinsci/customizable-header-plugin/pull/194/files#r2054468199

deprecated parameter: hoverColor