### PR TITLE
cleanup(privatek8s/infra.ci) remove the docker-inbound-agents jobs as the repository is archived

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -60,8 +60,6 @@ jobsDefinition:
         disableTagDiscovery: true
       docker-geoipupdate:
         disableTagDiscovery: true
-      docker-inbound-agents:
-        disableTagDiscovery: true
       docker-jenkins-lts:
         disableTagDiscovery: true
       docker-jenkins-weeklyci:
@@ -226,9 +224,6 @@ jobsDefinition:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
       docker-geoipupdate:
-        jenkinsfilePath: Jenkinsfile_updatecli
-        disableTagDiscovery: true
-      docker-inbound-agents:
         jenkinsfilePath: Jenkinsfile_updatecli
         disableTagDiscovery: true
       docker-jenkins-infraci:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4554#issuecomment-2824152635