### PR TITLE
feat: add privatek8s_sponsorship cluster

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'privatek8s', 'publick8s', 'cijioagents1', 'infracijioagents1'
+            values 'privatek8s', 'privatek8s-sponsorship', 'publick8s', 'cijioagents1', 'infracijioagents1'
           }
         } // axes
         agent {

--- a/clusters/privatek8s-sponsorship.yaml
+++ b/clusters/privatek8s-sponsorship.yaml
@@ -1,0 +1,35 @@
+---
+helmDefaults:
+  atomic: true
+  force: false
+  timeout: 300
+  wait: true
+repositories:
+  # https://github.com/DataDog/helm-charts/
+  - name: datadog
+    url: https://helm.datadoghq.com
+  # https://github.com/timja/github-comment-ops/
+  - name: github-comment-ops
+    url: https://timja.github.io/github-comment-ops/
+  # https://github.com/kubernetes/ingress-nginx/
+  - name: ingress-nginx
+    url: https://kubernetes.github.io/ingress-nginx
+  # https://github.com/jenkinsci/helm-charts/
+  - name: jenkins
+    url: https://charts.jenkins.io
+  # https://github.com/jenkins-infra/helm-charts/
+  - name: jenkins-infra
+    url: https://jenkins-infra.github.io/helm-charts
+  # https://github.com/cert-manager/cert-manager/
+  - name: jetstack
+    url: https://charts.jetstack.io
+releases:
+  - name: datadog
+    namespace: datadog
+    chart: datadog/datadog
+    version: 3.110.13
+    values:
+      - "../config/datadog.yaml.gotmpl"
+      - "../config/datadog_privatek8s_sponsorship.yaml"
+    secrets:
+      - "../secrets/config/datadog/privatek8s_sponsorship-secrets.yaml"

--- a/config/datadog_privatek8s_sponsorship.yaml
+++ b/config/datadog_privatek8s_sponsorship.yaml
@@ -2,7 +2,7 @@ providers:
   aks:
     enabled: true
 datadog:
-  clusterName: 'privatek8s_sponsorship'
+  clusterName: 'privatek8s-sponsorship'
   env:
     - name: DD_HOSTNAME
       valueFrom:

--- a/config/datadog_privatek8s_sponsorship.yaml
+++ b/config/datadog_privatek8s_sponsorship.yaml
@@ -1,0 +1,44 @@
+providers:
+  aks:
+    enabled: true
+datadog:
+  clusterName: 'privatek8s_sponsorship'
+  env:
+    - name: DD_HOSTNAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+  kubelet:
+    host:
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
+    # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
+    tlsVerify: false
+agents:
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
+    - key: "CriticalAddonsOnly"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "jenkins"
+      operator: "Equal"
+      value: "infra.ci.jenkins.io"
+      effect: "NoSchedule"
+    - key: "jenkins"
+      operator: "Equal"
+      value: "release.ci.jenkins.io"
+      effect: "NoSchedule"
+    - key: "jenkins-component"
+      operator: "Equal"
+      value: "controller"
+      effect: "NoSchedule"
+    - key: "kubernetes.azure.com/scalesetpriority"
+      operator: "Equal"
+      value: "spot"
+      effect: "NoSchedule"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4250#issuecomment-2824642025

Requires #6484 

- The cluster manifest has been created from the current `privatek8s` but removed all releases except datadog
- Requires datadog secret tokens: https://github.com/jenkins-infra/charts-secrets/commit/aa40929da0811dfd85aec7908dad6d94f4a91db3
