### PR TITLE
feat(privatek8s-sponsorship) add public-nginx-ingress release

### DIFF
--- a/clusters/privatek8s-sponsorship.yaml
+++ b/clusters/privatek8s-sponsorship.yaml
@@ -63,3 +63,10 @@ releases:
     values:
       - ../config/private-nginx-ingress__common.yaml
       - ../config/private-nginx-ingress_privatek8s_sponsorship.yaml
+  - name: public-nginx-ingress
+    namespace: public-nginx-ingress
+    chart: ingress-nginx/ingress-nginx
+    version: 4.11.5
+    values:
+      - ../config/public-nginx-ingress__common.yaml
+      - ../config/public-nginx-ingress_privatek8s_sponsorship.yaml

--- a/config/public-nginx-ingress_privatek8s_sponsorship.yaml
+++ b/config/public-nginx-ingress_privatek8s_sponsorship.yaml
@@ -1,0 +1,16 @@
+controller:
+  config:
+    ## Ingress controller level
+    # Only allow GitHub's webhooks requests - https://api.github.com/meta ("hooks", tracked by updatecli)
+    whitelist-source-range: 140.82.112.0/20,143.55.64.0/20,185.199.108.0/22,192.30.252.0/22
+  service:
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-internal: false
+      # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      service.beta.kubernetes.io/azure-pip-name: public-privatek8s
+      # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      service.beta.kubernetes.io/azure-load-balancer-resource-group: prod-public-ips-sponsorship
+    externalTrafficPolicy: Local
+    ## Public LB level
+    # Only allow GitHub's webhooks requests - https://api.github.com/meta ("hooks", tracked by updatecli)
+    loadBalancerSourceRanges: ["140.82.112.0/20", "143.55.64.0/20", "185.199.108.0/22", "192.30.252.0/22"]


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4250#issuecomment-2824642025

Tested with success manually, then uninstalled (and removed NS) prior to the PR. The public LB was created with the provided public IPv4 with no errors.