### PR TITLE
feat(privatek8s-sponsorship) add core-package PV/PVCs

### DIFF
--- a/clusters/privatek8s-sponsorship.yaml
+++ b/clusters/privatek8s-sponsorship.yaml
@@ -70,3 +70,9 @@ releases:
     values:
       - ../config/public-nginx-ingress__common.yaml
       - ../config/public-nginx-ingress_privatek8s_sponsorship.yaml
+  - name: jenkins-release-core-package
+    namespace: jenkins-release-agents
+    chart: jenkins-infra/env-jenkins-release
+    version: 0.2.0
+    secrets:
+      - ../secrets/config/release.ci.jenkins.io/env-jenkins-secrets.yaml


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4250#issuecomment-2824642025

This PR adds the 2 PVCs (and associated resources: PVs and secret) used by release.ci agents.

Note: the goal is to create the resources with the same settings as in the current `privatek8s` before importing them in Terraform for static management (so it would be easier to check the settings and eventual drift in Terraform by importing them)