### PR TITLE
hotfix(privatek8s-sponsorship/private-nginx-ingress) correct internal LB annotation to use the proper IPv4

### DIFF
--- a/config/private-nginx-ingress_privatek8s_sponsorship.yaml
+++ b/config/private-nginx-ingress_privatek8s_sponsorship.yaml
@@ -1,5 +1,8 @@
 controller:
   service:
     annotations:
+      service.beta.kubernetes.io/azure-load-balancer-internal: "true"
       # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
       service.beta.kubernetes.io/azure-load-balancer-internal-subnet: privatek8s-sponsorship-tier
+      # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      service.beta.kubernetes.io/azure-load-balancer-ipv4: "10.241.255.254"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4250#issuecomment-2838032516

Applied manually with success: we can now reach the private ingress through the current DNS