### PR TITLE
feat(privatek8s-sponsorship) migrate rss2twitter and github-comment-ops

### DIFF
--- a/clusters/privatek8s-sponsorship.yaml
+++ b/clusters/privatek8s-sponsorship.yaml
@@ -103,21 +103,21 @@ releases:
       - jenkins-release/jenkins-release
     values:
       - "../config/jenkins-kubernetes-agents_release.ci.jenkins.io.yaml"
-  # - name: rss2twitter
-  #   namespace: rss2twitter
-  #   chart: jenkins-infra/rss2twitter
-  #   version: 0.1.0
-  #   values:
-  #     - "../config/rss2twitter.yaml"
-  #   secrets:
-  #     - "../secrets/config/rss2twitter/secrets.yaml" # @jenkins_release Twitter dev account credentials
-  # - name: github-comment-ops
-  #   namespace: github-comment-ops
-  #   chart: github-comment-ops/github-comment-ops
-  #   version: 1.5.2
-  #   needs:
-  #     - public-nginx-ingress/public-nginx-ingress # Required to expose the webhooks endpoint
-  #   values:
-  #     - "../config/github-comment-ops.yaml"
-  #   secrets:
-  #     - "../secrets/config/github-comment-ops/secrets.yaml"
+  - name: rss2twitter
+    namespace: rss2twitter
+    chart: jenkins-infra/rss2twitter
+    version: 0.1.0
+    values:
+      - "../config/rss2twitter.yaml"
+    secrets:
+      - "../secrets/config/rss2twitter/secrets.yaml" # @jenkins_release Twitter dev account credentials
+  - name: github-comment-ops
+    namespace: github-comment-ops
+    chart: github-comment-ops/github-comment-ops
+    version: 1.5.2
+    needs:
+      - public-nginx-ingress/public-nginx-ingress # Required to expose the webhooks endpoint
+    values:
+      - "../config/github-comment-ops.yaml"
+    secrets:
+      - "../secrets/config/github-comment-ops/secrets.yaml"

--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -24,31 +24,31 @@ repositories:
   - name: jetstack
     url: https://charts.jetstack.io
 releases:
-  - name: acme
-    namespace: cert-manager
-    chart: jenkins-infra/acme
-    version: 0.1.4
-    needs:
-      - cert-manager/cert-manager
-    values:
-      - "../config/acme.yaml"
-    secrets:
-      - "../secrets/config/acme/secrets.yaml"
-  - name: cert-manager
-    namespace: cert-manager
-    chart: jetstack/cert-manager
-    version: v1.17.2
-    values:
-      - "../config/cert-manager.yaml"
-  - name: datadog
-    namespace: datadog
-    chart: datadog/datadog
-    version: 3.110.14
-    values:
-      - "../config/datadog.yaml.gotmpl"
-      - "../config/datadog_privatek8s.yaml"
-    secrets:
-      - "../secrets/config/datadog/privatek8s-secrets.yaml"
+  # - name: acme
+  #   namespace: cert-manager
+  #   chart: jenkins-infra/acme
+  #   version: 0.1.4
+  #   needs:
+  #     - cert-manager/cert-manager
+  #   values:
+  #     - "../config/acme.yaml"
+  #   secrets:
+  #     - "../secrets/config/acme/secrets.yaml"
+  # - name: cert-manager
+  #   namespace: cert-manager
+  #   chart: jetstack/cert-manager
+  #   version: v1.17.2
+  #   values:
+  #     - "../config/cert-manager.yaml"
+  # - name: datadog
+  #   namespace: datadog
+  #   chart: datadog/datadog
+  #   version: 3.110.14
+  #   values:
+  #     - "../config/datadog.yaml.gotmpl"
+  #     - "../config/datadog_privatek8s.yaml"
+  #   secrets:
+  #     - "../secrets/config/datadog/privatek8s-secrets.yaml"
   - name: jenkins-infra
     namespace: jenkins-infra
     chart: jenkins/jenkins
@@ -62,12 +62,12 @@ releases:
       - "../config/jenkins_infra.ci.jenkins.io.yaml"
     secrets:
       - "../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml"
-  - name: jenkins-infra-jobs
-    namespace: jenkins-infra
-    chart: jenkins-infra/jenkins-jobs
-    version: 2.3.0
-    values:
-      - "../config/jenkins-jobs_infra.ci.jenkins.io.yaml"
+  # - name: jenkins-infra-jobs
+  #   namespace: jenkins-infra
+  #   chart: jenkins-infra/jenkins-jobs
+  #   version: 2.3.0
+  #   values:
+  #     - "../config/jenkins-jobs_infra.ci.jenkins.io.yaml"
   # - name: jenkins-release
   #   namespace: jenkins-release
   #   chart: jenkins/jenkins
@@ -86,41 +86,41 @@ releases:
   #   version: 1.1.0
   #   values:
   #     - "../config/jenkins-kubernetes-agents_release.ci.jenkins.io.yaml"
-  - name: jenkins-release-core-package
-    namespace: jenkins-release-agents
-    chart: jenkins-infra/env-jenkins-release
-    version: 0.2.0
-    secrets:
-      - ../secrets/config/release.ci.jenkins.io/env-jenkins-secrets.yaml
-  - name: public-nginx-ingress
-    namespace: public-nginx-ingress
-    chart: ingress-nginx/ingress-nginx
-    version: 4.11.5
-    values:
-      - "../config/public-nginx-ingress__common.yaml"
-      - "../config/public-nginx-ingress_privatek8s.yaml"
-  - name: private-nginx-ingress
-    namespace: private-nginx-ingress
-    chart: ingress-nginx/ingress-nginx
-    version: 4.11.5
-    values:
-      - "../config/private-nginx-ingress__common.yaml"
-      - "../config/private-nginx-ingress_privatek8s.yaml"
-  - name: rss2twitter
-    namespace: rss2twitter
-    chart: jenkins-infra/rss2twitter
-    version: 0.1.0
-    values:
-      - "../config/rss2twitter.yaml"
-    secrets:
-      - "../secrets/config/rss2twitter/secrets.yaml" # @jenkins_release Twitter dev account credentials
-  - name: github-comment-ops
-    namespace: github-comment-ops
-    chart: github-comment-ops/github-comment-ops
-    version: 1.5.2
-    needs:
-      - public-nginx-ingress/public-nginx-ingress # Required to expose the webhooks endpoint
-    values:
-      - "../config/github-comment-ops.yaml"
-    secrets:
-      - "../secrets/config/github-comment-ops/secrets.yaml"
+  # - name: jenkins-release-core-package
+  #   namespace: jenkins-release-agents
+  #   chart: jenkins-infra/env-jenkins-release
+  #   version: 0.2.0
+  #   secrets:
+  #     - ../secrets/config/release.ci.jenkins.io/env-jenkins-secrets.yaml
+  # - name: public-nginx-ingress
+  #   namespace: public-nginx-ingress
+  #   chart: ingress-nginx/ingress-nginx
+  #   version: 4.11.5
+  #   values:
+  #     - "../config/public-nginx-ingress__common.yaml"
+  #     - "../config/public-nginx-ingress_privatek8s.yaml"
+  # - name: private-nginx-ingress
+  #   namespace: private-nginx-ingress
+  #   chart: ingress-nginx/ingress-nginx
+  #   version: 4.11.5
+  #   values:
+  #     - "../config/private-nginx-ingress__common.yaml"
+  #     - "../config/private-nginx-ingress_privatek8s.yaml"
+  # - name: rss2twitter
+  #   namespace: rss2twitter
+  #   chart: jenkins-infra/rss2twitter
+  #   version: 0.1.0
+  #   values:
+  #     - "../config/rss2twitter.yaml"
+  #   secrets:
+  #     - "../secrets/config/rss2twitter/secrets.yaml" # @jenkins_release Twitter dev account credentials
+  # - name: github-comment-ops
+  #   namespace: github-comment-ops
+  #   chart: github-comment-ops/github-comment-ops
+  #   version: 1.5.2
+  #   needs:
+  #     - public-nginx-ingress/public-nginx-ingress # Required to expose the webhooks endpoint
+  #   values:
+  #     - "../config/github-comment-ops.yaml"
+  #   secrets:
+  #     - "../secrets/config/github-comment-ops/secrets.yaml"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4250#issuecomment-2838032516

This PR introduces the following changes:

- Add the `rss2twitter` release
- Add the `github-comments-bot` release
- Comment out migrated releases from `privatek8s` even if disabled


This PR can only be merged after:

- https://github.com/jenkins-infra/azure-net/pull/371 is merged and deployed successfully
- The deployments of `rss2twitter` and `github-comment-ops` have been scaled to zero on `privatek8s`:

```
kubectl -n rss2twitter scale --replicas=0 deployment rss2twitter
kubectl -n github-comment-ops scale --replicas=0 deployment github-comment-ops
```