### PR TITLE
fix(privatek8s) correct deprecated node selector labels

### DIFF
--- a/config/github-comment-ops.yaml
+++ b/config/github-comment-ops.yaml
@@ -15,4 +15,4 @@ ingress:
         - webhook-github-comment-ops.jenkins.io
 
 nodeSelector:
-  agentpool: linuxpool
+  kubernetes.azure.com/agentpool: linuxpool

--- a/config/rss2twitter.yaml
+++ b/config/rss2twitter.yaml
@@ -8,4 +8,4 @@ env:
   dryMode: false
 
 nodeSelector:
-  agentpool: linuxpool
+  kubernetes.azure.com/agentpool: linuxpool


### PR DESCRIPTION
The Azure monitor on `privatek8s` shows we are using deprecated node selector labels:

![Capture d’écran 2025-04-29 à 19 00 29](https://github.com/user-attachments/assets/44e5d123-f4b3-4b49-b8ea-55e0ada75d13)

This PR fixes these depreciations by aligning the node selector labels with the infra.ci and release.ci controllers installations.