### PR TITLE
feat(privatek8s/infra.ci) remove the infra-reports/plugins-migration job

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -426,17 +426,6 @@ jobsDefinition:
         name: "Plugin Health Scoring Report"
         repository: "infra-reports"
         jenkinsfilePath: "plugin-health-scoring/Jenkinsfile"
-      plugin-migration:
-        name: "Plugin Migration Status Report"
-        repository: "infra-reports"
-        jenkinsfilePath: "plugin-migration/Jenkinsfile"
-        credentials:
-          githubapp-jenkins-infra-reports-private-key-b64:
-            description: "Base64 encoded private key of the Github App installed on jenkinsci org for https://github.com/jenkins-infra/infra-reports scripts"
-            secret: "${GITHUB_APP_JENKINSCI_INFRA_REPORTS_PRIVATE_KEY_B64}"
-          githubapp-jenkins-infra-reports-app-identifier:
-            description: "Identifier (integer) of the Github App installed on jenkinsci org for https://github.com/jenkins-infra/infra-reports scripts"
-            secret: "${GITHUB_APP_JENKINSCI_INFRA_REPORTS_ID}"
   terraform-jobs:
     name: Terraform Jobs
     description: Folder hosting all the Terraform-related jobs


### PR DESCRIPTION
Not needed anymore, as per https://github.com/jenkins-infra/helpdesk/issues/4671