### PR TITLE
Remove Design Library logo from Dashboard on weekly.ci.jenkins.io

### DIFF
--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -167,7 +167,7 @@ controller:
             - "jenkins.security.QueueItemAuthenticatorMonitor"
           views:
             - all:
-                description: "<div style=\"width: 100%; display: flex;justify-content: center;\">\r\n    <div style=\"text-align: center;\">\r\n        <p>\r\n            <img alt=\"Design Library\" src=\"https://raw.githubusercontent.com/jenkinsci/design-library-plugin/master/logo.svg\" height=\"100\" width=\"280\" />\r\n        </p>\r\n    </div>\r\n    <p style=\"font-size: 18px;\">The <a href=\"/design-library/\" rel=\"nofollow\">Design Library</a> makes it easy for developers to build complex and consistent interfaces using Jenkins UI components.</p>\r\n</div>\r\n"
+                description: "<p style=\"font-size: 18px;\">The <a href=\"/design-library/\" rel=\"nofollow\">Design Library</a> makes it easy for developers to build complex and consistent interfaces using Jenkins UI components.</p>"
                 name: "all"
           markupFormatter:
             rawHtml:


### PR DESCRIPTION
<img width="1052" alt="image" src="https://github.com/user-attachments/assets/f6f3bcac-7471-48ad-8997-f25d1d83314b" />

The Design Library logo only really works in light mode - its pretty hard to read in dark mode (and will be even harder when https://github.com/jenkinsci/dark-theme-plugin/pull/591 is released).