### PR TITLE
break!(infra.ci): change default jdk to jdk21

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -131,7 +131,7 @@ controller:
                             value: "/opt/jdk-21/bin/java"
                         - envVar:
                             key: "JAVA_HOME"
-                            value: "/opt/jdk-17"
+                            value: "/opt/jdk-21"
                         resourceLimitMemory: "2048Mi"
                         resourceRequestCpu: "500m"
                         resourceRequestMemory: "512Mi"
@@ -164,7 +164,7 @@ controller:
                             value: "/opt/jdk-21/bin/java"
                         - envVar:
                             key: "JAVA_HOME"
-                            value: "/opt/jdk-17"
+                            value: "/opt/jdk-21"
                         resourceLimitMemory: "2048Mi"
                         resourceRequestCpu: "500m"
                         resourceRequestMemory: "512Mi"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4127#issue-2335969330

change default jdk from jdk-17 to jdk-21