### PR TITLE
fix(privatek8s/infra.ci) ensure docker-plugin-site-issues job scans for tags

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -80,7 +80,7 @@ jobsDefinition:
       docker-packaging:
         disableTagDiscovery: true
       docker-plugin-site-issues:
-        disableTagDiscovery: true
+        disableTagDiscovery: false
       docker-rsyncd:
         disableTagDiscovery: true
       plugin-health-scoring:


### PR DESCRIPTION
Ref https://matrix.to/#/!JLUOInpEYmxJIYXlzs:matrix.org/$opnKFVudmgQHamLtoP5klsjg5od2i3MfE55dN-rsYKE?via=g4v.dev&via=gitter.im&via=matrix.org

@zbynek reported that creating a tag on https://github.com/jenkins-infra/docker-plugin-site-issues/ did not trigger publication on DockerHub.

As caught by @smerle33, we are missing a specific job configuration which prevents tags to be discovered. Ideally we should enable "CD" by setting `automaticSemanticVersioning` to `true` in https://github.com/jenkins-infra/docker-plugin-site-issues/blob/5c26cf209a8af5c8623b37fcede82d5250612f0f/Jenkinsfile_k8s#L7 but let's starting with this change now so we can deliver a new version