### PR TITLE
feat(publick8s) add pod annotations for datadog logs collection on `contributors`, `docs` and `stats` websites

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -268,7 +268,7 @@ releases:
   - name: contributors-jenkins-io
     namespace: contributors-jenkins-io
     chart: jenkins-infra/nginx-website
-    version: 0.3.2
+    version: 0.4.0
     values:
       - "../config/contributors.jenkins.io.yaml"
     secrets:
@@ -276,7 +276,7 @@ releases:
   - name: docs-jenkins-io
     namespace: docs-jenkins-io
     chart: jenkins-infra/nginx-website
-    version: 0.3.2
+    version: 0.4.0
     values:
       - "../config/docs.jenkins.io.yaml"
     secrets:
@@ -284,7 +284,7 @@ releases:
   - name: stats-jenkins-io
     namespace: stats-jenkins-io
     chart: jenkins-infra/nginx-website
-    version: 0.3.2
+    version: 0.4.0
     values:
       - "../config/stats.jenkins.io.yaml"
     secrets:

--- a/config/contributors.jenkins.io.yaml
+++ b/config/contributors.jenkins.io.yaml
@@ -54,3 +54,9 @@ affinity:
               values:
                 - contributors-jenkins-io
         topologyKey: "kubernetes.io/hostname"
+
+podAnnotations:
+  ad.datadoghq.com/nginx-website.logs: |
+    [
+      {"source":"nginx","service":"contributors.jenkins.io"}
+    ]

--- a/config/docs.jenkins.io.yaml
+++ b/config/docs.jenkins.io.yaml
@@ -54,3 +54,9 @@ affinity:
               values:
                 - docs-jenkins-io
         topologyKey: "kubernetes.io/hostname"
+
+podAnnotations:
+  ad.datadoghq.com/nginx-website.logs: |
+    [
+      {"source":"nginx","service":"docs.jenkins.io"}
+    ]

--- a/config/stats.jenkins.io.yaml
+++ b/config/stats.jenkins.io.yaml
@@ -78,3 +78,9 @@ nginx:
         autoindex on;
         try_files $uri /index.html;
     }
+
+podAnnotations:
+  ad.datadoghq.com/nginx-website.logs: |
+    [
+      {"source":"nginx","service":"stats.jenkins.io"}
+    ]


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4680

Requires https://github.com/jenkins-infra/helm-charts/pull/1681 to be merged and released (as the `0.4.0` chart release)