### PR TITLE
feat(infra.ci): adding a credential for kubeconfig for infracijioagents2

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -178,6 +178,10 @@ jobsDefinition:
             fileName: "kubeconfig"
             description: "Kubeconfig file for infracijioagents1"
             secretBytes: "${base64:${KUBECONFIG_INFRACIJIOAGENTS1}}"
+          kubeconfig-infracijioagents2:
+            fileName: "kubeconfig"
+            description: "Kubeconfig file for infracijioagents2"
+            secretBytes: "${base64:${KUBECONFIG_INFRACIJIOAGENTS2}}"
   updatecli:
     name: Dependencies Management with Updatecli
     kind: folder


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4689#issuecomment-2961894408

add the credential into infra.ci to admin the new cluster infracijioagents2