### PR TITLE
feat(publick8s/reports.jio) switch to the "common" nginx-webserver chart to allow custom pod annotation for datadog logs collection

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -165,8 +165,8 @@ releases:
       - "../secrets/config/uplink/secrets.yaml"
   - name: reports
     namespace: reports
-    chart: jenkins-infra/reports
-    version: 0.4.6
+    chart: jenkins-infra/nginx-website
+    version: 0.4.0
     values:
       - "../config/reports.yaml"
     secrets:

--- a/config/reports.yaml
+++ b/config/reports.yaml
@@ -1,3 +1,4 @@
+---
 ingress:
   enabled: true
   className: public-nginx
@@ -28,9 +29,7 @@ htmlVolume:
 
 replicaCount: 2
 
-# Specify the "hard" scheduling constraints
 nodeSelector:
-  # arm64 is cheaper than x86
   kubernetes.io/arch: arm64
 
 tolerations:
@@ -49,3 +48,24 @@ affinity:
               values:
                 - reports
         topologyKey: "kubernetes.io/hostname"
+nginx:
+  overrideLocations: |
+    location / {
+      root   /usr/share/nginx/html;
+      index  index.html index.htm;
+      autoindex on;
+
+      # Enable CORS from https://www.jenkins.io
+      #
+      add_header Access-Control-Allow-Origin      "https://www.jenkins.io";
+      add_header Vary                             "Origin";
+      add_header Access-Control-Allow-Credentials true;
+      add_header Access-Control-Allow-Headers     $http_access_control_request_headers;
+      add_header Access-Control-Allow-Methods     $http_access_control_request_method;
+    }
+
+podAnnotations:
+  ad.datadoghq.com/nginx-website.logs: |
+    [
+      {"source":"nginx","service":"reports.jenkins.io"}
+    ]


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4680

Note: this PR changes the chart so it will recreate ressources. The goal is to get rid of the `jenkin-infra/reports` chart which is only duplicating the `nginx-webserver` but with less features.
It's easier to provide the custom annotation (even if we could contribute the `podAnnotation` helm value in `report`)