### PR TITLE
fix(publick8s/phs) ensure datadog uses the correct container for logs retrieval

### DIFF
--- a/config/plugin-health-scoring.yaml
+++ b/config/plugin-health-scoring.yaml
@@ -15,11 +15,10 @@ ingress:
         - plugin-health.jenkins.io
 
 podAnnotations:
-  ad.datadoghq.com/plugin-health-score.logs: |
+  ad.datadoghq.com/plugin-health-scoring.logs: |
     [
       {"source":"java","service":"plugin-health.jenkins.io"}
     ]
-
 
 database:
   username: plugin_health


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4680