### PR TITLE
fix(publick8s/get.jio) add missing datadog logs collection annotation for httpd

### DIFF
--- a/config/get-jenkins-io.yaml
+++ b/config/get-jenkins-io.yaml
@@ -176,6 +176,9 @@ httpd:
                 values:
                   - mirrorbits-files
           topologyKey: "kubernetes.io/hostname"
+  annotations:
+    ad.datadoghq.com/httpd.logs: |
+      [{"source":"apache","service":"get.jenkins.io"}]
 
 rsyncd:
   enabled: false


### PR DESCRIPTION


Ref. https://github.com/jenkins-infra/helpdesk/issues/4680