### PR TITLE
chore(updatecli): remove datadog tracking for infracijioagents1 and add infracijioagents2

### DIFF
--- a/updatecli/updatecli.d/charts/datadog.yaml
+++ b/updatecli/updatecli.d/charts/datadog.yaml
@@ -30,7 +30,7 @@ targets:
         - clusters/privatek8s-sponsorship.yaml
         - clusters/publick8s.yaml
         - clusters/cijioagents1.yaml
-        - clusters/infracijioagents1.yaml
+        - clusters/infracijioagents2.yaml
       engine: yamlpath
       key: $.releases[?(@.name == 'datadog')].version
 


### PR DESCRIPTION
to fix errors on main builds since removal of infracijioagents1: https://github.com/jenkins-infra/helpdesk/issues/4689#issuecomment-2961894408