### PR TITLE
feat(privatek8s/infra.ci) replace the kubeconfig of (deprecated) infracijenkinsio-agents-1 by the new AWS cijenkinsio-agents-2

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -174,10 +174,10 @@ jobsDefinition:
             fileName: "kubeconfig"
             description: "Kubeconfig file for cijioagents1"
             secretBytes: "${base64:${KUBECONFIG_CIJIOAGENTS1}}"
-          kubeconfig-infracijioagents1:
+          kubeconfig-cijioagents2:
             fileName: "kubeconfig"
-            description: "Kubeconfig file for infracijioagents1"
-            secretBytes: "${base64:${KUBECONFIG_INFRACIJIOAGENTS1}}"
+            description: "Kubeconfig file for cijioagents2"
+            secretBytes: "${base64:${KUBECONFIG_CIJIOAGENTS2}}"
           kubeconfig-infracijioagents2:
             fileName: "kubeconfig"
             description: "Kubeconfig file for infracijioagents2"


### PR DESCRIPTION
Requires https://github.com/jenkins-infra/charts-secrets/commit/7ec95fbf5afedefbb86db5da50c8108c3a0b8881

Ref. https://github.com/jenkins-infra/helpdesk/issues/4688