### PR TITLE
Revert "cleanup: remove cijenkinsagents2 and aws.ci.jenkins.io (#6436)"

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'privatek8s-sponsorship', 'publick8s', 'cijioagents1', 'infracijioagents2'
+            values 'privatek8s-sponsorship', 'publick8s', 'cijioagents1', 'cijioagents2', 'infracijioagents2'
           }
         } // axes
         agent {

--- a/clusters/cijioagents2.yaml
+++ b/clusters/cijioagents2.yaml
@@ -1,0 +1,24 @@
+---
+helmDefaults:
+  atomic: true
+  force: false
+  timeout: 300
+  wait: true
+repositories:
+  # https://github.com/DataDog/helm-charts/
+  - name: datadog
+    url: https://helm.datadoghq.com
+  # https://github.com/jenkins-infra/helm-charts/
+  - name: jenkins-infra
+    url: https://jenkins-infra.github.io/helm-charts
+releases:
+  - name: datadog
+    namespace: datadog
+    chart: datadog/datadog
+    # TODO: track with updatecli
+    version: 3.120.2
+    values:
+      - ../config/datadog.yaml.gotmpl
+      - ../config/datadog_cijenkinsio-agents-2.yaml
+    secrets:
+      - ../secrets/config/datadog/cijenkinsio-agents-2-secrets.yaml

--- a/config/cijioagents1-maven-cacher.yaml
+++ b/config/cijioagents1-maven-cacher.yaml
@@ -32,6 +32,7 @@ containerSecurityContext:
     drop:
       - ALL
 
+#TODO: track with updatecli
 cachePvc: ci-jenkins-io-maven-cache
 javaHome: /opt/jdk-21
 mavenMirror:

--- a/config/datadog_cijenkinsio-agents-2.yaml
+++ b/config/datadog_cijenkinsio-agents-2.yaml
@@ -1,0 +1,44 @@
+datadog:
+  clusterName: cijenkinsio-agents-2
+  env:
+    - name: DD_HOSTNAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+clusterAgent:
+  nodeSelector:
+    kubernetes.io/arch: arm64
+    jenkins: ci.jenkins.io
+    role: applications
+  tolerations:
+    - key: "ci.jenkins.io/applications"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+agents:
+  tolerations:
+    # These tolerations are needed to run the agents on the bom node pool
+    - key: "ci.jenkins.io/bom"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "ci.jenkins.io/applications"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "ci.jenkins.io/agents"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "CriticalAddonsOnly"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "ci.jenkins.io/windows-2019"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "ci.jenkins.io/windows-2022"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"

--- a/updatecli/updatecli.d/charts/datadog.yaml
+++ b/updatecli/updatecli.d/charts/datadog.yaml
@@ -31,6 +31,8 @@ targets:
         - clusters/publick8s.yaml
         - clusters/cijioagents1.yaml
         - clusters/infracijioagents2.yaml
+        ## TODO uncomment once cluster is managed
+        # - clusters/cijioagents2.yaml
       engine: yamlpath
       key: $.releases[?(@.name == 'datadog')].version
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4688

This PR sets up the new EKS cluster `cijenkinsio-agents-2` with only datadog as a first step.

- Revert "cleanup: remove cijenkinsagents2 and aws.ci.jenkins.io (#6436)" (partially)
  This partially reverts commit 87330fd0cebdbe36784547a685c09ddcb66a0042, reversing changes made to df1c4aaf947a49fa1850629a7c70e545db5d617a.
