### PR TITLE
feat(publick8s/ldap) allow aws.ci.jenkins.io to reach the LDAP for authentication

### DIFF
--- a/config/ldap.yaml
+++ b/config/ldap.yaml
@@ -28,6 +28,8 @@ service:
     privatek8s-sponsorship-nat: '172.200.139.164/32, 128.24.89.148/32'
     # Tracked by updatecli - updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
     jfrog-artifactory: 34.233.58.83/32,34.201.191.93/32,18.214.241.149/32,54.236.124.56/32,34.199.85.0/32,54.204.174.26/32,54.237.44.112/32,52.1.113.0/32,52.86.38.82/32,44.198.238.218/32
+    # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+    aws.ci.jenkins.io: '18.217.202.59/32'
     # Tracked by updatecli - updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
     azure.ci.jenkins.io: 68.154.31.56/32,20.57.126.88/32
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4688

We'll have to track the IP in a subsequent PR, but at least initial provisioning can work so @smerle33 won't be blocked on the Puppet part.