### PR TITLE
fix(cijenkinsagents2/maven-cacher) correct ACP loadbalancer URL

### DIFF
--- a/config/cijioagents2-maven-cacher.yaml
+++ b/config/cijioagents2-maven-cacher.yaml
@@ -40,7 +40,7 @@ javaHome: /opt/jdk-21
 mavenMirror:
   enable: true
   # TODO: track with updatecli
-  url: http://k8s-artifact-artifact-f340ad86c3-70787fedaeca6b4d.elb.us-east-2.amazonaws.com:8080/
+  url: http://k8s-artifact-artifact-3d1949c260-a3739c22ffe2d924.elb.us-east-2.amazonaws.com:8080/
   # TODO: track with updatecli
   mirrorOf: "external:*,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io,!space-maven"
   mirrorId: artifact-caching-proxy


### PR DESCRIPTION
Fixup of #6745 with the correct LB for ACP to avoid the error below when triggering a cron job: https://github.com/jenkins-infra/kubernetes-management/pull/6745#issuecomment-3019828256

```
+ mvn -pl sample-plugin dependency:go-offline -DincludeScore=runtime,compile,test -Dmaven.repo.local=/home/jenkins/.m2/repository
Downloading from artifact-caching-proxy: http://k8s-artifact-artifact-f340ad86c3-70787fedaeca6b4d.elb.us-east-2.amazonaws.com:8080/io/jenkins/tools/incrementals/git-changelist-maven-extension/1.7/git-changelist-maven-extension-1.7.pom
[ERROR] Error executing Maven.
[ERROR] Extension io.jenkins.tools.incrementals:git-changelist-maven-extension:1.7 or one of its dependencies could not be resolved: Plugin io.jenkins.tools.incrementals:git-changelist-maven-extension:1.7 or one of its dependencies could not be resolved:
        Failed to read artifact descriptor for io.jenkins.tools.incrementals:git-changelist-maven-extension:jar:1.7

[ERROR] Caused by: Plugin io.jenkins.tools.incrementals:git-changelist-maven-extension:1.7 or one of its dependencies could not be resolved:
        Failed to read artifact descriptor for io.jenkins.tools.incrementals:git-changelist-maven-extension:jar:1.7
```