### PR TITLE
chore(updatecli) track (most) charts versions, docker image versions and configuration for `cijenkinsagents2` cluster

### DIFF
--- a/clusters/cijioagents2.yaml
+++ b/clusters/cijioagents2.yaml
@@ -15,7 +15,6 @@ releases:
   - name: datadog
     namespace: datadog
     chart: datadog/datadog
-    # TODO: track with updatecli
     version: 3.120.2
     values:
       - ../config/datadog.yaml.gotmpl
@@ -25,14 +24,12 @@ releases:
   - name: artifact-caching-proxy
     namespace: artifact-caching-proxy
     chart: jenkins-infra/artifact-caching-proxy
-    # TODO: track with updatecli
     version: 1.6.7
     values:
       - ../config/artifact-caching-proxy_aws-cijenkinsio-agents-2.yaml
   - name: hub-mirror
     namespace: hub-mirror
     chart: jenkins-infra/docker-registry
-    # TODO: track with updatecli
     version: 1.0.0
     values:
       - ../config/hub-mirror_cijioagents2.yaml
@@ -41,21 +38,18 @@ releases:
   - name: jenkins-agents
     namespace: jenkins-agents
     chart: jenkins-infra/jenkins-kubernetes-agents
-    # TODO: track with updatecli
     version: 1.1.0
     values:
       - ../config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents2.yaml
   - name: jenkins-agents-bom
     namespace: jenkins-agents-bom
     chart: jenkins-infra/jenkins-kubernetes-agents
-    # TODO: track with updatecli
     version: 1.1.0
     values:
       - ../config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents2-bom.yaml
   - name: maven-cacher
     namespace: maven-cache
     chart: jenkins-infra/maven-cacher
-    # TODO: track with updatecli
     version: 0.0.2
     values:
       - ../config/cijioagents2-maven-cacher.yaml

--- a/config/artifact-caching-proxy_aws-cijenkinsio-agents-2.yaml
+++ b/config/artifact-caching-proxy_aws-cijenkinsio-agents-2.yaml
@@ -37,9 +37,9 @@ service:
     service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
     # We want the LB to directly send requests to the Pod IPs (requires VPC-CNI)
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
-    # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+    # Tracked by updatecli (updatecli/updatecli.d/configs/acp-lb-aws.yaml)
     service.beta.kubernetes.io/aws-load-balancer-subnets: "subnet-003b868ae937f290a,subnet-00279b22fc0bb0997,subnet-0cbf5a4a8a81322f5"
-    # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+    # Tracked by updatecli (updatecli/updatecli.d/configs/acp-lb-aws.yaml)
     service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses: "10.0.131.248,10.0.129.248,10.0.151.248"
     service.beta.kubernetes.io/aws-load-balancer-ip-address-type: "ipv4"
     # Misc.

--- a/config/cijioagents2-maven-cacher.yaml
+++ b/config/cijioagents2-maven-cacher.yaml
@@ -1,5 +1,4 @@
 image:
-  # TODO: track with updatecli here or in the chart
   tag: 2.51.0
 
 nodeSelector:
@@ -33,7 +32,6 @@ containerSecurityContext:
     drop:
       - ALL
 
-#TODO: track with updatecli
 cachePvc: ci-jenkins-io-maven-cache
 #TODO: track with updatecli
 javaHome: /opt/jdk-21

--- a/config/hub-mirror_cijioagents2.yaml
+++ b/config/hub-mirror_cijioagents2.yaml
@@ -26,9 +26,9 @@ service:
     service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
     # We want the LB to directly send requests to the Pod IPs (requires VPC-CNI)
     service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
-    # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+    # Tracked by updatecli (updatecli/updatecli.d/configs/docker-registry-aws.yaml)
     service.beta.kubernetes.io/aws-load-balancer-subnets: "subnet-003b868ae937f290a,subnet-00279b22fc0bb0997,subnet-0cbf5a4a8a81322f5"
-    # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+    # Tracked by updatecli (updatecli/updatecli.d/configs/docker-registry-aws.yaml)
     service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses: "10.0.131.247,10.0.129.247,10.0.151.247"
     service.beta.kubernetes.io/aws-load-balancer-ip-address-type: "ipv4"
     # Misc.

--- a/config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents2-bom.yaml
+++ b/config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents2-bom.yaml
@@ -1,6 +1,5 @@
 quotas:
   pods: 150
 
-## TODO track with updatecli
 groups:
   - ci-jenkins-io

--- a/config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents2.yaml
+++ b/config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents2.yaml
@@ -1,6 +1,5 @@
 quotas:
   pods: 150
 
-## TODO track with updatecli
 groups:
   - ci-jenkins-io

--- a/updatecli/updatecli.d/charts/datadog.yaml
+++ b/updatecli/updatecli.d/charts/datadog.yaml
@@ -31,8 +31,7 @@ targets:
         - clusters/publick8s.yaml
         - clusters/cijioagents1.yaml
         - clusters/infracijioagents2.yaml
-        ## TODO uncomment once cluster is managed
-        # - clusters/cijioagents2.yaml
+        - clusters/cijioagents2.yaml
       engine: yamlpath
       key: $.releases[?(@.name == 'datadog')].version
 

--- a/updatecli/updatecli.d/charts/docker-registry.yaml
+++ b/updatecli/updatecli.d/charts/docker-registry.yaml
@@ -1,4 +1,4 @@
-name: "Bump `artifact-caching-proxy` helm chart version"
+name: "Bump `docker-registry` helm chart version"
 
 scms:
   default:
@@ -18,26 +18,25 @@ sources:
     name: get last chart version
     spec:
       url: https://jenkins-infra.github.io/helm-charts
-      name: artifact-caching-proxy
+      name: docker-registry
 
 targets:
   updateChartVersion:
-    name: "Update the chart version for artifact-caching-proxy"
+    name: "Update the chart version for docker-registry"
     kind: yaml
     spec:
       files:
-        - clusters/cijioagents1.yaml
         - clusters/cijioagents2.yaml
       engine: yamlpath
-      key: $.releases[?(@.name == 'artifact-caching-proxy')].version
+      key: $.releases[?(@.chart == 'jenkins-infra/docker-registry')].version
     scmid: default
 
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump `artifact-caching-proxy` helm chart version to {{ source `lastChartVersion` }}
+    title: Bump `docker-registry` helm chart version to {{ source `lastChartVersion` }}
     spec:
       labels:
         - dependencies
-        - artifact-caching-proxy
+        - docker-registry

--- a/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
+++ b/updatecli/updatecli.d/charts/jenkins-kubernetes-agent.yaml
@@ -27,8 +27,11 @@ targets:
     spec:
       files:
         - clusters/privatek8s-sponsorship.yaml
+        - clusters/infracijioagents2.yaml
+        - clusters/cijioagents1.yaml
+        - clusters/cijioagents2.yaml
       engine: yamlpath
-      key: $.releases[?(@.name == 'jenkins-release-agents')].version
+      key: $.releases[?(@.chart == 'jenkins-infra/jenkins-kubernetes-agents')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/charts/maven-cacher.yaml
+++ b/updatecli/updatecli.d/charts/maven-cacher.yaml
@@ -25,9 +25,11 @@ targets:
     name: Update the chart version for maven-cacher
     kind: yaml
     spec:
-      file: clusters/cijioagents1.yaml
+      files:
+        - clusters/cijioagents1.yaml
+        - clusters/cijioagents2.yaml
       engine: yamlpath
-      key: $.releases[?(@.name == 'maven-cacher')].version
+      key: $.releases[?(@.chart == 'jenkins-infra/maven-cacher')].version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/configs/acp-lb-aws.yaml
+++ b/updatecli/updatecli.d/configs/acp-lb-aws.yaml
@@ -1,0 +1,71 @@
+---
+name: Update Artifact Caching Proxy AWS Settings
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  acpAwsSubnets:
+    kind: json
+    name: Retrieve the list of subnet IDS for the ACP AWS LB from infra report
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: aws\.ci\.jenkins\.io.cijenkinsio-agents-2.artifact_caching_proxy.subnet_ids
+    transformers:
+      - trimprefix: '['
+      - trimsuffix: ']'
+      - replacer:
+          from: ' '
+          to: ','
+  acpLbIps:
+    kind: json
+    name: Retrieve the list of subnet IDS for the ACP AWS LB from infra report
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: aws\.ci\.jenkins\.io.cijenkinsio-agents-2.artifact_caching_proxy.ips
+    transformers:
+      - trimprefix: '['
+      - trimsuffix: ']'
+      - replacer:
+          from: ' '
+          to: ','
+targets:
+  updateAcpLbIps:
+    name: Update ACP LB IPv4
+    sourceid: acpLbIps
+    kind: yaml
+    transformers:
+      - addprefix: '"'
+      - addsuffix: '"'
+    spec:
+      file: config/artifact-caching-proxy_aws-cijenkinsio-agents-2.yaml
+      key: $.service.annotations.'service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses'
+    scmid: default
+  updateAcpLbSubnets:
+    name: Update ACP LB Subnets
+    disablesourceinput: true # We need to combine 2 sources
+    kind: yaml
+    spec:
+      file: config/artifact-caching-proxy_aws-cijenkinsio-agents-2.yaml
+      key: $.service.annotations.'service.beta.kubernetes.io/aws-load-balancer-subnets'
+      value: '"{{ source `acpAwsSubnets` }}"'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Update configuration of the Artifact Caching Proxy for AWS
+    spec:
+      labels:
+        - artifact-caching-proxy
+        - aws

--- a/updatecli/updatecli.d/configs/docker-registry-aws.yaml
+++ b/updatecli/updatecli.d/configs/docker-registry-aws.yaml
@@ -1,0 +1,71 @@
+---
+name: Update Docker Registry Hub Mirror Settings for AWS
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  acpAwsSubnets:
+    kind: json
+    name: Retrieve the list of subnet IDS for the ACP AWS LB from infra report
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: aws\.ci\.jenkins\.io.cijenkinsio-agents-2.docker_registry_mirror.subnet_ids
+    transformers:
+      - trimprefix: '['
+      - trimsuffix: ']'
+      - replacer:
+          from: ' '
+          to: ','
+  acpLbIps:
+    kind: json
+    name: Retrieve the list of subnet IDS for the ACP AWS LB from infra report
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: aws\.ci\.jenkins\.io.cijenkinsio-agents-2.docker_registry_mirror.ips
+    transformers:
+      - trimprefix: '['
+      - trimsuffix: ']'
+      - replacer:
+          from: ' '
+          to: ','
+targets:
+  updateAcpLbIps:
+    name: Update ACP LB IPv4
+    sourceid: acpLbIps
+    kind: yaml
+    transformers:
+      - addprefix: '"'
+      - addsuffix: '"'
+    spec:
+      file: config/hub-mirror_cijioagents2.yaml
+      key: $.service.annotations.'service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses'
+    scmid: default
+  updateAcpLbSubnets:
+    name: Update ACP LB Subnets
+    disablesourceinput: true # We need to combine 2 sources
+    kind: yaml
+    spec:
+      file: config/hub-mirror_cijioagents2.yaml
+      key: $.service.annotations.'service.beta.kubernetes.io/aws-load-balancer-subnets'
+      value: '"{{ source `acpAwsSubnets` }}"'
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Update Docker Registry Hub Mirror Settings for AWS
+    spec:
+      labels:
+        - docker-registry
+        - aws

--- a/updatecli/updatecli.d/configs/jenkins-kubernetes-agent.yaml
+++ b/updatecli/updatecli.d/configs/jenkins-kubernetes-agent.yaml
@@ -1,0 +1,50 @@
+name: Update Jenkins Kubernetes Agents Configuration
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getMainGroup:
+    kind: yaml
+    name: Retrieve the main kubernetes group
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: $.'aws.ci.jenkins.io'.cijenkinsio-agents-2.kubernetes_groups[0]
+    transformers:
+      - trimprefix: '"'
+      - trimsuffix: '"'
+
+targets:
+  updateGroupForAgents:
+    name: Update group in "normal" agents setup
+    kind: yaml
+    spec:
+      file: config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents2.yaml
+      key: $.groups[0]
+    scmid: default
+  updateGroupForBomAgents:
+    name: Update group in "BOM" agents setup
+    kind: yaml
+    spec:
+      file: config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents2-bom.yaml
+      key: $.groups[0]
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Update Jenkins Kubernetes Agents Configuration
+    spec:
+      labels:
+        - dependencies
+        - jenkins-kubernetes-agents

--- a/updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
+++ b/updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
@@ -63,6 +63,14 @@ sources:
           from: ' '
           to: ','
 
+  aws-ci-jenkins-io:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: .aws\.ci\.jenkins\.io.service_ips.ipv4
+    transformers:
+      - addsuffix: "/32"
+
   azure-ci-jenkins-io:
     kind: json
     spec:
@@ -105,6 +113,18 @@ targets:
     spec:
       file: config/ldap.yaml
       key: $.service.lbAllowSources.publick8s-out-lb
+    scmid: default
+
+  aws-ci-jenkins-io:
+    name: Update aws.ci.jenkins.io CIDR in the LDAP configuration
+    kind: yaml
+    sourceid: aws-ci-jenkins-io
+    transformers:
+      - addprefix: "'"
+      - addsuffix: "'"
+    spec:
+      file: config/ldap.yaml
+      key: $.service.lbAllowSources.'aws.ci.jenkins.io'
     scmid: default
 
   azure-ci-jenkins-io:

--- a/updatecli/updatecli.d/configs/maven-cacher.yaml
+++ b/updatecli/updatecli.d/configs/maven-cacher.yaml
@@ -13,20 +13,40 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  getPVCName:
-    kind: json
-    name: Retrieve the PVC name from the Terraform report
+  getAzurePVCName:
+    kind: yaml
+    name: Retrieve the PVC name from the Azure Terraform report
     spec:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
-      key: azure\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio_agents_1.maven_cache_pvcs.maven-cache
+      key: $.'azure.ci.jenkins.io'.agents_kubernetes_clusters.cijenkinsio_agents_1.maven_cache_pvcs.maven-cache
+    transformers:
+      - trimprefix: '"'
+      - trimsuffix: '"'
+  getAwsPVCName:
+    kind: yaml
+    name: Retrieve the PVC name from the AWS Sponsored Terraform report
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
+      key: $.'aws.ci.jenkins.io'.cijenkinsio-agents-2.maven_cache_pvcs.maven-cache
+    transformers:
+      - trimprefix: '"'
+      - trimsuffix: '"'
 
 targets:
-  updatePVCNameInConfig:
+  updateAzurePVCNameInConfig:
     name: Update PVC name in the configuration
     kind: yaml
-    sourceid: getPVCName
+    sourceid: getAzurePVCName
     spec:
       file: ./config/cijioagents1-maven-cacher.yaml
+      key: $.cachePvc
+    scmid: default
+  updateAwsPVCNameInConfig:
+    name: Update PVC name in the configuration
+    kind: yaml
+    sourceid: getAwsPVCName
+    spec:
+      file: ./config/cijioagents2-maven-cacher.yaml
       key: $.cachePvc
     scmid: default
 

--- a/updatecli/updatecli.d/docker-images/maven-cacher.yaml
+++ b/updatecli/updatecli.d/docker-images/maven-cacher.yaml
@@ -38,7 +38,9 @@ targets:
     name: Update maven-cacher Docker image tag
     kind: yaml
     spec:
-      file: ./config/cijioagents1-maven-cacher.yaml
+      files:
+        - ./config/cijioagents1-maven-cacher.yaml
+        - ./config/cijioagents2-maven-cacher.yaml
       key: $.image.tag
     scmid: default
 

--- a/updatecli/updatecli.d/jenkins-controllers/kubernetes-pods-quotas.yaml
+++ b/updatecli/updatecli.d/jenkins-controllers/kubernetes-pods-quotas.yaml
@@ -13,43 +13,74 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  jenkins_agents_maxcapacity:
-    kind: json
-    name: get pods number for ci.jenkins.io-agents-1 in ci.jenkins.io, namespace 'jenkins-agents-bom'
+  ## TODO uncomment once in production
+  # ci.jenkins.io-agents-2_maxcapacity:
+  #   kind: yaml
+  #   name: get the maximum allowed pods capacity in ci.jenkins.io-agents-2, namespace 'jenkins-agents'
+  #   spec:
+  #      file: https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/production/hieradata/clients/aws.ci.jenkins.io.yaml
+  #      key: $.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes.'ci.jenkins.io-agents-2'.max_capacity
+  # ci.jenkins.io-agents-2_bom_maxcapacity:
+  #   kind: yaml
+  #   name: get the maximum allowed pods capacity in ci.jenkins.io-agents-2, namespace 'jenkins-agents-bom'
+  #   spec:
+  #     file: https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/production/hieradata/clients/aws.ci.jenkins.io.yaml
+  #     key: $.profile::jenkinscontroller::jcasc.cloud_agents.kubernetes.'ci.jenkins.io-agents-2-bom'.max_capacity
+  ci.jenkins.io-agents-1_maxcapacity:
+    kind: yaml
+    name: get the maximum allowed pods capacity in ci.jenkins.io-agents-1, namespace 'jenkins-agents'
     spec:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
-      key: azure\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio_agents_1.agents_namespaces.jenkins-agents.pods_quota
-  jenkins_agents_bom_maxcapacity:
-    kind: json
-    name: get pods number for ci.jenkins.io-agents-1 in ci.jenkins.io, namespace 'jenkins-agents-bom'
+      key: $.'azure.ci.jenkins.io'.agents_kubernetes_clusters.cijenkinsio_agents_1.agents_namespaces.jenkins-agents.pods_quota
+  ci.jenkins.io-agents-1_bom_maxcapacity:
+    kind: yaml
+    name: get the maximum allowed pods capacity in ci.jenkins.io-agents-1, namespace 'jenkins-agents-bom'
     spec:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
-      key: azure\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio_agents_1.agents_namespaces.jenkins-agents-bom.pods_quota
+      key: $.'azure.ci.jenkins.io'.agents_kubernetes_clusters.cijenkinsio_agents_1.agents_namespaces.jenkins-agents.pods_quota
 
 targets:
-  pod_quotas_jenkins_agents:
-    name: Update the pods quotas in kubernetes for the namespace 'jenkins-agents'
+  pod_quotas_ci.jenkins.io-agents-1:
+    name: Update the maximum allowed pods capacity in ci.jenkins.io-agents-1, namespace 'jenkins-agents'
     kind: yaml
-    sourceid: jenkins_agents_maxcapacity
+    sourceid: ci.jenkins.io-agents-1_maxcapacity
     spec:
       file: config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents1.yaml
       key: $.quotas.pods
     scmid: default
-  pod_quotas_jenkins_agents_bom:
-    name: Update the pods quotas in kubernetes for the namespace 'jenkins-agents-bom'
+  pod_quotas_ci.jenkins.io-agents-1_bom:
+    name: Update the maximum allowed pods capacity in ci.jenkins.io-agents-1, namespace 'jenkins-agents-bom'
     kind: yaml
-    sourceid: jenkins_agents_bom_maxcapacity
+    sourceid: ci.jenkins.io-agents-1_bom_maxcapacity
     spec:
       file: config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents1-bom.yaml
       key: $.quotas.pods
     scmid: default
+  ## TODO uncomment once in production
+  # pod_quotas_ci.jenkins.io-agents-2:
+  #   name: "Update the pods quotas in kubernetes for ci.jenkins.io-agents-2"
+  #   kind: yaml
+  #   sourceid: ci.jenkins.io-agents-2_maxcapacity
+  #   spec:
+  #     file: config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents2.yaml
+  #     key: $.quotas.pods
+  #   scmid: default
+  # pod_quotas_ci.jenkins.io-agents-2_bom:
+  #   name: "Update the pods quotas in kubernetes for ci.jenkins.io-agents-2-bom"
+  #   kind: yaml
+  #   sourceid: ci.jenkins.io-agents-2_bom_maxcapacity
+  #   spec:
+  #     file: config/jenkins-kubernetes-agents_ci.jenkins.io_cijioagents2-bom.yaml
+  #     key: $.quotas.pods
+  #   scmid: default
 
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: '[ci.jenkins.io-agents-1] Update jenkins-agents `quotas.pods` to {{ source "jenkins_agents_maxcapacity" }} and jenkins-agents-bom to {{ source "jenkins_agents_bom_maxcapacity" }}'
+    title: Update `quotas.pods` within `ci.jenkins.io` Kubernetes clusters
     spec:
       labels:
         - dependencies
-        - ci.jenkins.io-agents-1
+        - jenkins-kubernetes-agents
+        - quotas.pods


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4688

Follows up (and tracks) most of the moving elements introduced by:
- https://github.com/jenkins-infra/kubernetes-management/pull/6739
- https://github.com/jenkins-infra/kubernetes-management/pull/6740
- https://github.com/jenkins-infra/kubernetes-management/pull/6741
- https://github.com/jenkins-infra/kubernetes-management/pull/6743
- https://github.com/jenkins-infra/kubernetes-management/pull/6744
- https://github.com/jenkins-infra/kubernetes-management/pull/6745
- https://github.com/jenkins-infra/kubernetes-management/pull/6746