### PR TITLE
feat(privatek8s/infra.ci) add kubeconfig credential for the new `privatek8s` CDF cluster

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -162,6 +162,10 @@ jobsDefinition:
           sops-tenant-id:
             secret: "${SOPS_TENANT_ID}"
             description: Azure tenant id used by sops to decrypt secrets
+          kubeconfig-privatek8s:
+            fileName: "kubeconfig"
+            description: "Kubeconfig file for privatek8s"
+            secretBytes: "${base64:${KUBECONFIG_PRIVATEK8S}}"
           kubeconfig-privatek8s-sponsorship:
             fileName: "kubeconfig"
             description: "Kubeconfig file for privatek8s_sponsorship"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4690

- Retrieved with `terraform output privatek8s_admin_sa_kubeconfig` from jenkins-infra/azure project
- Secret value set up by https://github.com/jenkins-infra/charts-secrets/commit/fcf3400fd4e6193be9f5f4cdbd5ec33707cf4b90 (required)