### PR TITLE
feat: add privatek8s (CDF) cluster with only datadog helmfile release

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'privatek8s-sponsorship', 'publick8s', 'cijioagents2', 'infracijioagents2'
+            values 'privatek8s', 'privatek8s-sponsorship', 'publick8s', 'cijioagents2', 'infracijioagents2'
           }
         } // axes
         agent {

--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -1,0 +1,130 @@
+---
+helmDefaults:
+  atomic: true
+  force: false
+  timeout: 300
+  wait: true
+repositories:
+  # https://github.com/DataDog/helm-charts/
+  - name: datadog
+    url: https://helm.datadoghq.com
+  # https://github.com/timja/github-comment-ops/
+  - name: github-comment-ops
+    url: https://timja.github.io/github-comment-ops/
+  # https://github.com/kubernetes/ingress-nginx/
+  - name: ingress-nginx
+    url: https://kubernetes.github.io/ingress-nginx
+  # https://github.com/jenkinsci/helm-charts/
+  - name: jenkins
+    url: https://charts.jenkins.io
+  # https://github.com/jenkins-infra/helm-charts/
+  - name: jenkins-infra
+    url: https://jenkins-infra.github.io/helm-charts
+  # https://github.com/cert-manager/cert-manager/
+  - name: jetstack
+    url: https://charts.jetstack.io
+releases:
+  - name: datadog
+    namespace: datadog
+    chart: datadog/datadog
+    version: 3.123.2
+    values:
+      - ../config/datadog.yaml.gotmpl
+      - ../config/datadog_privatek8s.yaml
+    secrets:
+      - ../secrets/config/datadog/privatek8s-secrets.yaml
+  # - name: cert-manager
+  #   namespace: cert-manager
+  #   chart: jetstack/cert-manager
+  #   version: v1.18.2
+  #   values:
+  #     - ../config/cert-manager.yaml
+  # - name: acme
+  #   namespace: cert-manager
+  #   chart: jenkins-infra/acme
+  #   version: 0.1.4
+  #   needs:
+  #     # CRDs must be installed BEFORE any diff or apply operation
+  #     - cert-manager/cert-manager
+  #   values:
+  #     - ../config/acme.yaml
+  #   secrets:
+  #     - ../secrets/config/acme/jenkins.io-secrets.yaml
+  # - name: jenkins-infra-jobs
+  #   namespace: jenkins-infra
+  #   chart: jenkins-infra/jenkins-jobs
+  #   version: 2.3.0
+  #   values:
+  #     - ../config/jenkins-jobs_infra.ci.jenkins.io.yaml
+  # - name: jenkins-infra
+  #   namespace: jenkins-infra
+  #   chart: jenkins/jenkins
+  #   version: 5.8.72
+  #   timeout: 1200
+  #   needs:
+  #     # Required to generate the job definition in a configmap
+  #     - jenkins-infra-jobs
+  #     # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
+  #     - public-nginx-ingress/public-nginx-ingress
+  #     # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
+  #     - private-nginx-ingress/private-nginx-ingress
+  #   values:
+  #     - ../config/jenkins_infra.ci.jenkins.io.yaml
+  #   secrets:
+  #     - ../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml
+  # - name: private-nginx-ingress
+  #   namespace: private-nginx-ingress
+  #   chart: ingress-nginx/ingress-nginx
+  #   version: 4.11.8
+  #   values:
+  #     - ../config/private-nginx-ingress__common.yaml
+  #     - ../config/private-nginx-ingress_privatek8s.yaml
+  # - name: public-nginx-ingress
+  #   namespace: public-nginx-ingress
+  #   chart: ingress-nginx/ingress-nginx
+  #   version: 4.11.8
+  #   values:
+  #     - ../config/public-nginx-ingress__common.yaml
+  #     - ../config/public-nginx-ingress_privatek8s.yaml
+  # - name: jenkins-release
+  #   namespace: jenkins-release
+  #   chart: jenkins/jenkins
+  #   version: 5.8.72
+  #   timeout: 600
+  #   needs:
+  #     # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
+  #     - public-nginx-ingress/public-nginx-ingress
+  #     # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
+  #     - private-nginx-ingress/private-nginx-ingress
+  #   values:
+  #     - ../config/jenkins_release.ci.jenkins.io.yaml
+  #   secrets:
+  #     - ../secrets/config/release.ci.jenkins.io/jenkins-secrets.yaml
+  # - name: jenkins-release-agents
+  #   namespace: jenkins-release-agents
+  #   chart: jenkins-infra/jenkins-kubernetes-agents
+  #   version: 1.1.1
+  #   needs:
+  #     - jenkins-release/jenkins-release
+  #   values:
+  #     - ../config/jenkins-kubernetes-agents_release.ci.jenkins.io.yaml
+  # - name: rss2twitter
+  #   namespace: rss2twitter
+  #   chart: jenkins-infra/rss2twitter
+  #   version: 0.1.0
+  #   values:
+  #     - ../config/rss2twitter.yaml
+  #   secrets:
+  #     # @jenkins_release Twitter dev account credentials
+  #     - ../secrets/config/rss2twitter/secrets.yaml
+  # - name: github-comment-ops
+  #   namespace: github-comment-ops
+  #   chart: github-comment-ops/github-comment-ops
+  #   version: 1.5.2
+  #   needs:
+  #     # Required to expose the webhooks endpoint
+  #     - public-nginx-ingress/public-nginx-ingress
+  #   values:
+  #     - ../config/github-comment-ops.yaml
+  #   secrets:
+  #     - ../secrets/config/github-comment-ops/secrets.yaml

--- a/config/datadog_privatek8s.yaml
+++ b/config/datadog_privatek8s.yaml
@@ -1,0 +1,44 @@
+providers:
+  aks:
+    enabled: true
+datadog:
+  clusterName: 'privatek8s'
+  env:
+    - name: DD_HOSTNAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+  kubelet:
+    host:
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
+    # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
+    tlsVerify: false
+agents:
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
+    - key: "CriticalAddonsOnly"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "jenkins"
+      operator: "Equal"
+      value: "infra.ci.jenkins.io"
+      effect: "NoSchedule"
+    - key: "jenkins"
+      operator: "Equal"
+      value: "release.ci.jenkins.io"
+      effect: "NoSchedule"
+    - key: "jenkins-component"
+      operator: "Equal"
+      value: "controller"
+      effect: "NoSchedule"
+    - key: "kubernetes.azure.com/scalesetpriority"
+      operator: "Equal"
+      value: "spot"
+      effect: "NoSchedule"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4690

Requires #6849 (`kubeconfig` to reach the `privatek8s` cluster) and https://github.com/jenkins-infra/charts-secrets/commit/3ff996d33601d8bdc32dc125af2c786d764313f9 (datadog secrets)