### PR TITLE
fix(privatek8s) remove datadog workaround around kubelet certificate and enable tls verification again

### DIFF
--- a/config/datadog_privatek8s.yaml
+++ b/config/datadog_privatek8s.yaml
@@ -8,14 +8,6 @@ datadog:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
-  kubelet:
-    host:
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
-    hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
-    # Required as of Agent 7.35 because Kubelet certificates in AKS do not have a Subject Alternative Name (SAN) set.
-    tlsVerify: false
 agents:
   tolerations:
     - key: "kubernetes.io/arch"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4690

This PR ensure `datadog` installation in `privatek8s` is successful. It removes a workaround which used to be recommended by Datadog to ensure AKS kubelet CRT can be used (as it was not supporting SAN back in that time).

However they [now recommend to remove the workaround](https://docs.datadoghq.com/containers/kubernetes/distributions/?tab=helm#kubelet-serving-certificate-rotation) if the cluster has auto-cert. enabled, which is the case for `privatek8s` :

```
$ kubectl get nodes | wc -l
       6
$ kubectl get nodes -L kubernetes.azure.com/kubelet-serving-ca | wc -l
       6
```

