### PR TITLE
feat(privatek8s) add cert-manager, then acme and the ingresses

### DIFF
--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -33,23 +33,37 @@ releases:
       - ../config/datadog_privatek8s.yaml
     secrets:
       - ../secrets/config/datadog/privatek8s-secrets.yaml
-  # - name: cert-manager
-  #   namespace: cert-manager
-  #   chart: jetstack/cert-manager
-  #   version: v1.18.2
-  #   values:
-  #     - ../config/cert-manager.yaml
-  # - name: acme
-  #   namespace: cert-manager
-  #   chart: jenkins-infra/acme
-  #   version: 0.1.4
-  #   needs:
-  #     # CRDs must be installed BEFORE any diff or apply operation
-  #     - cert-manager/cert-manager
-  #   values:
-  #     - ../config/acme.yaml
-  #   secrets:
-  #     - ../secrets/config/acme/jenkins.io-secrets.yaml
+  - name: cert-manager
+    namespace: cert-manager
+    chart: jetstack/cert-manager
+    version: v1.18.2
+    values:
+      - ../config/cert-manager.yaml
+  - name: acme
+    namespace: cert-manager
+    chart: jenkins-infra/acme
+    version: 0.1.4
+    needs:
+      # CRDs must be installed BEFORE any diff or apply operation
+      - cert-manager/cert-manager
+    values:
+      - ../config/acme.yaml
+    secrets:
+      - ../secrets/config/acme/jenkins.io-secrets.yaml
+  - name: private-nginx-ingress
+    namespace: private-nginx-ingress
+    chart: ingress-nginx/ingress-nginx
+    version: 4.11.8
+    values:
+      - ../config/private-nginx-ingress__common.yaml
+      - ../config/private-nginx-ingress_privatek8s.yaml
+  - name: public-nginx-ingress
+    namespace: public-nginx-ingress
+    chart: ingress-nginx/ingress-nginx
+    version: 4.11.8
+    values:
+      - ../config/public-nginx-ingress__common.yaml
+      - ../config/public-nginx-ingress_privatek8s.yaml
   # - name: jenkins-infra-jobs
   #   namespace: jenkins-infra
   #   chart: jenkins-infra/jenkins-jobs
@@ -72,20 +86,6 @@ releases:
   #     - ../config/jenkins_infra.ci.jenkins.io.yaml
   #   secrets:
   #     - ../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml
-  # - name: private-nginx-ingress
-  #   namespace: private-nginx-ingress
-  #   chart: ingress-nginx/ingress-nginx
-  #   version: 4.11.8
-  #   values:
-  #     - ../config/private-nginx-ingress__common.yaml
-  #     - ../config/private-nginx-ingress_privatek8s.yaml
-  # - name: public-nginx-ingress
-  #   namespace: public-nginx-ingress
-  #   chart: ingress-nginx/ingress-nginx
-  #   version: 4.11.8
-  #   values:
-  #     - ../config/public-nginx-ingress__common.yaml
-  #     - ../config/public-nginx-ingress_privatek8s.yaml
   # - name: jenkins-release
   #   namespace: jenkins-release
   #   chart: jenkins/jenkins

--- a/config/private-nginx-ingress_privatek8s.yaml
+++ b/config/private-nginx-ingress_privatek8s.yaml
@@ -1,0 +1,8 @@
+controller:
+  service:
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+      # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      service.beta.kubernetes.io/azure-load-balancer-internal-subnet: privatek8s-tier
+      # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      service.beta.kubernetes.io/azure-load-balancer-ipv4: "10.249.255.254"

--- a/config/public-nginx-ingress_privatek8s.yaml
+++ b/config/public-nginx-ingress_privatek8s.yaml
@@ -1,0 +1,16 @@
+controller:
+  config:
+    ## Ingress controller level
+    # Only allow GitHub's webhooks requests - https://api.github.com/meta ("hooks", tracked by updatecli)
+    whitelist-source-range: 140.82.112.0/20,143.55.64.0/20,185.199.108.0/22,192.30.252.0/22
+  service:
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-internal: false
+      # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      service.beta.kubernetes.io/azure-pip-name: public-privatek8s
+      # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      service.beta.kubernetes.io/azure-load-balancer-resource-group: prod-public-ips
+    externalTrafficPolicy: Local
+    ## Public LB level
+    # Only allow GitHub's webhooks requests - https://api.github.com/meta ("hooks", tracked by updatecli)
+    loadBalancerSourceRanges: ["140.82.112.0/20", "143.55.64.0/20", "185.199.108.0/22", "192.30.252.0/22"]


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4690

Note: Successfuly applied manually (due to infra.ci being down - https://status.jenkins.io/issues/2025-07-29-infra.ci-down/) in 2 times (due to ACME requiring Cert Manager CRDs to be installed):

```
helmfile apply -f ./clusters/privatek8s.yaml -l name=cert-manager
helmfile apply -f ./clusters/privatek8s.yaml
```
