### PR TITLE
feat(privatek8s) add infra.ci jobs and release.ci agents releases

### DIFF
--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -64,20 +64,20 @@ releases:
     values:
       - ../config/public-nginx-ingress__common.yaml
       - ../config/public-nginx-ingress_privatek8s.yaml
-  # - name: jenkins-infra-jobs
-  #   namespace: jenkins-infra
-  #   chart: jenkins-infra/jenkins-jobs
-  #   version: 2.3.0
-  #   values:
-  #     - ../config/jenkins-jobs_infra.ci.jenkins.io.yaml
-  # - name: jenkins-infra
-  #   namespace: jenkins-infra
+  - name: infra-ci-jenkins-io-jobs
+    namespace: infra-ci-jenkins-io
+    chart: jenkins-infra/jenkins-jobs
+    version: 2.3.0
+    values:
+      - ../config/jenkins-jobs_infra.ci.jenkins.io.yaml
+  # - name: infra-ci-jenkins-io
+  #   namespace: infra-ci-jenkins-io
   #   chart: jenkins/jenkins
   #   version: 5.8.72
   #   timeout: 1200
   #   needs:
   #     # Required to generate the job definition in a configmap
-  #     - jenkins-infra-jobs
+  #     - infra-ci-jenkins-io-jobs
   #     # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
   #     - public-nginx-ingress/public-nginx-ingress
   #     # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
@@ -86,6 +86,12 @@ releases:
   #     - ../config/jenkins_infra.ci.jenkins.io.yaml
   #   secrets:
   #     - ../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml
+  - name: release-ci-jenkins-io-agents
+    namespace: release-ci-jenkins-io-agents
+    chart: jenkins-infra/jenkins-kubernetes-agents
+    version: 1.1.1
+    values:
+      - ../config/jenkins-kubernetes-agents_release.ci.jenkins.io.yaml
   # - name: jenkins-release
   #   namespace: jenkins-release
   #   chart: jenkins/jenkins
@@ -100,14 +106,6 @@ releases:
   #     - ../config/jenkins_release.ci.jenkins.io.yaml
   #   secrets:
   #     - ../secrets/config/release.ci.jenkins.io/jenkins-secrets.yaml
-  # - name: jenkins-release-agents
-  #   namespace: jenkins-release-agents
-  #   chart: jenkins-infra/jenkins-kubernetes-agents
-  #   version: 1.1.1
-  #   needs:
-  #     - jenkins-release/jenkins-release
-  #   values:
-  #     - ../config/jenkins-kubernetes-agents_release.ci.jenkins.io.yaml
   # - name: rss2twitter
   #   namespace: rss2twitter
   #   chart: jenkins-infra/rss2twitter

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -1,4 +1,4 @@
-jenkinsName: jenkins-infra
+jenkinsName: infra-ci-jenkins-io
 jenkinsFqdn: infra.ci.jenkins.io
 jobsDefinition:
   docker-jobs:

--- a/config/jenkins-kubernetes-agents_release.ci.jenkins.io.yaml
+++ b/config/jenkins-kubernetes-agents_release.ci.jenkins.io.yaml
@@ -1,1 +1,2 @@
-existingServiceAccount: jenkins-release:jenkins-release-controller
+# TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+existingServiceAccount: release-ci-jenkins-io:release-ci-jenkins-io-controller


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4690

Requires https://github.com/jenkins-infra/azure/pull/1139

Applied manually due to infra.ci being down.