### PR TITLE
feat: migrate infra.ci from privatek8s to privatek8s (CDF) and stop managing privatek8s-sponsorship

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'privatek8s', 'privatek8s-sponsorship', 'publick8s', 'cijioagents2', 'infracijioagents2'
+            values 'privatek8s', 'publick8s', 'cijioagents2', 'infracijioagents2'
           }
         } // axes
         agent {

--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -70,22 +70,21 @@ releases:
     version: 2.3.0
     values:
       - ../config/jenkins-jobs_infra.ci.jenkins.io.yaml
-  # - name: infra-ci-jenkins-io
-  #   namespace: infra-ci-jenkins-io
-  #   chart: jenkins/jenkins
-  #   version: 5.8.72
-  #   timeout: 1200
-  #   needs:
-  #     # Required to generate the job definition in a configmap
-  #     - infra-ci-jenkins-io-jobs
-  #     # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
-  #     - public-nginx-ingress/public-nginx-ingress
-  #     # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
-  #     - private-nginx-ingress/private-nginx-ingress
-  #   values:
-  #     - ../config/jenkins_infra.ci.jenkins.io.yaml
-  #   secrets:
-  #     - ../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml
+  - name: infra-ci-jenkins-io
+    namespace: infra-ci-jenkins-io
+    chart: jenkins/jenkins
+    version: 5.8.72
+    needs:
+      # Required to generate the job definition in a configmap
+      - infra-ci-jenkins-io-jobs
+      # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
+      - public-nginx-ingress/public-nginx-ingress
+      # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
+      - private-nginx-ingress/private-nginx-ingress
+    values:
+      - ../config/jenkins_infra.ci.jenkins.io.yaml
+    secrets:
+      - ../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml
   - name: release-ci-jenkins-io-agents
     namespace: release-ci-jenkins-io-agents
     chart: jenkins-infra/jenkins-kubernetes-agents

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -1,7 +1,7 @@
 serviceAccount:
   create: false
   # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
-  name: jenkins-infra-controller
+  name: infra-ci-jenkins-io-controller
 serviceAccountAgent:
   create: false
 rbac:
@@ -9,7 +9,8 @@ rbac:
   readSecrets: true
 persistence:
   enabled: true
-  existingClaim: jenkins-infra-data
+  # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+  existingClaim: infra-ci-jenkins-io-data
 agent:
   componentName: "agent"
 networkPolicy:
@@ -17,7 +18,7 @@ networkPolicy:
   internalAgents:
     allowed: true
     namespaceLabels:
-      name: "jenkins-infra"
+      name: "infra-ci-jenkins-io"
 controller:
   podLabels:
     "azure.workload.identity/use": "true"
@@ -27,6 +28,14 @@ controller:
     supplementalGroups: [1000]
     # fsGroup: 1000 # Uncomment once for new volumes
     # fsGroupChangePolicy: OnRootMismatch # Uncomment once for new volumes
+  # TODO: uncomment once bootstrapped
+  # probes:
+  #   startupProbe:
+  #     initialDelaySeconds: 60
+  #   livenessProbe:
+  #     initialDelaySeconds: 60
+  #   readinessProbe:
+  #     initialDelaySeconds: 60
   image:
     repository: jenkinsciinfra/jenkins-infraci
     tag: 3.9.6-2.520
@@ -55,13 +64,6 @@ controller:
     requests:
       cpu: "2"
       memory: "8Gi"
-  probes:
-    startupProbe:
-      initialDelaySeconds: 60
-    livenessProbe:
-      initialDelaySeconds: 60
-    readinessProbe:
-      initialDelaySeconds: 60
   testEnabled: false
   # This setting deletes the content of $ JENKINS_HOME/plugins on each pod restart to ensure only container image plugins are used
   overwritePlugins: true


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4690

Note: merging and then applying to ensure infra.ci, once started, won't try to rollback things.

