### PR TITLE
fix(ci.jenkins.io-agents-2) disable blob caching as a hack to avoid corrupted zero-sized blobs

### DIFF
--- a/config/hub-mirror_cijioagents2.yaml
+++ b/config/hub-mirror_cijioagents2.yaml
@@ -51,3 +51,8 @@ initContainers:
     volumeMounts:
       - mountPath: /var/lib/registry
         name: data
+
+extraEnvVars:
+  # Ref. https://github.com/distribution/distribution/issues/2367#issuecomment-1874449361
+  - name: REGISTRY_STORAGE_CACHE_BLOBDESCRIPTOR
+    value: dummyvalue


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4547

It looks like I missed this code block in https://github.com/jenkins-infra/kubernetes-management/pull/6743 when re-creating the service.
So here is the re-cherry pick of https://github.com/jenkins-infra/kubernetes-management/pull/6359

Ref. https://github.com/distribution/distribution/issues/2367\#issuecomment-1874449361

(cherry picked from commit 5cee6c4fd6460053375fa66b6374095d4a3becce)