### PR TITLE
Revert "Bump `mirrorbits-parent` helm chart version to 7.1.0"

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -178,7 +178,7 @@ releases:
   - name: get-jenkins-io
     namespace: get-jenkins-io
     chart: jenkins-infra/mirrorbits-parent
-    version: 7.1.0
+    version: 7.0.31
     values:
       - "../config/get-jenkins-io.yaml"
     secrets:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#6900

Migration to mirrorbits v0.6.0 on get.jenkins.io failed with the following error during the redis migration:

```
2025/08/07 06:49:07.619 UTC Upgrade failed: redigo: nil returned
github.com/etix/mirrorbits/database/v2.(*Version2).UpdateMirrors
        /mirrorbits/database/v2/version2.go:95
github.com/etix/mirrorbits/database/v2.(*Version2).Upgrade
        /mirrorbits/database/v2/version2.go:50
github.com/etix/mirrorbits/database.(*Redis).Upgrade
        /mirrorbits/database/upgrade.go:78
github.com/etix/mirrorbits/database.(*Redis).dbUpdateHandler
        /mirrorbits/database/redis.go:381
runtime.goexit
        /usr/local/go/src/runtime/asm_arm64.s:1223
```

Coming from https://github.com/etix/mirrorbits/blob/v0.6/database/v2/version2.go#L92-L96