### PR TITLE
feat(publick8s) add a redis database for mirrorbits usages

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -268,3 +268,11 @@ releases:
       - ../config/geoipdata.yaml
     secrets:
       - ../secrets/config/geoipdata/secrets.yaml
+  - name: redis
+    namespace: redis
+    chart: oci://registry-1.docker.io/bitnamicharts/redis
+    version: 21.2.14
+    values:
+      - ../config/publick8s-redis.yaml
+    secrets:
+      - ../secrets/config/redis/publick8s.yaml

--- a/config/publick8s-redis.yaml
+++ b/config/publick8s-redis.yaml
@@ -1,0 +1,21 @@
+auth:
+  # Mirrorbits does not support sentinel auth
+  sentinel: false
+sentinel:
+  enabled: true
+  masterSet: publick8s-master
+replica:
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 4096Mi
+    requests:
+      cpu: 500m
+      memory: 2048Mi
+  nodeSelector:
+    kubernetes.io/arch: arm64
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4691

Initial implementation with the following assertions:

- 3 nodes (more efficient reconciliation compared to 2)
- Only 1 master (read and write) but 2 replica (read only)
- Redis Sentinel enabled to track master (as mirrorbits supports it)
- Assuming we start at 1.8 Gb dataset, but allowing for more