### PR TITLE
feat(publick8s/get.jenkins.io) bump mirrorbits-parent chart to latest but pin mirrorbits to `v0.5.1`

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -178,11 +178,11 @@ releases:
   - name: get-jenkins-io
     namespace: get-jenkins-io
     chart: jenkins-infra/mirrorbits-parent
-    version: 7.0.31
+    version: 7.1.4
     values:
-      - "../config/get-jenkins-io.yaml"
+      - ../config/get-jenkins-io.yaml
     secrets:
-      - "../secrets/config/get-jenkins-io/secrets.yaml"
+      - ../secrets/config/get-jenkins-io/secrets.yaml
   - name: plugin-site-issues
     namespace: plugin-site
     chart: jenkins-infra/plugin-site-issues

--- a/config/get-jenkins-io.yaml
+++ b/config/get-jenkins-io.yaml
@@ -65,6 +65,9 @@ global:
 
 mirrorbits:
   enabled: true
+  image:
+    #repository: jenkinsciinfra/mirrorbits
+    tag: 0.2.92 # mirrorbits v0.5.1 - https://github.com/jenkins-infra/helpdesk/issues/4764
   replicaCount: 2
   resources:
     limits:


### PR DESCRIPTION
- Closes https://github.com/jenkins-infra/kubernetes-management/pull/6903 (superseds)
- Ref. https://github.com/jenkins-infra/helpdesk/issues/4764#issuecomment-3174675784 and https://github.com/jenkins-infra/helpdesk/issues/4691#issuecomment-3175499497

This change will fix the following behaviors on get.jenkins.io mirrorbits instance:

- Fix the PID file not being created to a filesystem (remove the error log and use a tmpfs dir for it)
- Fix the downloads logs path to ensure stdout gets the logs



NOTE: the pinning to 0.5.1 is there until we fixed the filesystem
