### PR TITLE
fix(publick8s/updates.jenkins.io) correct mirrorbits PVC setup (both updatecli and configuration)

### DIFF
--- a/config/updates.jenkins.io-content.yaml
+++ b/config/updates.jenkins.io-content.yaml
@@ -27,7 +27,7 @@ containerSecurityContext:
 repository:
   name: updates-jenkins-io
   existingPVC: true
-  subDir: ./content/
+  subDir: ./updates.jenkins.io/content/
 config:
   # Ingress already does gzip/brotli
   gzip: false
@@ -73,7 +73,10 @@ cli:
       service.beta.kubernetes.io/azure-pls-visibility: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
       service.beta.kubernetes.io/azure-pls-auto-approval: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
 geoipdata:
-  existingPVCName: updates-jenkins-io
+  existingPVCName: updates-jenkins-io-geoip-data
+  ## TODO: implement merging geoipdata and mirrorbits PVC in helm chart + subdir support for geoipdata
+  # existingPVCName: updates-jenkins-io
+  # subDir: ./updates.jenkins.io/geoipdata/
 annotations:
   ad.datadoghq.com/mirrorbits.logs: |
     [{"source":"mirrorbits","service":"updates.jenkins.io"}]

--- a/updatecli/updatecli.d/configs/pvc-updates-jenkins-io-content.yaml
+++ b/updatecli/updatecli.d/configs/pvc-updates-jenkins-io-content.yaml
@@ -1,5 +1,5 @@
 ---
-name: Update PVC names for updates.jenkins.io mirrorbits
+name: Update PVC names for updates.jenkins.io "content" service (mirrorbits)
 
 scms:
   default:
@@ -14,7 +14,7 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  pvcName:
+  contentPvcName:
     kind: json
     name: Retrieve the PVC name for updates-jenkins-io
     spec:
@@ -22,23 +22,31 @@ sources:
       key: .updates\.jenkins\.io.content.pvc_name
   contentPvcSubdir:
     kind: json
-    name: Retrieve the subdir inside the PVC for service "content" in updates-jenkins-io
+    name: Retrieve the subdir inside the PVC for component "content" in updates-jenkins-io
     spec:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .updates\.jenkins\.io.content.share_uri
     transformers:
       - addprefix: '.'
-  pvcNameGeoipData:
+  geoipdataPvcName:
     kind: json
     name: Retrieve the pvc name for geoipdata
     spec:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .updates\.jenkins\.io.geoipdata.pvc_name
+  geoipdataPvcSubdir:
+    kind: json
+    name: Retrieve the subdir inside the PVC for component "geoipdata" in updates-jenkins-io
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+      key: .updates\.jenkins\.io.geoipdata.share_uri
+    transformers:
+      - addprefix: '.'
 
 targets:
-  updatePvcName:
-    sourceid: pvcName
-    name: Update updates-jenkins-io PVC name
+  updateContentPvcName:
+    sourceid: contentPvcName
+    name: Update updates-jenkins-io-content "repository" PVC name
     kind: yaml
     spec:
       file: config/updates.jenkins.io-content.yaml
@@ -47,24 +55,33 @@ targets:
   updateContentPvcSubdir:
     sourceid: contentPvcSubdir
     kind: yaml
-    name: Update the subdir inside the PVC for service "content" in updates-jenkins-io
+    name: Update updates-jenkins-io-content "repository" PVC subDir mount
     spec:
       file: config/updates.jenkins.io-content.yaml
       key: $.repository.subDir
-  updateGeoipPvcName:
-    sourceid: pvcNameGeoipData
-    name: Update geoipdata PVC name
+    scmid: default
+  updateGeoipdataPvcName:
+    sourceid: geoipdataPvcName
+    name: Update updates-jenkins-io-content "geoipdata" PVC name
     kind: yaml
     spec:
       file: config/updates.jenkins.io-content.yaml
       key: $.geoipdata.existingPVCName
+    scmid: default
+  updateGeoipdataPvcSubdir:
+    sourceid: geoipdataPvcSubdir
+    kind: yaml
+    name: Update updates-jenkins-io-content "geoipdata" PVC subDir mount
+    spec:
+      file: config/updates.jenkins.io-content.yaml
+      key: $.geoipdata.subDir
     scmid: default
 
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Update PVC names for updates.jenkins.io mirrorbits
+    title: Update PVC names for updates.jenkins.io "content" service (mirrorbits)
     spec:
       labels:
         - updates.jenkins.io

--- a/updatecli/updatecli.d/configs/pvc-updates-jenkins-io-redirections.yaml
+++ b/updatecli/updatecli.d/configs/pvc-updates-jenkins-io-redirections.yaml
@@ -1,5 +1,5 @@
 ---
-name: Update PVC names for updates.jenkins.io HTTPD
+name: Update PVC names for updates.jenkins.io "redirections" service (httpd)
 
 scms:
   default:
@@ -51,7 +51,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Update PVC names for updates.jenkins.io HTTPD
+    title: Update PVC names for updates.jenkins.io "redirections" service (httpd)
     spec:
       labels:
         - updates.jenkins.io


### PR DESCRIPTION
hotfix of #6942 

- Updatecli did not track all the subdir correctly
- geoipdata does not support (yet) subdir
- The `mirrorbits` helm chart must detect that we provide twice the same PVC and merge the 2 declarations, otherwise pods are not created (kubelet error).