### PR TITLE
feat(publick8s/updates.jenkins.io) use the same NFS volume in content for both mirrorbits repository and geoipdata

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -218,7 +218,7 @@ releases:
   - name: updates-jenkins-io-content
     namespace: updates-jenkins-io
     chart: jenkins-infra/mirrorbits
-    version: 5.8.2
+    version: 5.9.0
     values:
       - ../config/updates.jenkins.io-content.yaml
     secrets:

--- a/config/updates.jenkins.io-content.yaml
+++ b/config/updates.jenkins.io-content.yaml
@@ -73,10 +73,8 @@ cli:
       service.beta.kubernetes.io/azure-pls-visibility: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
       service.beta.kubernetes.io/azure-pls-auto-approval: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
 geoipdata:
-  existingPVCName: updates-jenkins-io-geoip-data
-  ## TODO: implement merging geoipdata and mirrorbits PVC in helm chart + subdir support for geoipdata
-  # existingPVCName: updates-jenkins-io
-  # subDir: ./updates.jenkins.io/geoipdata/
+  existingPVCName: updates-jenkins-io
+  subDir: ./updates.jenkins.io/geoipdata/
 annotations:
   ad.datadoghq.com/mirrorbits.logs: |
     [{"source":"mirrorbits","service":"updates.jenkins.io"}]


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4767#issuecomment-3180139293

Follows up #6942 and #6943 

Requires https://github.com/jenkins-infra/helm-charts/pull/1761

=> this PR changes the `geoipdata` mount to use the sub directory `updates.jenkins.io/geoipdata` from the common NFS volume. This directory has already been populated, but is NOT kept up to date yet (update once a week usually).