### PR TITLE
feat(publick8s) create staging.get.jenkins.io

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -215,6 +215,20 @@ releases:
       - public-nginx-ingress/public-nginx-ingress
     values:
       - "../config/ipv6-lb-service.yaml"
+  - name: staging-get-jenkins-io-mirrorbits
+    namespace: get-jenkins-io # Same NS as the PVC
+    chart: jenkins-infra/mirrorbits
+    version: 5.9.0
+    values:
+      - ../config/staging.get.jenkins.io-mirrorbits.yaml
+    secrets:
+      - ../secrets/config/get-jenkins-io/staging-secrets.yaml
+  - name: staging-get-jenkins-io-httpd
+    namespace: get-jenkins-io # Same NS as the PVC
+    chart: jenkins-infra/httpd
+    version: 1.4.7
+    values:
+      - ../config/staging.get.jenkins.io-httpd.yaml
   - name: updates-jenkins-io-content
     namespace: updates-jenkins-io
     chart: jenkins-infra/mirrorbits
@@ -223,7 +237,7 @@ releases:
       - ../config/updates.jenkins.io-content.yaml
     secrets:
       - ../secrets/config/updates.jenkins.io/secrets.yaml
-  # Can be removed once mirrorbits support scanning through s3
+  # Can be removed once mirrorbits support scanning through s3 - https://github.com/etix/mirrorbits/issues/141
   - name: updates-jenkins-io-rsync
     namespace: updates-jenkins-io
     chart: jenkins-infra/rsyncd

--- a/config/staging.get.jenkins.io-httpd.yaml
+++ b/config/staging.get.jenkins.io-httpd.yaml
@@ -1,0 +1,40 @@
+enabled: true
+replicaCount: 1
+resources:
+  limits:
+    cpu: 500m
+    memory: 1024Mi
+  requests:
+    cpu: 50m
+    memory: 500Mi
+nodeSelector:
+  kubernetes.io/arch: arm64
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+repository:
+  name: get-jenkins-io
+  reuseExistingPersistentVolumeClaim: true
+  subDir: ./get.jenkins.io/mirrorbits/
+annotations:
+  ad.datadoghq.com/httpd.logs: |
+    [{"source":"apache","service":"staging.get.jenkins.io"}]
+
+ingress:
+  enabled: true
+  className: public-nginx
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true" # Required to allow regexp path matching with Nginx
+  hosts:
+    - host: staging.get.jenkins.io
+      paths:
+        - path: /
+  tls:
+    - secretName: staging-get-jenkins-io-tls
+      hosts:
+        - staging.get.jenkins.io

--- a/config/staging.get.jenkins.io-mirrorbits.yaml
+++ b/config/staging.get.jenkins.io-mirrorbits.yaml
@@ -1,0 +1,86 @@
+enabled: true
+replicaCount: 1
+resources:
+  limits:
+    cpu: 2
+    memory: 2048Mi
+  requests:
+    cpu: 100m
+    memory: 400Mi
+nodeSelector:
+  kubernetes.io/arch: arm64
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+podSecurityContext:
+  runAsUser: 1000 # User 'mirrorbits'
+  runAsGroup: 1000 # Group 'mirrorbits'
+  runAsNonRoot: true
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+repository:
+  name: get-jenkins-io
+  existingPVC: true
+  subDir: ./get.jenkins.io/mirrorbits/
+config:
+  # Ingress already does gzip/brotli
+  gzip: false
+  traceFile: /TIME
+  # Do not answer mirrorbits API JSON content when accept header is set to application/json (behavior with default value "auto")
+  outputMode: redirect
+  redis:
+    sentinelMasterName: publick8s-master
+    sentinels:
+      - redis.redis.svc.cluster.local:26379
+    # password is stored in SOPS secrets
+    ## RedisDB - Use 0 for staging and 1, get.jio production and 2 for update.jio production
+    dbId: 0
+  ## Interval in minutes between mirrors scan
+  scanInterval: 10
+  ## Interval between two scans of the local repository.
+  ## This should, more or less, match the frequency where the local repo is updated (e.g. update center)
+  repositoryScanInterval: 5
+  checkInterval: 1
+  # Disable a mirror if it triggers HTTP/3xx redirects on its own (safer for mirrors we do not control)
+  disallowRedirects: true
+  disableOnMissingFile: false
+  ## List of mirrors to use as fallback which will be used in case mirrorbits
+  ## is unable to answer a request because the database is unreachable.
+  ## Note: Mirrorbits will redirect to one of these mirrors based on the user
+  ## location but won't be able to know if the mirror has the requested file.
+  ## Therefore only put your most reliable and up-to-date mirrors here.
+  fallbacks:
+    ## archives.jenkins.io has ALL the artefacts
+    - url: https://archives.jenkins.io/
+      countryCode: DE
+      continentCode: EU
+geoipdata:
+  existingPVCName: get-jenkins-io
+  subDir: ./get.jenkins.io/geoipdata/
+annotations:
+  ad.datadoghq.com/mirrorbits.logs: |
+    [{"source":"mirrorbits","service":"staging.get.jenkins.io"}]
+
+ingress:
+  enabled: true
+  className: public-nginx
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true" # Required to allow regexp path matching with Nginx
+  hosts:
+    - host: staging.get.jenkins.io
+      paths:
+        - path: /.*[.](deb|hpi|war|rpm|msi|pkg|sha256|md5sum|zip|gz|pdf|json|svg|sh|jpeg|ico|png|html)$  # Requires the regexp engine of Nginx to be enabled
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: staging-get-jenkins-io-tls
+      hosts:
+        - staging.get.jenkins.io


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4767#issuecomment-3180139293

- Both mirrorbits and httpd but without the "mirrorbits-parent" chart
  - Distinct charts: easier to manage (shorter feedback loop, less code)

- mirrorbits v0.6.0

- New NFS data store
  - ReadonlyMany
  - Proper Storage class (no typo)
  - Better performances
  - Timestamp kept