### PR TITLE
feat(publick8s/get.jenkins.io) switch persistent volume for geoipupdate to the new data-storage common NFS

### DIFF
--- a/config/get-jenkins-io.yaml
+++ b/config/get-jenkins-io.yaml
@@ -119,20 +119,8 @@ mirrorbits:
         countryCode: DE
         continentCode: EU
   geoipdata:
-    persistentData:
-      enabled: true
-      capacity: 1Gi
-      storageClassName: statically-provisionned
-      csi:
-        driver: file.csi.azure.com
-        fsType: ext4
-        nodeStageSecretRef:
-          name: geoip-data
-          namespace: geoip-data
-        volumeAttributes:
-          resourceGroup: publick8s
-          shareName: geoip-data
-        volumeHandle: https://publick8spvdata.file.core.windows.net/geoip-data
+    existingPVCName: get-jenkins-io
+    subDir: ./get.jenkins.io/geoipdata/
   annotations:
     ad.datadoghq.com/mirrorbits.logs: |
       [{"source":"mirrorbits","service":"get.jenkins.io"}]


### PR DESCRIPTION
Follow up #6958 . It's the same but only for the geoipdata persistent volume.

Ref. https://github.com/jenkins-infra/helpdesk/issues/4767

- The Staging service (staging.get.jenkins.io) shows that we have a working data storage with the provided attributes: https://github.com/jenkins-infra/helpdesk/issues/4764#issuecomment-3187400908 (geoip databases included)