### PR TITLE
cleanup(publick8s/get.jenkins.io) scale down to 1 replicas for each component as a preliminary for migration to split helm releases

### DIFF
--- a/config/get-jenkins-io.yaml
+++ b/config/get-jenkins-io.yaml
@@ -47,7 +47,7 @@ mirrorbits:
   image:
     #repository: jenkinsciinfra/mirrorbits
     tag: 0.2.92 # mirrorbits v0.5.1 - https://github.com/jenkins-infra/helpdesk/issues/4764
-  replicaCount: 2
+  replicaCount: 1
   resources:
     limits:
       cpu: 2
@@ -127,7 +127,7 @@ mirrorbits:
 
 httpd:
   enabled: true
-  replicaCount: 2
+  replicaCount: 1
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
Preliminary to https://github.com/jenkins-infra/kubernetes-management/pull/6960:

- Removes the PDB (easier to start new pods)
- Make the incoming "sync" part faster to run