### PR TITLE
feat(publick8s/get.jenkins.io) bump mirrorbits from 0.5.1 to 0.6.0

### DIFF
--- a/config/get-jenkins-io-mirrorbits.yaml
+++ b/config/get-jenkins-io-mirrorbits.yaml
@@ -1,7 +1,4 @@
 enabled: true
-image:
-  #repository: jenkinsciinfra/mirrorbits
-  tag: 0.2.92 # mirrorbits v0.5.1 - https://github.com/jenkins-infra/helpdesk/issues/4764
 replicaCount: 2
 resources:
   limits:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4764#issuecomment-3191693775