### PR TITLE
feat(publick8s,privatek8s) use private Azure Container Registry for `jenkinsciinfra/404` image and re-enable updatecli version tracking for it

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -59,8 +59,8 @@ releases:
     chart: ingress-nginx/ingress-nginx
     version: 4.11.8
     values:
-      - "../config/public-nginx-ingress__common.yaml"
-      - "../config/public-nginx-ingress_publick8s.yaml"
+      - ../config/public-nginx-ingress__common.yaml
+      - ../config/public-nginx-ingress_publick8s.yaml
   - name: private-nginx-ingress
     namespace: private-nginx-ingress
     chart: ingress-nginx/ingress-nginx

--- a/config/private-nginx-ingress__common.yaml
+++ b/config/private-nginx-ingress__common.yaml
@@ -1,8 +1,8 @@
 defaultBackend:
   enabled: true
   image:
-    repository: jenkinsciinfra/404
-    tag: 0.4.96
+    repository: dockerhubmirror.azurecr.io/jenkinsciinfra/404
+    tag: 0.4.104
     pullPolicy: IfNotPresent
   ## Unprivileged port as non root user and no escalation allowed
   port: 8080

--- a/config/public-nginx-ingress__common.yaml
+++ b/config/public-nginx-ingress__common.yaml
@@ -1,8 +1,8 @@
 defaultBackend:
   enabled: true
   image:
-    repository: jenkinsciinfra/404
-    tag: 0.4.96
+    repository: dockerhubmirror.azurecr.io/jenkinsciinfra/404
+    tag: 0.4.104
     pullPolicy: IfNotPresent
   ## Unprivileged port as non root user and no escalation allowed
   port: 8080

--- a/updatecli/updatecli.d/docker-images/404.yaml
+++ b/updatecli/updatecli.d/docker-images/404.yaml
@@ -15,36 +15,37 @@ scms:
 sources:
   latestRelease:
     kind: githubrelease
-    name: "Get latest jenkins-infra/docker-404 release"
+    name: Get latest jenkins-infra/docker-404 release
     spec:
-      owner: "jenkins-infra"
-      repository: "docker-404"
+      owner: jenkins-infra
+      repository: docker-404
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
 
 conditions:
   checkDockerImagePublished:
-    name: "Test jenkinsciinfra/404:<latest_version> docker image tag"
+    name: Test jenkinsciinfra/404:<latest_version> docker image tag
     kind: dockerimage
     spec:
-      image: "jenkinsciinfra/404"
+      image: dockerhubmirror.azurecr.io/jenkinsciinfra/404
       ## Tag from source
-      architecture: amd64
+      architectures:
+        - arm64
 
 targets:
   updatePrivateNginxIngress404:
-    name: "Update 404 docker image tag"
+    name: Update 404 docker image tag
     kind: yaml
     spec:
-      file: "config/private-nginx-ingress__common.yaml"
-      key: "defaultBackend.image.tag"
+      file: config/private-nginx-ingress__common.yaml
+      key: $.defaultBackend.image.tag
     scmid: default
   updatePublicNginxIngress404:
-    name: "Update 404 docker image tag"
+    name: Update 404 docker image tag
     kind: yaml
     spec:
-      file: "config/public-nginx-ingress__common.yaml"
-      key: "defaultBackend.image.tag"
+      file: config/public-nginx-ingress__common.yaml
+      key: $.defaultBackend.image.tag
     scmid: default
 
 actions:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4769

This PR is the last validation step for https://github.com/jenkins-infra/pipeline-library/pull/955.
It has been tested once manually, and then reverted back.

Note: the "condition" of the `updatecli` manifest requires to be run inside the infra.ci.jenkins.io private network for now.
=> If admin want to run it themselves, they'll have to allow their IP o,n the registry on short term (and have VPN routing requests to the private registry on long term)