### PR TITLE
feat(privatek8s/infra.ci.jenkins.io) use private ACR for both controller and agent Docker images

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -36,8 +36,9 @@ controller:
     readinessProbe:
       initialDelaySeconds: 60
   image:
+    registry: dockerhubmirror.azurecr.io
     repository: jenkinsciinfra/jenkins-infraci
-    tag: 3.9.20-2.523
+    tag: 3.9.22-2.523
     pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux
@@ -130,7 +131,7 @@ controller:
                     nodeSelector: "kubernetes.io/arch=amd64"
                     containers:
                       - name: jnlp
-                        image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.60.0"
+                        image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.60.0
                         command: "/usr/local/bin/jenkins-agent"
                         args: ""
                         envVars:
@@ -169,7 +170,7 @@ controller:
                     nodeSelector: "kubernetes.io/arch=arm64"
                     containers:
                       - name: jnlp
-                        image: "jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.60.0"
+                        image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.60.0
                         command: "/usr/local/bin/jenkins-agent"
                         args: ""
                         envVars:
@@ -212,7 +213,7 @@ controller:
                     nodeSelector: "kubernetes.io/arch=amd64"
                     containers:
                       - name: jnlp
-                        image: "jenkinsciinfra/builder@sha256:7150f769249c071fec7ee18338183193c36d489dc9a2fb2d211242fcc89350cd"
+                        image: dockerhubmirror.azurecr.io/jenkinsciinfra/builder@sha256:7150f769249c071fec7ee18338183193c36d489dc9a2fb2d211242fcc89350cd
                         command: "/usr/local/bin/jenkins-agent"
                         args: ""
                         envVars:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4769

- Controller image has been set up to use the private registry (https://github.com/jenkins-infra/docker-jenkins-infraci/commit/0a9d43b1c4c80d61733a749289a82912a5ba25bc) and released (https://github.com/jenkins-infra/docker-jenkins-infraci/releases/tag/3.9.21-2.523, but we'll use https://github.com/jenkins-infra/docker-jenkins-infraci/releases/tag/3.9.22-2.523 to get latest plugins)
- Verified that agent images are usable in the `infracijenkinsio-agents2` cluster with a dummy pod