### PR TITLE
fix(infra.ci): use github as SCM for shared pipeline library

### DIFF
--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -708,10 +708,23 @@ controller:
               includeInChangesets: false
               retriever:
                 modernSCM:
+                  libraryPath: "."
                   scm:
-                    git:
+                    github:
+                      configuredByUrl: true
                       credentialsId: "github-app-infra"
-                      remote: "https://github.com/jenkins-infra/pipeline-library.git"
+                      id: "8a6c1fca-d270-4bae-bfed-ca322a7052fe"
+                      repoOwner: "jenkins-infra"
+                      repository: "pipeline-library"
+                      repositoryUrl: "https://github.com/jenkins-infra/pipeline-library"
+                      traits:
+                      - gitHubBranchDiscovery:
+                          strategyId: 1
+                      - gitHubPullRequestDiscovery:
+                          strategyId: 2
+                      - gitHubForkDiscovery:
+                          strategyId: 2
+                          trust: "gitHubTrustPermissions"
       matrix-settings: |
         jenkins:
           authorizationStrategy:


### PR DESCRIPTION
as per https://plugins.jenkins.io/github-branch-source/releases/#version_1844.v4a_9883d49126

we need to use github as scm to give enough context to the plugin to use the github app to checkout the shared pipeline library and avoid: 

```
09:12:07  Caching library pipeline-library@master
09:12:07  Attempting to resolve master from remote references...
09:12:07   > git --version # timeout=10
09:12:07   > git --version # 'git version 2.39.5'
09:12:07  using GIT_ASKPASS to set credentials GitHub App for infra.ci.jenkins.io
09:12:07  ERROR: Checkout failed
09:12:07  org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials$InferredAccessibleRepositoriesException: Cannot generate App Installation Token for app ID 96324 because the accessible repositories could not be inferred. This is due to the repository access configuration for the credentials with ID: github-app-infra
09:12:07  	at PluginClassLoader for github-branch-source//org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials.getToken(GitHubAppCredentials.java:384)
```