### PR TITLE
feat(publick8s) add cert-manager and private-ingress charts

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -37,3 +37,19 @@ releases:
       - ../config/datadog_confd_checksd.yaml
     secrets:
       - ../secrets/config/datadog/publick8s-secrets.yaml
+  - name: cert-manager
+    namespace: cert-manager
+    chart: jetstack/cert-manager
+    version: v1.18.2
+    values:
+      - ../config/cert-manager.yaml
+      - ../config/cert-manager_publick8s.yaml
+  # TODO: acme
+  # TODO: public-ingress
+  - name: private-nginx-ingress
+    namespace: private-nginx-ingress
+    chart: ingress-nginx/ingress-nginx
+    version: 4.11.8
+    values:
+      - ../config/private-nginx-ingress__common.yaml
+      - ../config/private-nginx-ingress_publick8s-endless-ghoul.yaml

--- a/config/cert-manager_publick8s.yaml
+++ b/config/cert-manager_publick8s.yaml
@@ -1,0 +1,38 @@
+nodeSelector:
+  kubernetes.io/arch: arm64
+
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+
+webhook:
+  nodeSelector:
+    kubernetes.io/arch: arm64
+
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
+
+cainjector:
+  nodeSelector:
+    kubernetes.io/arch: arm64
+
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
+
+startupapicheck:
+  nodeSelector:
+    kubernetes.io/arch: arm64
+
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"

--- a/config/private-nginx-ingress_publick8s.yaml
+++ b/config/private-nginx-ingress_publick8s.yaml
@@ -1,0 +1,32 @@
+controller:
+  replicaCount: 2
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: "app.kubernetes.io/instance"
+                operator: In
+                values:
+                  - private-nginx-ingress
+          topologyKey: "kubernetes.io/hostname"
+  ingressClass: private-ingress
+  service:
+    annotations:
+      # azure-net:vnets.tf/public-vnet-data-tier
+      service.beta.kubernetes.io/azure-load-balancer-internal-subnet: public-vnet-data-tier
+  nodeSelector:
+    kubernetes.io/arch: arm64
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
+defaultBackend:
+  nodeSelector:
+    kubernetes.io/arch: arm64
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4617

- `cert-manager` to install its CRDs (required for `acme` and `public-ingress`)
- `private-ingress` (to use as default and verify private subnet LB setup)