### PR TITLE
feat(publick8s) add redis (with dandydev HA chart instead of bitnami) and all mirrorbits releases

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -26,6 +26,8 @@ repositories:
   # https://github.com/codecentric/helm-charts/
   - name: codecentric
     url: https://codecentric.github.io/helm-charts
+  - name: dandydev
+    url: https://dandydeveloper.github.io/charts
 releases:
   - name: datadog
     namespace: datadog
@@ -172,14 +174,14 @@ releases:
   #     - "../config/accountapp.yaml"
   #   secrets:
   #     - "../secrets/config/accountapp/secrets.yaml"
-  # - name: get-jenkins-io-mirrorbits
-  #   namespace: get-jenkins-io
-  #   chart: jenkins-infra/mirrorbits
-  #   version: 5.10.0
-  #   values:
-  #     - ../config/get-jenkins-io-mirrorbits.yaml
-  #   secrets:
-  #     - ../secrets/config/get-jenkins-io/mirrorbits-secrets.yaml
+  - name: get-jenkins-io-mirrorbits
+    namespace: get-jenkins-io
+    chart: jenkins-infra/mirrorbits
+    version: 5.10.0
+    values:
+      - ../config/publick8s_get-jenkins-io-mirrorbits.yaml
+    secrets:
+      - ../secrets/config/get-jenkins-io/mirrorbits-secrets.yaml
   - name: get-jenkins-io-httpd
     namespace: get-jenkins-io
     chart: jenkins-infra/httpd
@@ -218,14 +220,14 @@ releases:
       - public-nginx-ingress/public-nginx-ingress
     values:
       - ../config/publick8s-ipv6-lb-service.yaml
-  # - name: updates-jenkins-io-content
-  #   namespace: updates-jenkins-io
-  #   chart: jenkins-infra/mirrorbits
-  #   version: 5.10.0
-  #   values:
-  #     - ../config/updates.jenkins.io-content.yaml
-  #   secrets:
-  #     - ../secrets/config/updates.jenkins.io/secrets.yaml
+  - name: updates-jenkins-io-content
+    namespace: updates-jenkins-io
+    chart: jenkins-infra/mirrorbits
+    version: 5.10.0
+    values:
+      - ../config/publick8s_updates.jenkins.io-content.yaml
+    secrets:
+      - ../secrets/config/updates.jenkins.io/secrets.yaml
   # Can be removed once mirrorbits support scanning through s3 - https://github.com/etix/mirrorbits/issues/141
   - name: updates-jenkins-io-rsync
     namespace: updates-jenkins-io
@@ -257,11 +259,11 @@ releases:
     version: 0.5.0
     values:
       - ../config/publick8s_stats.jenkins.io.yaml
-  # - name: redis
-  #   namespace: redis
-  #   chart: oci://registry-1.docker.io/bitnamicharts/redis
-  #   version: 21.2.14
-  #   values:
-  #     - ../config/publick8s-endless-ghoul-redis.yaml
-  #   secrets:
-  #     - ../secrets/config/redis/publick8s-endless-ghoul.yaml
+  - name: redis
+    namespace: redis
+    chart: dandydev/redis-ha
+    version: 4.34.13
+    values:
+      - ../config/publick8s_redis.yaml
+    secrets:
+      - ../secrets/config/redis/publick8s.yaml

--- a/config/publick8s_get-jenkins-io-mirrorbits.yaml
+++ b/config/publick8s_get-jenkins-io-mirrorbits.yaml
@@ -1,0 +1,106 @@
+enabled: true
+replicaCount: 2
+resources:
+  limits:
+    cpu: 2
+    memory: 2048Mi
+  requests:
+    cpu: 100m
+    memory: 400Mi
+nodeSelector:
+  kubernetes.io/arch: arm64
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+podSecurityContext:
+  runAsUser: 1000  # User 'mirrorbits'
+  runAsGroup: 1000  # Group 'mirrorbits'
+  runAsNonRoot: true
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: "app.kubernetes.io/name"
+              operator: In
+              values:
+                - mirrorbits
+        topologyKey: "kubernetes.io/hostname"
+repository:
+  name: get-jenkins-io
+  existingPVC: true
+  subDir: ./get.jenkins.io/mirrorbits/
+config:
+  # Ingress already does gzip/brotli
+  gzip: false
+  traceFile: /TIME
+  # Do not answer mirrorbits API JSON content when accept header is set to application/json (behavior with default value "auto")
+  outputMode: redirect
+  redis:
+    sentinelMasterName: mymaster
+    sentinels:
+      - redis.redis.svc.cluster.local:26379
+    # password is stored in SOPS secrets
+    ## RedisDB - Use 0 for staging and 1, get.jio production and 2 for update.jio production
+    dbId: 1
+  ## Interval in minutes between mirrors scan
+  scanInterval: 10
+  ## Interval between two scans of the local repository.
+  ## This should, more or less, match the frequency where the local repo is updated (e.g. update center)
+  repositoryScanInterval: 5
+  checkInterval: 1
+  # Disable a mirror if it triggers HTTP/3xx redirects on its own (safer for mirrors we do not control)
+  disallowRedirects: true
+  disableOnMissingFile: false
+  ## List of mirrors to use as fallback which will be used in case mirrorbits
+  ## is unable to answer a request because the database is unreachable.
+  ## Note: Mirrorbits will redirect to one of these mirrors based on the user
+  ## location but won't be able to know if the mirror has the requested file.
+  ## Therefore only put your most reliable and up-to-date mirrors here.
+  fallbacks:
+    ## archives.jenkins.io has ALL the artefacts
+    - url: https://archives.jenkins.io/
+      countryCode: DE
+      continentCode: EU
+geoipdata:
+  existingPVCName: get-jenkins-io
+  subDir: ./get.jenkins.io/geoipdata/
+annotations:
+  ad.datadoghq.com/mirrorbits.logs: |
+    [{"source":"mirrorbits","service":"get.jenkins.io"}]
+
+ingress:
+  enabled: true
+  className: public-nginx
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true" # Required to allow regexp path matching with Nginx
+  hosts:
+    - host: get.jenkins.io
+      paths:
+        - path: /.*[.](deb|hpi|war|rpm|msi|pkg|sha256|md5sum|zip|gz|pdf|json|svg|sh|jpeg|ico|png|html)$  # Requires the regexp engine of Nginx to be enabled
+          pathType: ImplementationSpecific
+    - host: mirrors.jenkins.io
+      paths:
+        - path: /.*[.](deb|hpi|war|rpm|msi|pkg|sha256|md5sum|zip|gz|pdf|json|svg|sh|jpeg|ico|png|html)$  # Requires the regexp engine of Nginx to be enabled
+          pathType: ImplementationSpecific
+    - host: mirrors.jenkins-ci.org
+      paths:
+        - path: /.*[.](deb|hpi|war|rpm|msi|pkg|sha256|md5sum|zip|gz|pdf|json|svg|sh|jpeg|ico|png|html)$  # Requires the regexp engine of Nginx to be enabled
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: get-jenkins-io-tls
+      hosts:
+        - get.jenkins.io
+        - mirrors.jenkins.io
+        - mirrors.jenkins-ci.org

--- a/config/publick8s_redis.yaml
+++ b/config/publick8s_redis.yaml
@@ -1,0 +1,26 @@
+auth: enabled
+sentinel:
+  # Mirrorbits does not support sentinel auth
+  auth: false
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1024Mi
+    requests:
+      cpu: 200m
+      memory: 256Mi
+redis:
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 4096Mi
+    requests:
+      cpu: 150m
+      memory: 750Mi
+nodeSelector:
+  kubernetes.io/arch: arm64
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"

--- a/config/publick8s_updates.jenkins.io-content.yaml
+++ b/config/publick8s_updates.jenkins.io-content.yaml
@@ -1,0 +1,100 @@
+enabled: true
+replicaCount: 2
+resources:
+  limits:
+    cpu: 2
+    memory: 2048Mi
+  requests:
+    cpu: 100m
+    memory: 200Mi
+nodeSelector:
+  kubernetes.io/arch: arm64
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+podSecurityContext:
+  runAsUser: 1000 # User 'mirrorbits'
+  runAsGroup: 1000 # Group 'mirrorbits'
+  runAsNonRoot: true
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+repository:
+  name: updates-jenkins-io
+  existingPVC: true
+  subDir: ./updates.jenkins.io/content/
+config:
+  # Ingress already does gzip/brotli
+  gzip: false
+  traceFile: /TIME
+  # Do not answer mirrorbits API JSON content when accept header is set to application/json (behavior with default value "auto")
+  outputMode: redirect
+  redis:
+    sentinelMasterName: mymaster
+    sentinels:
+      - redis-redis-ha.redis.svc.cluster.local:26379
+    # password is stored in SOPS secrets
+    ## RedisDB - Use 0 for staging and 1, get.jio production and 2 for update.jio production
+    dbId: 2
+  ## Interval between two scans of the local repository.
+  ## This should, more or less, match the frequency where the local repo is updated.
+  ## TODO: set it once a day once the update-center2 would run a `mirrorbits refresh` command by itself
+  repositoryScanInterval: 10
+  ## Interval in minutes between mirror scan
+  ## Once a day is enough as jenkins-infra/update-center2 runs it every X min.
+  scanInterval: 1440
+  checkInterval: 1
+  disallowRedirects: false
+  disableOnMissingFile: false
+  ## List of mirrors to use as fallback which will be used in case mirrorbits
+  ## is unable to answer a request because the database is unreachable.
+  ## Note: Mirrorbits will redirect to one of these mirrors based on the user
+  ## location but won't be able to know if the mirror has the requested file.
+  ## Therefore only put your most reliable and up-to-date mirrors here.
+  fallbacks:
+    # We always fall back to this mirror. Useful to serve stale file during a mirror scan
+    - url: https://archives.jenkins.io/update-center/
+      countryCode: DE
+      continentCode: EU
+cli:
+  enabled: true
+  service:
+    type: LoadBalancer
+    annotations:
+      service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+      service.beta.kubernetes.io/azure-pls-create: "true"
+      service.beta.kubernetes.io/azure-pls-name: "publick8s-updates.jenkins.io"
+      service.beta.kubernetes.io/azure-pls-ip-configuration-subnet: "publick8s"
+      service.beta.kubernetes.io/azure-pls-visibility: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+      service.beta.kubernetes.io/azure-pls-auto-approval: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+geoipdata:
+  existingPVCName: updates-jenkins-io
+  subDir: ./updates.jenkins.io/geoipdata/
+annotations:
+  ad.datadoghq.com/mirrorbits.logs: |
+    [{"source":"mirrorbits","service":"updates.jenkins.io"}]
+
+ingress:
+  enabled: true
+  className: public-nginx
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/use-regex: "true" # Required to allow regexp path matching with Nginx
+    nginx.ingress.kubernetes.io/enable-rewrite-log: "true" # Only enabled if need to debug as it is resources-hungry (I/O)
+  hosts:
+    - host: mirrors.updates.jenkins.io
+      paths:
+        # Only send request to files with these extensions to mirrorbits
+        - path: /.*([.](html|json|txt|ico)|TIME)$ # Requires the regexp engine of Nginx to be enabled
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: updates-jenkins-io-mirrorbits-tls
+      hosts:
+        - mirrors.updates.jenkins.io


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4617#issuecomment-3319456065

This PR has been tested (which created a production outage on the old cluster as I made a mistake with my kubeconfigs when importing redis dumps between clusters 🤦  - https://matrix.to/#/!JLUOInpEYmxJIYXlzs:matrix.org/$CH2JG4izfIx9xepn-hK_lO5Xv6lehYD77O14gM_2OxE?via=matrix.org&via=gitter.im&via=g4v.dev).


It adds:
- Redis in HA mode with a new chart to get rid of bitnami: https://artifacthub.io/packages/helm/dandydev-charts/redis-ha
  - Requires https://github.com/jenkins-infra/charts-secrets/commit/348f338f6279880e76aa0e121b3d3388bde5b379
- All mirrorbits chart releases (update center and get.jio)
  - UC has a new PLS name to avoid conflicts with the current one: will require subsequent code in jenkins-infra/azure

