### PR TITLE
feat(publick8s) add more services (DB related, jenkins-weekly, wiki)

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -77,28 +77,28 @@ releases:
     version: 6.3.0
     values:
       - ../config/publick8s-falco.yaml
-  # - name: jenkins-weekly
-  #   namespace: jenkins-weekly
-  #   chart: jenkins/jenkins
-  #   version: 5.8.90
-  #   needs:
-  #     - public-nginx-ingress/public-nginx-ingress # Required to expose both the UI and the webhooks endpoint
-  #   values:
-  #     - "../config/jenkins_weekly.ci.jenkins.io.yaml"
-  #   secrets:
-  #     - "../secrets/config/weekly.ci.jenkins.io/jenkins-secrets.yaml"
+  - name: jenkins-weekly
+    namespace: jenkins-weekly
+    chart: jenkins/jenkins
+    version: 5.8.90
+    needs:
+      - public-nginx-ingress/public-nginx-ingress # Required to expose both the UI and the webhooks endpoint
+    values:
+      - ../config/jenkins_weekly.ci.jenkins.io.yaml
+    secrets:
+      - ../secrets/config/weekly.ci.jenkins.io/jenkins-secrets.yaml
   - name: javadoc-jenkins-io
     namespace: javadoc-jenkins-io
     chart: jenkins-infra/nginx-website
     version: 0.5.0
     values:
       - ../config/javadoc-jenkins-io.yaml
-  # - name: wiki
-  #   namespace: wiki
-  #   chart: jenkins-infra/wiki
-  #   version: 0.8.0
-  #   values:
-  #     - "../config/wiki.yaml"
+  - name: wiki
+    namespace: wiki
+    chart: jenkins-infra/wiki
+    version: 0.8.0
+    values:
+      - ../config/wiki.yaml
   # - name: ldap
   #   namespace: ldap
   #   chart: jenkins-infra/ldap
@@ -118,40 +118,40 @@ releases:
   #   secrets:
   #     - "../secrets/config/keycloak/public-db.yaml"
   #     - "../secrets/config/keycloak/http.yaml"
-  # - name: plugin-health-scoring
-  #   namespace: plugin-health-scoring
-  #   chart: jenkins-infra/plugin-health-scoring
-  #   version: 3.1.3
-  #   needs:
-  #     - public-nginx-ingress/public-nginx-ingress # Required to expose the service
-  #   values:
-  #     - "../config/plugin-health-scoring.yaml"
-  #   secrets:
-  #     - "../secrets/config/plugin-health-scoring/secrets.yaml"
-  # - name: incrementals-publisher
-  #   namespace: incrementals-publisher
-  #   chart: jenkins-infra/incrementals-publisher
-  #   version: 0.8.2
-  #   values:
-  #     - "../config/incrementals-publisher.yaml"
-  #   secrets:
-  #     - "../secrets/config/incrementals-publisher/secrets.yaml"
-  # - name: rating
-  #   namespace: rating
-  #   chart: jenkins-infra/rating
-  #   version: 0.5.0
-  #   values:
-  #     - "../config/rating.yaml"
-  #   secrets:
-  #     - "../secrets/config/rating/secrets.yaml"
-  # - name: uplink
-  #   namespace: uplink
-  #   chart: jenkins-infra/uplink
-  #   version: 1.2.0
-  #   values:
-  #     - "../config/uplink.yaml"
-  #   secrets:
-  #     - "../secrets/config/uplink/secrets.yaml"
+  - name: plugin-health-scoring
+    namespace: plugin-health-scoring
+    chart: jenkins-infra/plugin-health-scoring
+    version: 3.1.3
+    needs:
+      - public-nginx-ingress/public-nginx-ingress # Required to expose the service
+    values:
+      - ../config/plugin-health-scoring.yaml
+    secrets:
+      - ../secrets/config/plugin-health-scoring/secrets.yaml
+  - name: incrementals-publisher
+    namespace: incrementals-publisher
+    chart: jenkins-infra/incrementals-publisher
+    version: 0.8.2
+    values:
+      - ../config/incrementals-publisher.yaml
+    secrets:
+      - ../secrets/config/incrementals-publisher/secrets.yaml
+  - name: rating
+    namespace: rating
+    chart: jenkins-infra/rating
+    version: 0.5.0
+    values:
+      - ../config/rating.yaml
+    secrets:
+      - ../secrets/config/rating/secrets.yaml
+  - name: uplink
+    namespace: uplink
+    chart: jenkins-infra/uplink
+    version: 1.2.0
+    values:
+      - ../config/uplink.yaml
+    secrets:
+      - ../secrets/config/uplink/secrets.yaml
   - name: reports-jenkins-io
     namespace: reports-jenkins-io
     chart: jenkins-infra/nginx-website
@@ -188,14 +188,14 @@ releases:
     version: 2.0.0
     values:
       - ../config/get-jenkins-io-httpd.yaml
-  # - name: plugin-site-issues
-  #   namespace: plugin-site
-  #   chart: jenkins-infra/plugin-site-issues
-  #   version: 0.4.1
-  #   values:
-  #     - "../config/plugin-site-issues.yaml"
-  #   secrets:
-  #     - "../secrets/config/plugin-site-issues/secrets.yaml"
+  - name: plugin-site-issues
+    namespace: plugin-site
+    chart: jenkins-infra/plugin-site-issues
+    version: 0.4.1
+    values:
+      - ../config/plugin-site-issues.yaml
+    secrets:
+      - ../secrets/config/plugin-site-issues/secrets.yaml
   - name: plugins-jenkins-io
     namespace: plugins-jenkins-io
     chart: jenkins-infra/plugin-site

--- a/config/jenkins_weekly.ci.jenkins.io.yaml
+++ b/config/jenkins_weekly.ci.jenkins.io.yaml
@@ -1,22 +1,14 @@
 serviceAccount:
-  create: true
-  name: jenkins-controller
+  create: false
 serviceAccountAgent:
   create: false
 rbac:
-  create: true
-  readSecrets: true
+  create: false
 persistence:
   enabled: true
   existingClaim: jenkins-weekly-data
 agent:
   componentName: "agent"
-networkPolicy:
-  enabled: true
-  internalAgents:
-    allowed: true
-    namespaceLabels:
-      name: "jenkins-weekly"
 controller:
   image:
     registry: dockerhubmirror.azurecr.io


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4617#issuecomment-3319456065

- Jenkins weekly.ci.jenkins.io controller has its setup changed for 2 clusters (removing unused elements such as RBAC or NetworkPolicies because we do not use agents for it) 
- PHS is added, I hope it won't break the other instance.
- Adding all other "DB" related services