### PR TITLE
feat(publick8s) add www.(origin.)jenkins.io using the nginx-website nd the new data NFS storage

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -90,7 +90,7 @@ releases:
   - name: javadoc-jenkins-io
     namespace: javadoc-jenkins-io
     chart: jenkins-infra/nginx-website
-    version: 0.5.0
+    version: 0.6.0
     values:
       - ../config/javadoc-jenkins-io.yaml
   - name: wiki
@@ -155,13 +155,13 @@ releases:
   - name: reports-jenkins-io
     namespace: reports-jenkins-io
     chart: jenkins-infra/nginx-website
-    version: 0.5.0
+    version: 0.6.0
     values:
       - ../config/publick8s_reports-jenkins-io.yaml
   - name: builds-reports-jenkins-io
     namespace: builds-reports-jenkins-io
     chart: jenkins-infra/nginx-website
-    version: 0.5.0
+    version: 0.6.0
     values:
       - ../config/builds.reports.jenkins.io.yaml
   # - name: accountapp
@@ -204,14 +204,12 @@ releases:
       - ../config/publick8s_plugins-jenkins-io.yaml
     secrets:
       - ../secrets/config/plugins-jenkins-io/secrets.yaml
-  # - name: jenkinsio
-  #   namespace: jenkinsio
-  #   chart: jenkins-infra/jenkinsio
-  #   version: 1.3.1
-  #   values:
-  #     - "../config/jenkinsio.yaml"
-  #   secrets:
-  #     - "../secrets/config/jenkinsio/secrets.yaml"
+  - name: www-jenkins-io
+    namespace: www-jenkins-io
+    chart: jenkins-infra/nginx-website
+    version: 0.6.0
+    values:
+      - ../config/www-jenkins-io.yaml
   - name: ipv6-lb-service
     namespace: public-nginx-ingress
     chart: jenkins-infra/ipv6-lb-service
@@ -244,19 +242,19 @@ releases:
   - name: contributors-jenkins-io
     namespace: contributors-jenkins-io
     chart: jenkins-infra/nginx-website
-    version: 0.5.0
+    version: 0.6.0
     values:
       - ../config/publick8s_contributors.jenkins.io.yaml
   - name: docs-jenkins-io
     namespace: docs-jenkins-io
     chart: jenkins-infra/nginx-website
-    version: 0.5.0
+    version: 0.6.0
     values:
       - ../config/publick8s_docs.jenkins.io.yaml
   - name: stats-jenkins-io
     namespace: stats-jenkins-io
     chart: jenkins-infra/nginx-website
-    version: 0.5.0
+    version: 0.6.0
     values:
       - ../config/publick8s_stats.jenkins.io.yaml
   - name: redis

--- a/config/www-jenkins-io.yaml
+++ b/config/www-jenkins-io.yaml
@@ -1,45 +1,37 @@
 ingress:
-  enabled: false
-  # TODO
-  # enabled: true
-  # className: public-nginx
-  # annotations:
-  #   "cert-manager.io/cluster-issuer": "letsencrypt-prod"
-  #   "nginx.ingress.kubernetes.io/configuration-snippet": |
-  #     more_set_headers "X-Content-Type-Options: nosniff";
-  #     more_set_headers "X-Frame-Options: DENY";
-  # hosts:
-  #   - host: jenkins.io
-  #     paths:
-  #       - path: /
-  #         serviceName: jenkinsio
-  #   - host: www.jenkins.io
-  #     paths:
-  #       - path: /
-  #         serviceName: jenkinsio
-  #   - host: www.origin.jenkins.io
-  #     paths:
-  #       - path: /
-  #         serviceName: jenkinsio
-  #   - host: jenkins-ci.org
-  #     paths:
-  #       - path: /
-  #         serviceName: jenkinsio
-  #   - host: www.jenkins-ci.org
-  #     paths:
-  #       - path: /
-  #         serviceName: jenkinsio
-  # tls:
-  #   - secretName: jenkinsio-tls
-  #     hosts:
-  #       - jenkins-ci.org
-  #       - jenkins.io
-  #       - www.jenkins-ci.org
-  #       - www.origin.jenkins.io
-  #       #- www.jenkins.io # certificate is managed by Fastly
+  enabled: true
+  className: public-nginx
+  annotations:
+    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+    "nginx.ingress.kubernetes.io/configuration-snippet": |
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "X-Frame-Options: DENY";
+  hosts:
+    - host: jenkins.io
+      paths:
+        - path: /
+    - host: www.jenkins.io
+      paths:
+        - path: /
+    - host: www.origin.jenkins.io
+      paths:
+        - path: /
+    - host: jenkins-ci.org
+      paths:
+        - path: /
+    - host: www.jenkins-ci.org
+      paths:
+        - path: /
+  # www.jenkins.io certificate is managed by Fastly
+  tls:
+    - secretName: jenkinsio-tls
+      hosts:
+        - jenkins-ci.org
+        - jenkins.io
+        - www.jenkins-ci.org
+        - www.origin.jenkins.io
 
-# TODO
-# replicaCount: 1
+replicaCount: 2
 
 resources:
   limits:


### PR DESCRIPTION
This PR adds the `www-jenkins-io` helm release on the new `publick8s` cluster.

The following changes are added to this helm release:
- Naming change, as it was named `jenkinsio` in the former `publick8s-endless-ghoul` cluster
- Namespace name change (from `jenkinsio` to `www-jenkins-io`) following https://github.com/jenkins-infra/azure/blob/c96d5e45019341e21b71a62cd2cf8ad16cc271e2/locals.tf#L96
- Chart change: from [`jenkinsio`](https://github.com/jenkins-infra/helm-charts/tree/main/charts/jenkinsio) to [`nginx-webserver`](https://github.com/jenkins-infra/helm-charts/tree/main/charts/nginx-website) following https://github.com/jenkins-infra/helm-charts/pull/1787
- Using the centralized NFS data storage as per https://github.com/jenkins-infra/helpdesk/issues/4767#issuecomment-3206476233
  - Note: it has only been populated once with the data from www.jenkins.io on the subdir 's root AND with the `./zh/` from zh-jenkins-io
- Only 2 pods for the whole website (www.jenkins.io and chinese website which is only visible on `/zh/` URI) instead of 4 in the past

Note: this PR also bumps the nginx-webserver chart to version `0.6.0` on all other helm releases using it