### PR TITLE
fix(publick8s) use coherent naming/NS for wiki.jenkins.io

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -93,12 +93,12 @@ releases:
     version: 0.6.0
     values:
       - ../config/javadoc-jenkins-io.yaml
-  - name: wiki
-    namespace: wiki
+  - name: wiki-jenkins-io
+    namespace: wiki-jenkins-io
     chart: jenkins-infra/wiki
     version: 0.8.0
     values:
-      - ../config/wiki.yaml
+      - ../config/publick8s_wiki.yaml
   # - name: ldap-jenkins-io
   #   namespace: ldap-jenkins-io
   #   chart: jenkins-infra/ldap

--- a/config/publick8s_wiki.yaml
+++ b/config/publick8s_wiki.yaml
@@ -1,0 +1,56 @@
+ingress:
+  enabled: true
+  className: public-nginx
+  annotations:
+    "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+    "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+  hosts:
+    - host: wiki.jenkins.io
+      paths:
+        - path: /
+          pathType: Prefix
+    - host: wiki.jenkins-ci.org
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: wiki-tls
+      hosts:
+        - wiki.jenkins.io
+        - wiki.jenkins-ci.org
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+replicaCount: 2
+
+nodeSelector:
+  kubernetes.io/arch: arm64
+
+tolerations:
+  - key: "kubernetes.io/arch"
+    operator: "Equal"
+    value: "arm64"
+    effect: "NoSchedule"
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+            - key: "app.kubernetes.io/name"
+              operator: In
+              values:
+                - wiki
+        topologyKey: "kubernetes.io/hostname"
+
+podAnnotations:
+  ad.datadoghq.com/wiki.logs: |
+    [
+      {"source":"nginx","service":"wiki.jenkins.io"}
+    ]


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4617

- Already applied manually which created the namespace `wiki-jenkins-io`
- Removed the former `wiki` namespace