### PR TITLE
fix(publick8s) expose private ingress to the cluster subnet

### DIFF
--- a/config/publick8s_private-nginx-ingress.yaml
+++ b/config/publick8s_private-nginx-ingress.yaml
@@ -13,8 +13,8 @@ controller:
   ingressClass: private-ingress
   service:
     annotations:
-      # TODO: track with updatecli - azure-net:vnets.tf/public-vnet-data-tier - https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
-      service.beta.kubernetes.io/azure-load-balancer-internal-subnet: public-vnet-data-tier
+      # TODO: track with updatecli
+      service.beta.kubernetes.io/azure-load-balancer-internal-subnet: publick8s
   nodeSelector:
     kubernetes.io/arch: arm64
   tolerations:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4617

We want to expose the private accesses (Azure PLS for updates.jenkins.io, and the private ingress) in the same subnet as the cluster itself