### PR TITLE
feat(datadog): add all build report jobs excluding docker-jobs to staleness monitor 

### DIFF
--- a/config/datadog_confd_checksd.yaml
+++ b/config/datadog_confd_checksd.yaml
@@ -492,7 +492,79 @@ datadog:
           threshold_in_minutes: 1440
           # TODO: restore 5 mins after jenkins-infra/helpdesk#2843
           min_collection_interval: 60
-        - url: https://builds.reports.jenkins.io/build_status_reports/ci.jenkins.io/acceptance-tests/check-agent-availability/status.json
-          controller: ci.jenkins.io
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/acceptance-tests/acceptance-tests/check-agent-availability/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-confluence-data/main/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-geoipupdate/main/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-jenkins-infraci/main/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-jenkins-lts/main/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-jenkins-weeklyci/main/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-openvpn/main/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-packaging/main/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/plugin-health-scoring/main/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/rating/master/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/kubernetes-jobs/kubernetes-management/main/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/terraform-jobs/azure/main/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/terraform-jobs/azure-net/main/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/terraform-jobs/datadog/main/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/terraform-jobs/digitalocean/main/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/terraform-jobs/terraform-aws-sponsorship/main/status.json
+          controller: infra.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/trusted.ci.jenkins.io/update_center/status.json
+          controller: trusted.ci.jenkins.io
+          threshold_in_minutes: 10
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/trusted.ci.jenkins.io/acceptance-tests-check-agent-availability/status.json
+          controller: trusted.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/release.ci.jenkins.io/infra-agents-health/status.json
+          controller: release.ci.jenkins.io
           threshold_in_minutes: 1440
           min_collection_interval: 60

--- a/config/datadog_confd_checksd.yaml
+++ b/config/datadog_confd_checksd.yaml
@@ -496,42 +496,6 @@ datadog:
           controller: infra.ci.jenkins.io
           threshold_in_minutes: 1440
           min_collection_interval: 60
-        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-confluence-data/main/status.json
-          controller: infra.ci.jenkins.io
-          threshold_in_minutes: 1440
-          min_collection_interval: 60
-        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-geoipupdate/main/status.json
-          controller: infra.ci.jenkins.io
-          threshold_in_minutes: 1440
-          min_collection_interval: 60
-        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-jenkins-infraci/main/status.json
-          controller: infra.ci.jenkins.io
-          threshold_in_minutes: 1440
-          min_collection_interval: 60
-        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-jenkins-lts/main/status.json
-          controller: infra.ci.jenkins.io
-          threshold_in_minutes: 1440
-          min_collection_interval: 60
-        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-jenkins-weeklyci/main/status.json
-          controller: infra.ci.jenkins.io
-          threshold_in_minutes: 1440
-          min_collection_interval: 60
-        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-openvpn/main/status.json
-          controller: infra.ci.jenkins.io
-          threshold_in_minutes: 1440
-          min_collection_interval: 60
-        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-packaging/main/status.json
-          controller: infra.ci.jenkins.io
-          threshold_in_minutes: 1440
-          min_collection_interval: 60
-        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/plugin-health-scoring/main/status.json
-          controller: infra.ci.jenkins.io
-          threshold_in_minutes: 1440
-          min_collection_interval: 60
-        - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/rating/master/status.json
-          controller: infra.ci.jenkins.io
-          threshold_in_minutes: 1440
-          min_collection_interval: 60
         - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/kubernetes-jobs/kubernetes-management/main/status.json
           controller: infra.ci.jenkins.io
           threshold_in_minutes: 1440
@@ -566,5 +530,9 @@ datadog:
           min_collection_interval: 60
         - url: https://builds.reports.jenkins.io/build_status_reports/release.ci.jenkins.io/infra-agents-health/status.json
           controller: release.ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/cert.ci.jenkins.io/acceptance-tests/acceptance-tests/check-agent-availability/status.json
+          controller: infra.ci.jenkins.io
           threshold_in_minutes: 1440
           min_collection_interval: 60

--- a/config/datadog_confd_checksd.yaml
+++ b/config/datadog_confd_checksd.yaml
@@ -532,7 +532,3 @@ datadog:
           controller: release.ci.jenkins.io
           threshold_in_minutes: 1440
           min_collection_interval: 60
-        - url: https://builds.reports.jenkins.io/build_status_reports/cert.ci.jenkins.io/acceptance-tests/acceptance-tests/check-agent-availability/status.json
-          controller: infra.ci.jenkins.io
-          threshold_in_minutes: 1440
-          min_collection_interval: 60

--- a/config/datadog_confd_checksd.yaml
+++ b/config/datadog_confd_checksd.yaml
@@ -492,3 +492,7 @@ datadog:
           threshold_in_minutes: 1440
           # TODO: restore 5 mins after jenkins-infra/helpdesk#2843
           min_collection_interval: 60
+        - url: https://builds.reports.jenkins.io/build_status_reports/ci.jenkins.io/acceptance-tests/check-agent-availability/status.json
+          controller: ci.jenkins.io
+          threshold_in_minutes: 1440
+          min_collection_interval: 60


### PR DESCRIPTION
Ref:

- https://github.com/jenkins-infra/helpdesk/issues/2843

Adds all currently publishing jobs (except docker-jobs) on [builds.reports.jenkins.io](https://builds.reports.jenkins.io/build_status_reports/) to the `buildReportStalenessCheck` AgentCheck config.

### Jobs (21 total)

| Controller | Job | Threshold |
|---|---|---|
| infra.ci | acceptance-tests/acceptance-tests/check-agent-availability | 24h |
| infra.ci | docker-jobs/docker-404/main | 24h (not-included this PR) |
| infra.ci | docker-jobs/docker-confluence-data/main | 24h (not-included this PR)  |
| infra.ci | docker-jobs/docker-geoipupdate/main | 24h (not-included this PR)  |
| infra.ci | docker-jobs/docker-jenkins-infraci/main | 24h (not-included this PR)  |
| infra.ci | docker-jobs/docker-jenkins-lts/main | 24h (not-included this PR)  |
| infra.ci | docker-jobs/docker-jenkins-weeklyci/main | 24h (not-included this PR)  |
| infra.ci | docker-jobs/docker-openvpn/main | 24h (not-included this PR)  |
| infra.ci | docker-jobs/docker-packaging/main | 24h (not-included this PR)  |
| infra.ci | docker-jobs/plugin-health-scoring/main | 24h (not-included this PR)  |
| infra.ci | docker-jobs/rating/master | 24h (not-included this PR)  |
| infra.ci | kubernetes-jobs/kubernetes-management/main | 24h |
| infra.ci | terraform-jobs/azure/main | 24h |
| infra.ci | terraform-jobs/azure-net/main | 24h |
| infra.ci | terraform-jobs/datadog/main | 24h |
| infra.ci | terraform-jobs/digitalocean/main | 24h |
| infra.ci | terraform-jobs/terraform-aws-sponsorship/main | 24h |
| trusted.ci | update_center | **10 min** |
| trusted.ci | acceptance-tests-check-agent-availability | 24h |
| release.ci | infra-agents-health | 24h |
| cert.ci | acceptance-tests/acceptance-tests/check-agent-availability | 24h (not-included this PR) |

### Not included

- All docker-jobs, cert-ci jobs