### PR TITLE
feat(Jenkinsfile_k8s): publish build status report on main branch

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,5 @@
+@Library('pipeline-library@pull/1005/head') _
+
 def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
 
 pipeline {

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,5 +1,3 @@
-@Library('pipeline-library@pull/1005/head') _
-
 def cronExpr = env.BRANCH_IS_PRIMARY ? 'H/30 * * * *' : ''
 
 pipeline {

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -81,5 +81,16 @@ pipeline {
         } // stages
       } // matrix
     } // stage 'stage('Kubernetes Management Tasks')
+    stage('Publish Build Status Report') {
+      when {
+        branch 'main'
+      }
+      agent {
+        label 'jnlp-linux-arm64'
+      }
+      steps {
+        publishBuildStatusReport()
+      }
+    }
   } // stages
 }

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -84,9 +84,6 @@ pipeline {
       } // matrix
     } // stage 'stage('Kubernetes Management Tasks')
     stage('Publish Build Status Report') {
-      when {
-        branch 'main'
-      }
       agent {
         label 'jnlp-linux-arm64'
       }


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2843

Adds a `publishBuildStatusReport()` stage after the Kubernetes Management matrix on the `main` branch, enabling staleness monitoring for this job.



