### PR TITLE
feat(publick8s/updates.jenkins.io) allow private endpoint access to mirrorbits CLI Private Link Service from sponsored subscription

### DIFF
--- a/config/publick8s_updates-jenkins-io-content.yaml
+++ b/config/publick8s_updates-jenkins-io-content.yaml
@@ -70,8 +70,8 @@ cli:
       service.beta.kubernetes.io/azure-pls-create: "true"
       service.beta.kubernetes.io/azure-pls-name: "publick8s-updates.jenkins.io"
       service.beta.kubernetes.io/azure-pls-ip-configuration-subnet: "publick8s"
-      service.beta.kubernetes.io/azure-pls-visibility: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
-      service.beta.kubernetes.io/azure-pls-auto-approval: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+      service.beta.kubernetes.io/azure-pls-visibility: "dff2ec18-6a8e-405c-8e45-b7df7465acf0 1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
+      service.beta.kubernetes.io/azure-pls-auto-approval: "dff2ec18-6a8e-405c-8e45-b7df7465acf0 1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
 geoipdata:
   existingPVCName: updates-jenkins-io
   subDir: ./updates.jenkins.io/geoipdata/


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5070#issuecomment-4268303462

This PR updates the Private Link Service used to expose the `mirrorbits` CLI for updates.jenkins.io in `publick8s` to trusted.ci.jenkins.io by allowing access from the new sponsored subscription.

It should fix https://github.com/jenkins-infra/azure/pull/1407#issuecomment-4278362223 (Private Endpoint error creation in the new subscription).


Note: https://learn.microsoft.com/en-us/azure/aks/internal-lb?tabs=set-service-annotations for reference