### PR TITLE
feat: Add new routes in nginx config of stats.jenkins.io

### DIFF
--- a/config/publick8s/stats-jenkins-io.yaml
+++ b/config/publick8s/stats-jenkins-io.yaml
@@ -70,31 +70,31 @@ nginx:
         index  index.html index.htm;
         autoindex on;
     }
-    location / {
+    location = /statistics {
+        root   /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files /index.html =404;
+    }   
+    location = /plugin-trends {
+        root   /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files /index.html =404;
+    }
+    location = /plugin-versions {
+        root   /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files /index.html =404;
+    }
+    location = /dep-graph {
+        root   /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files /index.html =404;
+    }
+    location = / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         autoindex on;
         try_files $uri /index.html;
-    }
-    location /dep-graph {
-        root /usr/share/nginx/html;
-        index index.html index.htm;
-        autoindex on;
-    }
-    location /statistics {
-        root /usr/share/nginx/html;
-        index index.html index.htm;
-        autoindex on;
-    }
-    location /plugin-versions {
-        root /usr/share/nginx/html;
-        index index.html index.htm;
-        autoindex on;
-    }
-    location /plugin-trends {
-        root /usr/share/nginx/html;
-        index index.html index.htm;
-        autoindex on;
     }
 
 podAnnotations:

--- a/config/publick8s/stats-jenkins-io.yaml
+++ b/config/publick8s/stats-jenkins-io.yaml
@@ -76,6 +76,26 @@ nginx:
         autoindex on;
         try_files $uri /index.html;
     }
+    location /dep-graph {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        autoindex on;
+    }
+    location /statistics {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        autoindex on;
+    }
+    location /plugin-versions {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        autoindex on;
+    }
+    location /plugin-trends {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        autoindex on;
+    }
 
 podAnnotations:
   ad.datadoghq.com/nginx-website.logs: |

--- a/config/publick8s/stats-jenkins-io.yaml
+++ b/config/publick8s/stats-jenkins-io.yaml
@@ -70,27 +70,27 @@ nginx:
         index  index.html index.htm;
         autoindex on;
     }
-    location = /statistics {
+    location /statistics {
         root   /usr/share/nginx/html;
         index index.html index.htm;
         try_files /index.html =404;
     }   
-    location = /plugin-trends {
+    location /plugin-trends {
         root   /usr/share/nginx/html;
         index index.html index.htm;
         try_files /index.html =404;
     }
-    location = /plugin-versions {
+    location /plugin-versions {
         root   /usr/share/nginx/html;
         index index.html index.htm;
         try_files /index.html =404;
     }
-    location = /dep-graph {
+    location /dep-graph {
         root   /usr/share/nginx/html;
         index index.html index.htm;
         try_files /index.html =404;
     }
-    location = / {
+    location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         autoindex on;

--- a/config/publick8s_stats-jenkins-io.yaml
+++ b/config/publick8s_stats-jenkins-io.yaml
@@ -70,31 +70,31 @@ nginx:
         index  index.html index.htm;
         autoindex on;
     }
-    location / {
+    location = /statistics {
+        root   /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files /index.html =404;
+    }   
+    location = /plugin-trends {
+        root   /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files /index.html =404;
+    }
+    location = /plugin-versions {
+        root   /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files /index.html =404;
+    }
+    location = /dep-graph {
+        root   /usr/share/nginx/html;
+        index index.html index.htm;
+        try_files /index.html =404;
+    }
+    location = / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         autoindex on;
         try_files $uri /index.html;
-    }
-    location /dep-graph {
-        root /usr/share/nginx/html;
-        index index.html index.htm;
-        autoindex on;
-    }
-    location /statistics {
-        root /usr/share/nginx/html;
-        index index.html index.htm;
-        autoindex on;
-    }
-    location /plugin-versions {
-        root /usr/share/nginx/html;
-        index index.html index.htm;
-        autoindex on;
-    }
-    location /plugin-trends {
-        root /usr/share/nginx/html;
-        index index.html index.htm;
-        autoindex on;
     }
 
 podAnnotations:

--- a/config/publick8s_stats-jenkins-io.yaml
+++ b/config/publick8s_stats-jenkins-io.yaml
@@ -76,6 +76,26 @@ nginx:
         autoindex on;
         try_files $uri /index.html;
     }
+    location /dep-graph {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        autoindex on;
+    }
+    location /statistics {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        autoindex on;
+    }
+    location /plugin-versions {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        autoindex on;
+    }
+    location /plugin-trends {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+        autoindex on;
+    }
 
 podAnnotations:
   ad.datadoghq.com/nginx-website.logs: |

--- a/config/publick8s_stats-jenkins-io.yaml
+++ b/config/publick8s_stats-jenkins-io.yaml
@@ -70,27 +70,27 @@ nginx:
         index  index.html index.htm;
         autoindex on;
     }
-    location = /statistics {
+    location /statistics {
         root   /usr/share/nginx/html;
         index index.html index.htm;
         try_files /index.html =404;
     }   
-    location = /plugin-trends {
+    location /plugin-trends {
         root   /usr/share/nginx/html;
         index index.html index.htm;
         try_files /index.html =404;
     }
-    location = /plugin-versions {
+    location /plugin-versions {
         root   /usr/share/nginx/html;
         index index.html index.htm;
         try_files /index.html =404;
     }
-    location = /dep-graph {
+    location /dep-graph {
         root   /usr/share/nginx/html;
         index index.html index.htm;
         try_files /index.html =404;
     }
-    location = / {
+    location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         autoindex on;


### PR DESCRIPTION
stats.jenkins.io is a SPA becuase of which it shows 200 OK status on the pages that don't exist or are invlid. So, I found this ngnix config where we can define strict routing. 

Currently, the routes present are of old.stats.jenkins.io, However new routes such as: 
```
/dep-graph
/statistics
/plugin-versions
/plugin-trends
```
are not yet added.

### Question from maintainers
- should we remove new.stats.jenkins.io as host which is present in this file since new.stats.jenkins.io is not live



fixes https://github.com/jenkins-infra/stats.jenkins.io/issues/671