### PR TITLE
Revert "Bump `mirrorbits` helm chart version to 5.10.9"

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -174,7 +174,7 @@ releases:
   - name: get-jenkins-io-mirrorbits
     namespace: get-jenkins-io
     chart: jenkins-infra/mirrorbits
-    version: 5.10.9
+    version: 5.10.6
     values:
       - ../config/publick8s_get-jenkins-io-mirrorbits.yaml
     secrets:
@@ -224,7 +224,7 @@ releases:
   - name: updates-jenkins-io-content
     namespace: updates-jenkins-io
     chart: jenkins-infra/mirrorbits
-    version: 5.10.9
+    version: 5.10.6
     values:
       - ../config/publick8s_updates-jenkins-io-content.yaml
     secrets:


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#7561 which failed to deploy with:

```
08:19:50  STDERR:

08:19:50    Error: UPGRADE FAILED: release get-jenkins-io-mirrorbits failed, and has been rolled back due to atomic being set: cannot patch "get-jenkins-io-mirrorbits" with kind PodDisruptionBudget: PodDisruptionBudget.policy "get-jenkins-io-mirrorbits" is invalid: metadata.labels: Invalid value: "\"v0.6.1\"": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?') && cannot patch "get-jenkins-io-mirrorbits" with kind Service: Service "get-jenkins-io-mirrorbits" is invalid: metadata.labels: Invalid value: "\"v0.6.1\"": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?') && cannot patch "get-jenkins-io-mirrorbits" with kind Deployment: Deployment.apps "get-jenkins-io-mirrorbits" is invalid: metadata.labels: Invalid value: "\"v0.6.1\"": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?') && cannot patch "get-jenkins-io-mirrorbits" with kind Ingress: Ingress.networking.k8s.io "get-jenkins-io-mirrorbits" is invalid: metadata.labels: Invalid value: "\"v0.6.1\"": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')

08:19:50  

08:19:50  COMBINED OUTPUT:

08:19:50    Error: UPGRADE FAILED: release get-jenkins-io-mirrorbits failed, and has been rolled back due to atomic being set: cannot patch "get-jenkins-io-mirrorbits" with kind PodDisruptionBudget: PodDisruptionBudget.policy "get-jenkins-io-mirrorbits" is invalid: metadata.labels: Invalid value: "\"v0.6.1\"": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?') && cannot patch "get-jenkins-io-mirrorbits" with kind Service: Service "get-jenkins-io-mirrorbits" is invalid: metadata.labels: Invalid value: "\"v0.6.1\"": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?') && cannot patch "get-jenkins-io-mirrorbits" with kind Deployment: Deployment.apps "get-jenkins-io-mirrorbits" is invalid: metadata.labels: Invalid value: "\"v0.6.1\"": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?') && cannot patch "get-jenkins-io-mirrorbits" with kind Ingress: Ingress.networking.k8s.io "get-jenkins-io-mirrorbits" is invalid: metadata.labels: Invalid value: "\"v0.6.1\"": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')

script returned exit code 1
```