### PR TITLE
feat(privatek8s/infra.ci.jenkins.io) restrict Gatsby job to only production deployment

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -684,21 +684,6 @@ jobsDefinition:
             appId: "${GITHUB_APP_JENKINS_IO_COMPONENTS_ID}"
             owner: "jenkins-infra"
             privateKey: "${GITHUB_APP_JENKINS_IO_COMPONENTS_PRIVATE_KEY}"
-      gatsby-plugin-jenkins-layout:
-        name: Gatsby plugin for standard Jenkins.io layout
-        # See https://github.com/jenkins-infra/helpdesk/issues/4282
-        allowUntrustedChanges: false
-        jenkinsfilePath: Jenkinsfile
-        branchIncludes: "main alpha beta PR-*"
-        credentials:
-          jenkinsci-npm-token:
-            secret: "${JENKINSCI_NPM_AUTOMATION_TOKEN}"
-            description: "NPM automation token to publish jenkins.io Web Components"
-          jenkins-io-components-ghapp:
-            description: "Github App for semantic-release"
-            appId: "${GITHUB_APP_JENKINS_IO_COMPONENTS_ID}"
-            owner: "jenkins-infra"
-            privateKey: "${GITHUB_APP_JENKINS_IO_COMPONENTS_PRIVATE_KEY}"
       contributor-spotlight:
         name: Contributor Spotlight
         description: "Jenkins Contributor Spotlight Website"
@@ -747,6 +732,21 @@ jobsDefinition:
     description: "Folder hosting all the Website jobs dedicated to deployment in production"
     kind: folder
     children:
+      gatsby-plugin-jenkins-layout:
+        name: Gatsby plugin for standard Jenkins.io layout
+        jenkinsfilePath: Jenkinsfile
+        branchIncludes: "main alpha beta"
+        disableTagDiscovery: false
+        disablePullRequests: true
+        credentials:
+          jenkinsci-npm-token:
+            secret: "${JENKINSCI_NPM_AUTOMATION_TOKEN}"
+            description: "NPM automation token to publish jenkins.io Web Components"
+          jenkins-io-components-ghapp:
+            description: "Github App for semantic-release"
+            appId: "${GITHUB_APP_JENKINS_IO_COMPONENTS_ID}"
+            owner: "jenkins-infra"
+            privateKey: "${GITHUB_APP_JENKINS_IO_COMPONENTS_PRIVATE_KEY}"
       stats.jenkins.io:
         name: stats.jenkins.io
         allowUntrustedChanges: false


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5062#issuecomment-4327443012

This PR updates the configuration of the `gatsby-plugin-jenkins-layout` Multibranch job on infra.ci.jenkins.io with the following changes:

- Disable pull request builds (handled by ci.jenkins.io as no Netlify preview is needed)
- Remove `allowUntrustedChanges` attribute (implicitly set to `false` as there are no PRs anymore)
- Explicitly specify `disableTagDiscovery` to `true` as it seems to have tag based builds
- Move out of the "Website Jobs" folder to "Website production Jobs" folder to ensure credentials are a bit more isolated (following #4282)

In order to keep the jobs history, i'll backup the current job on disk and I'll restore the main's branch builds along with the tags builds *before* merging this. Then we'll let JCasC do its magic, and we'll reload from disk.