### PR TITLE
feat(privatek8s/infra.ci.jenkins.io) split contributor-spotlight into 2 jobs: 1 for PR preview and 1 for production deployment

### DIFF
--- a/clusters/privatek8s.yaml
+++ b/clusters/privatek8s.yaml
@@ -67,7 +67,7 @@ releases:
   - name: infra-ci-jenkins-io-jobs
     namespace: infra-ci-jenkins-io
     chart: jenkins-infra/jenkins-jobs
-    version: 3.1.0
+    version: 3.2.0
     values:
       - ../config/jenkins-jobs_infra.ci.jenkins.io.yaml
   - name: infra-ci-jenkins-io

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -687,22 +687,9 @@ jobsDefinition:
       contributor-spotlight:
         name: Contributor Spotlight
         description: "Jenkins Contributor Spotlight Website"
-        # See https://github.com/jenkins-infra/helpdesk/issues/4282
-        allowUntrustedChanges: false
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: true
-        credentials:
-          contributors-jenkins-io-fileshare-service-principal-writer:
-            kind: azure-serviceprincipal
-            azureEnvironmentName: "Azure"
-            clientId: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
-            clientSecret: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET}"
-            description: "Contributors.jenkins.io File Share Service Principal Writer"
-            subscriptionId: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
-            tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
-          fastly-api-token-purge:
-            secret: "${FASTLY_API_TOKEN_PURGE}"
-            description: "Fastly API token used for purging CDN pages"
+        disableTagDiscovery: true
       docs.jenkins.io:
         name: docs.jenkins.io
         description: "Versioned docs of jenkins.io"
@@ -732,6 +719,25 @@ jobsDefinition:
     description: "Folder hosting all the Website jobs dedicated to deployment in production"
     kind: folder
     children:
+      contributor-spotlight:
+        name: Contributor Spotlight
+        description: "Jenkins Contributor Spotlight Website"
+        jenkinsfilePath: Jenkinsfile
+        branchIncludes: "main"
+        disableTagDiscovery: true
+        disablePullRequests: true
+        credentials:
+          contributors-jenkins-io-fileshare-service-principal-writer:
+            kind: azure-serviceprincipal
+            azureEnvironmentName: "Azure"
+            clientId: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
+            clientSecret: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET}"
+            description: "Contributors.jenkins.io File Share Service Principal Writer"
+            subscriptionId: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+            tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
+          fastly-api-token-purge:
+            secret: "${FASTLY_API_TOKEN_PURGE}"
+            description: "Fastly API token used for purging CDN pages"
       gatsby-plugin-jenkins-layout:
         name: Gatsby plugin for standard Jenkins.io layout
         jenkinsfilePath: Jenkinsfile

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -687,22 +687,10 @@ jobsDefinition:
       contributor-spotlight:
         name: Contributor Spotlight
         description: "Jenkins Contributor Spotlight Website"
-        # See https://github.com/jenkins-infra/helpdesk/issues/4282
-        allowUntrustedChanges: false
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: true
-        credentials:
-          contributors-jenkins-io-fileshare-service-principal-writer:
-            kind: azure-serviceprincipal
-            azureEnvironmentName: "Azure"
-            clientId: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
-            clientSecret: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET}"
-            description: "Contributors.jenkins.io File Share Service Principal Writer"
-            subscriptionId: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
-            tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
-          fastly-api-token-purge:
-            secret: "${FASTLY_API_TOKEN_PURGE}"
-            description: "Fastly API token used for purging CDN pages"
+        disableTagDiscovery: true
+        disableBranchDiscovery: true
       docs.jenkins.io:
         name: docs.jenkins.io
         description: "Versioned docs of jenkins.io"
@@ -732,6 +720,25 @@ jobsDefinition:
     description: "Folder hosting all the Website jobs dedicated to deployment in production"
     kind: folder
     children:
+      contributor-spotlight:
+        name: Contributor Spotlight
+        description: "Jenkins Contributor Spotlight Website"
+        jenkinsfilePath: Jenkinsfile
+        branchIncludes: "main"
+        disableTagDiscovery: true
+        disablePullRequests: true
+        credentials:
+          contributors-jenkins-io-fileshare-service-principal-writer:
+            kind: azure-serviceprincipal
+            azureEnvironmentName: "Azure"
+            clientId: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
+            clientSecret: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET}"
+            description: "Contributors.jenkins.io File Share Service Principal Writer"
+            subscriptionId: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+            tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
+          fastly-api-token-purge:
+            secret: "${FASTLY_API_TOKEN_PURGE}"
+            description: "Fastly API token used for purging CDN pages"
       gatsby-plugin-jenkins-layout:
         name: Gatsby plugin for standard Jenkins.io layout
         jenkinsfilePath: Jenkinsfile


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4985

Splitting into 2 jobs allows to decrease the risks for contributors on PRs.

Requires https://github.com/jenkins-infra/helm-charts/pull/1937 to be released and deployed