### PR TITLE
fix(publick8s/datadog/custom-checks): parse Unix epoch timestamp in build report staleness check

### DIFF
--- a/config/datadog_confd_checksd.yaml
+++ b/config/datadog_confd_checksd.yaml
@@ -195,7 +195,7 @@ datadog:
 
               # Age (staleness)
               try:
-                  ts = datetime.fromisoformat(data['report_timestamp'].replace('Z', '+00:00'))
+                  ts = datetime.fromtimestamp(int(data['report_timestamp']), tz=timezone.utc)
                   age_in_hours = (datetime.now(timezone.utc) - ts).total_seconds() / 3600
                   threshold_in_hours = threshold_in_minutes / 60
                   stale = age_in_hours > threshold_in_hours


### PR DESCRIPTION
Ref:

- https://github.com/jenkins-infra/helpdesk/issues/2843

The build report staleness check (`BuildReportStaleness`) fails to parse  `report_timestamp` from `status.json`, causing `age_in_hours`, `threshold_in_hours`, and `stale` metrics to never be emitted.

The report generator shell script was updated in jenkins-infra/pipeline-library#956 to use Unix epoch format (`date -u +%s`) instead of ISO 8601, but the agent  check was never updated to match, it still calls `datetime.fromisoformat()`.

Issue diagnosed on datadog-agent logs:

<img width="1201" height="1280" alt="image" src="https://github.com/user-attachments/assets/eb0ed204-02d5-47d7-ae9b-0760c056350d" />
