### PR TITLE
feat: add security headers to nginx-website ingress configs

### DIFF
--- a/config/publick8s_alpha-docs-jenkins-io.yaml
+++ b/config/publick8s_alpha-docs-jenkins-io.yaml
@@ -5,6 +5,9 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+    "nginx.ingress.kubernetes.io/configuration-snippet": |
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "X-Frame-Options: DENY";
   hosts:
     - host: alpha.docs.jenkins.io
       paths:

--- a/config/publick8s_builds-reports-jenkins-io.yaml
+++ b/config/publick8s_builds-reports-jenkins-io.yaml
@@ -5,6 +5,9 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+    "nginx.ingress.kubernetes.io/configuration-snippet": |
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "X-Frame-Options: DENY";
   hosts:
     - host: builds.reports.jenkins.io
       paths:

--- a/config/publick8s_contributors-jenkins-io.yaml
+++ b/config/publick8s_contributors-jenkins-io.yaml
@@ -5,6 +5,9 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+    "nginx.ingress.kubernetes.io/configuration-snippet": |
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "X-Frame-Options: DENY";
   hosts:
     - host: contributors.jenkins.io
       paths:

--- a/config/publick8s_docs-jenkins-io.yaml
+++ b/config/publick8s_docs-jenkins-io.yaml
@@ -5,6 +5,9 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+    "nginx.ingress.kubernetes.io/configuration-snippet": |
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "X-Frame-Options: DENY";
   hosts:
     - host: docs.jenkins.io
       paths:

--- a/config/publick8s_javadoc-jenkins-io.yaml
+++ b/config/publick8s_javadoc-jenkins-io.yaml
@@ -5,6 +5,9 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+    "nginx.ingress.kubernetes.io/configuration-snippet": |
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "X-Frame-Options: DENY";
   hosts:
     - host: javadoc.jenkins.io
       paths:

--- a/config/publick8s_reports-jenkins-io.yaml
+++ b/config/publick8s_reports-jenkins-io.yaml
@@ -5,6 +5,9 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+    "nginx.ingress.kubernetes.io/configuration-snippet": |
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "X-Frame-Options: DENY";
   hosts:
     - host: reports.jenkins.io
       paths:

--- a/config/publick8s_stats-jenkins-io.yaml
+++ b/config/publick8s_stats-jenkins-io.yaml
@@ -5,6 +5,9 @@ ingress:
   annotations:
     "cert-manager.io/cluster-issuer": "letsencrypt-prod"
     "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+    "nginx.ingress.kubernetes.io/configuration-snippet": |
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "X-Frame-Options: DENY";
   hosts:
     - host: stats.jenkins.io
       paths:


### PR DESCRIPTION
### Description

Add `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` security headers to all nginx-website ingress configurations that are currently missing them. This aligns with the existing security hardening already applied to `www.jenkins.io` and `accounts.jenkins.io`.

### Motivation

Several public-facing Jenkins services are missing standard OWASP-recommended security headers. This PR ensures consistent security posture across all nginx-website deployments on `publick8s`.

### Changes

Added `nginx.ingress.kubernetes.io/configuration-snippet` annotation with security headers to:
- `config/publick8s_stats-jenkins-io.yaml`
- `config/publick8s_reports-jenkins-io.yaml`
- `config/publick8s_builds-reports-jenkins-io.yaml`
- `config/publick8s_contributors-jenkins-io.yaml`
- `config/publick8s_alpha-docs-jenkins-io.yaml`
- `config/publick8s_docs-jenkins-io.yaml`
- `config/publick8s_javadoc-jenkins-io.yaml`

Fixes #7646 

### Testing

- [x] All modified files pass `yamllint --config-file yamllint.config`
- [x] Changes follow the exact same pattern used by `config/publick8s_www-jenkins-io.yaml`
- [x] No breaking changes - only adds headers to HTTP responses

### Submitter checklist

- [x] Jira issue number or helpdesk issue is referenced in the PR title or body (N/A - improvement)
- [x] Change is code-reviewed
- [x] Tests are added/updated (N/A - config change, validated with yamllint)
- [x] Documentation is updated (N/A)

