### PR TITLE
feat(datadog): add HTTP monitoring checks for unmonitored services

### DIFF
--- a/config/datadog_confd_checksd.yaml
+++ b/config/datadog_confd_checksd.yaml
@@ -399,6 +399,66 @@ datadog:
           tags:
             - production
             - jenkins.io
+        - name: accounts.jenkins.io
+          url: https://accounts.jenkins.io
+          timeout: 10
+          threshold: 3
+          window: 5
+          collect_response_time: true
+          check_certificate_expiration: true
+          days_warning: 30
+          days_critical: 10
+          tags:
+            - production
+            - jenkins.io
+        - name: contributors.jenkins.io
+          url: https://contributors.jenkins.io
+          timeout: 10
+          threshold: 3
+          window: 5
+          collect_response_time: true
+          check_certificate_expiration: true
+          days_warning: 30
+          days_critical: 10
+          tags:
+            - production
+            - jenkins.io
+        - name: stats.jenkins.io
+          url: https://stats.jenkins.io
+          timeout: 10
+          threshold: 3
+          window: 5
+          collect_response_time: true
+          check_certificate_expiration: true
+          days_warning: 30
+          days_critical: 10
+          tags:
+            - production
+            - jenkins.io
+        - name: plugin-health.jenkins.io
+          url: https://plugin-health.jenkins.io
+          timeout: 10
+          threshold: 3
+          window: 5
+          collect_response_time: true
+          check_certificate_expiration: true
+          days_warning: 30
+          days_critical: 10
+          tags:
+            - production
+            - jenkins.io
+        - name: alpha.docs.jenkins.io
+          url: https://alpha.docs.jenkins.io
+          timeout: 10
+          threshold: 3
+          window: 5
+          collect_response_time: true
+          check_certificate_expiration: true
+          days_warning: 30
+          days_critical: 10
+          tags:
+            - production
+            - jenkins.io
         - name: ftp.belnet.be
           timeout: 10
           threshold: 3


### PR DESCRIPTION
### Description

Add Datadog HTTP health monitoring checks for 5 Jenkins services deployed on `publick8s` that are currently missing from the `http_check` configuration in `datadog_confd_checksd.yaml`.

### Motivation

Several actively deployed and public-facing services lack HTTP availability monitoring, TLS certificate expiration checks, and response time collection. This creates a monitoring gap where outages could go undetected.

### Changes

Added HTTP check instances for:
- **accounts.jenkins.io** - User account management
- **contributors.jenkins.io** - Contributor portal
- **stats.jenkins.io** - Jenkins usage statistics
- **plugin-health.jenkins.io** - Plugin health scoring
- **alpha.docs.jenkins.io** - New documentation site

All new checks follow the same configuration pattern used by existing monitored services:
- `timeout: 10`
- `threshold: 3`
- `window: 5`
- `collect_response_time: true`
- `check_certificate_expiration: true`
- `days_warning: 30` / `days_critical: 10`

Fixes #7647 

### Testing

- [x] File passes `yamllint --config-file yamllint.config`
- [x] Configuration follows existing patterns exactly
- [x] No breaking changes to existing monitoring

### Submitter checklist

- [x] Jira issue number or helpdesk issue is referenced in the PR title or body (N/A - improvement)
- [x] Change is code-reviewed
- [x] Tests are added/updated (N/A - config change, validated with yamllint)
- [x] Documentation is updated (N/A)

Signed-off-by: Vaishnav SK <vaishnavsk@users.noreply.github.com>
