### PR TITLE
feat(publick8s/ldap) allow trusted-ci-jenkins-io-sponsored new VM to LDAP

### DIFF
--- a/config/publick8s_ldap-jenkins-io.yaml
+++ b/config/publick8s_ldap-jenkins-io.yaml
@@ -10,8 +10,8 @@ service:
     publick8s-pods: "10.100.0.0/14"
     # Tracked by updatecli - updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
     puppet.jenkins.io: "20.12.27.65/32"
-    # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
-    trusted.ci.jenkins.io: '104.209.128.236/32'
+    # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+    trusted.ci.jenkins.io: '20.110.255.213/32'
     # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
     private.vpn.jenkins.io: '52.232.183.117/32'
     # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure.json


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5084#issuecomment-4343922083

I forgot this one 🤦 