### PR TITLE
Revert "Bump agent templates for infra.ci.jenkins.io (packer-image 2.101.3)"

### DIFF
--- a/config/cijioagents2-maven-cacher.yaml
+++ b/config/cijioagents2-maven-cacher.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 2.101.3
+  tag: 2.101.1
 
 nodeSelector:
   kubernetes.io/arch: arm64

--- a/config/jenkins_infra.ci.jenkins.io.yaml
+++ b/config/jenkins_infra.ci.jenkins.io.yaml
@@ -140,7 +140,7 @@ controller:
                     nodeSelector: "kubernetes.io/arch=amd64"
                     containers:
                       - name: jnlp
-                        image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.101.3
+                        image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.101.1
                         command: "/usr/local/bin/jenkins-agent"
                         args: ""
                         envVars:
@@ -185,7 +185,7 @@ controller:
                     nodeSelector: "kubernetes.io/arch=arm64"
                     containers:
                       - name: jnlp
-                        image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.101.3
+                        image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.101.1
                         command: "/usr/local/bin/jenkins-agent"
                         args: ""
                         envVars:
@@ -242,7 +242,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-amd64"
-                    galleryImageVersion: "2.101.3"
+                    galleryImageVersion: "2.101.1"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
@@ -315,7 +315,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
-                    galleryImageVersion: "2.101.3"
+                    galleryImageVersion: "2.101.1"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
@@ -388,7 +388,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
-                    galleryImageVersion: "2.101.3"
+                    galleryImageVersion: "2.101.1"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
@@ -461,7 +461,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
-                    galleryImageVersion: "2.101.3"
+                    galleryImageVersion: "2.101.1"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
@@ -534,7 +534,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
-                    galleryImageVersion: "2.101.3"
+                    galleryImageVersion: "2.101.1"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#7665 to allow publishing missing 2.101.3 Azure Ubuntu packer images