### PR TITLE
feat(publick8s/updates.jenkins.io/content) allow serving outdated files for 160 minute

### DIFF
--- a/config/publick8s_updates-jenkins-io-content.yaml
+++ b/config/publick8s_updates-jenkins-io-content.yaml
@@ -61,6 +61,10 @@ config:
     - url: https://archives.jenkins.io/update-center/
       countryCode: DE
       continentCode: EU
+  # As per https://github.com/jenkins-infra/helpdesk/issues/5077, the Yandex mirror for Russia/Bielorussia has an update interval of ~2 hours to 2.5 hours
+  allowOutdatedFiles:
+    - prefix: /
+      minutes: 160
 cli:
   enabled: true
   service:


### PR DESCRIPTION
- This 160 min drift is needed to allow Russian users as per https://github.com/jenkins-infra/helpdesk/issues/5077
- Also useful to decrease load on archives.jenkins.io during UC operations as per https://github.com/jenkins-infra/helpdesk/issues/4763

Ping @daniel-beck does 160 min for all mirrors (we can't specify a drift per mirror: it's all or nothing) seems acceptable for the Update Center (and tools) metadatas?

