### PR TITLE
feat(privatek8s/infra.ci.jenkins.io/website-jobs) allow untrusted jobs for external contributors on contributor-spotlight website preview

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -628,13 +628,9 @@ jobsDefinition:
       jenkins.io:
         name: Jenkins.io
         description: "Jenkins.io Website"
-        # See https://github.com/jenkins-infra/helpdesk/issues/4282
-        allowUntrustedChanges: false
       stories:
         name: Jenkins User Stories
         description: "Jenkins User Stories Website"
-        # See https://github.com/jenkins-infra/helpdesk/issues/4282
-        allowUntrustedChanges: false
         jenkinsfilePath: Jenkinsfile
         credentials:
           fastly-api-token-purge:
@@ -642,8 +638,6 @@ jobsDefinition:
             description: "Fastly API token used for purging CDN pages"
       plugin-site:
         name: Plugin Site
-        # See https://github.com/jenkins-infra/helpdesk/issues/4282
-        allowUntrustedChanges: false
         jenkinsfilePath: Jenkinsfile
         credentials:
           PLUGINSITE_STORAGEACCOUNTKEY:
@@ -671,8 +665,6 @@ jobsDefinition:
             description: "Fastly API token used for purging CDN pages"
       jenkins-io-components:
         name: Jenkins.io Web Components
-        # See https://github.com/jenkins-infra/helpdesk/issues/4282
-        allowUntrustedChanges: false
         jenkinsfilePath: Jenkinsfile
         branchIncludes: "main alpha beta PR-*"
         credentials:
@@ -691,6 +683,7 @@ jobsDefinition:
         enableGitHubChecks: true
         disableTagDiscovery: true
         disableBranchDiscovery: true
+        allowUntrustedChanges: true
       docs.jenkins.io:
         name: docs.jenkins.io
         description: "Versioned docs of jenkins.io"
@@ -711,7 +704,6 @@ jobsDefinition:
       stats.jenkins.io:
         name: stats.jenkins.io PR previews
         # See https://github.com/jenkins-infra/helpdesk/issues/4282
-        allowUntrustedChanges: false
         jenkinsfilePath: Jenkinsfile_previews
         enableGitHubChecks: true
         disableTagDiscovery: true
@@ -756,7 +748,6 @@ jobsDefinition:
             privateKey: "${GITHUB_APP_JENKINS_IO_COMPONENTS_PRIVATE_KEY}"
       stats.jenkins.io:
         name: stats.jenkins.io
-        allowUntrustedChanges: false
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: false
         branchIncludes: main


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4985

Following https://github.com/jenkins-infra/kubernetes-management/pull/7633, we can re-enable the untrusted as we don't have credential anymore in the PR jobs except Netlify's token.

It reverts the safety checks put in place in https://github.com/jenkins-infra/helpdesk/issues/4282 but only for this job