### PR TITLE
feat(privatek8s/infra.ci.jenkins.io) adapt configuration of the 2 stats.jenkins.io website jobs

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -703,10 +703,11 @@ jobsDefinition:
             description: "Fastly API token used for purging CDN pages"
       stats.jenkins.io:
         name: stats.jenkins.io PR previews
-        # See https://github.com/jenkins-infra/helpdesk/issues/4282
         jenkinsfilePath: Jenkinsfile_previews
         enableGitHubChecks: true
         disableTagDiscovery: true
+        disableBranchDiscovery: true
+        allowUntrustedChanges: true
   website-production-jobs:
     name: Website Production Jobs
     description: "Folder hosting all the Website jobs dedicated to deployment in production"

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -716,7 +716,7 @@ jobsDefinition:
         name: Contributor Spotlight
         description: "Jenkins Contributor Spotlight Website"
         jenkinsfilePath: Jenkinsfile
-        branchIncludes: "main"
+        branchIncludes: main
         disableTagDiscovery: true
         disablePullRequests: true
         credentials:
@@ -752,6 +752,7 @@ jobsDefinition:
         enableGitHubChecks: false
         branchIncludes: main
         disableTagDiscovery: true
+        disablePullRequests: true
         credentials:
           infraci-stats-jenkins-io-fileshare-service-principal-writer:
             kind: azure-serviceprincipal


### PR DESCRIPTION
Following #7633 and #7690, this PR updates the configuration of the stats.jenkins.io website jobs in infra.ci.jenkins.io:

- The "PR" previews job:
  - Won't build branches anymore. Only PRs as expected.
  - Will be triggered by external contributors (It reverts the safety setup put in place in https://github.com/jenkins-infra/helpdesk/issues/4282 as no more credentials in this job except the Netlify deploy token)
- The "production" deployment job won't build PRs anymore
