### PR TITLE
feat(privatek8s/infra.ci.jenkins.io) split the stories.jenkins.io project into 2 distinct jobs (PR previews and deployment)

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -632,10 +632,10 @@ jobsDefinition:
         name: Jenkins User Stories
         description: "Jenkins User Stories Website"
         jenkinsfilePath: Jenkinsfile
-        credentials:
-          fastly-api-token-purge:
-            secret: "${FASTLY_API_TOKEN_PURGE}"
-            description: "Fastly API token used for purging CDN pages"
+        enableGitHubChecks: true
+        disableTagDiscovery: true
+        disableBranchDiscovery: true
+        allowUntrustedChanges: true
       plugin-site:
         name: Plugin Site
         jenkinsfilePath: Jenkinsfile
@@ -763,3 +763,17 @@ jobsDefinition:
             description: "stats.jenkins.io File Share Service Principal Writer"
             subscriptionId: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
             tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
+      stories:
+        name: Jenkins User Stories
+        description: "Jenkins User Stories Website"
+        jenkinsfilePath: Jenkinsfile
+        branchIncludes: main
+        disableTagDiscovery: true
+        disablePullRequests: true
+        credentials:
+          fastly-api-token-purge:
+            secret: "${FASTLY_API_TOKEN_PURGE}"
+            description: "Fastly API token used for purging CDN pages"
+          netlify-auth-token:
+            description: "Auth token to communicate with netlify"
+            secret: "${NETLIFY_AUTH_TOKEN}"

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -617,8 +617,7 @@ jobsDefinition:
             description: AWS Secret key for the user updatecli
             secret: "${UPDATECLI_AWS_SECRET_ACCESS_KEY}"
   website-jobs:
-    name: Website Jobs
-    description: "Folder hosting all the Website jobs"
+    name: Website Jobs PR previews
     kind: folder
     credentials:
       netlify-auth-token:
@@ -629,8 +628,7 @@ jobsDefinition:
         name: Jenkins.io
         description: "Jenkins.io Website"
       stories:
-        name: Jenkins User Stories
-        description: "Jenkins User Stories Website"
+        name: Jenkins User Stories PR previews
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: true
         disableTagDiscovery: true
@@ -764,8 +762,7 @@ jobsDefinition:
             subscriptionId: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
             tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
       stories:
-        name: Jenkins User Stories
-        description: "Jenkins User Stories Website"
+        name: Jenkins User Stories Production Deployment
         jenkinsfilePath: Jenkinsfile
         branchIncludes: main
         disableTagDiscovery: true


### PR DESCRIPTION
Following #7694, let's split the stories.jenkins.io project, in infra.ci.jenkins.io jobs, into 2 distinct jobs:

- 1 for PR previews (only Netlify credential).
  - Will be triggered by external contributors (It reverts the safety setup put in place in https://github.com/jenkins-infra/helpdesk/issues/4282 as no more credentials in this job except the Netlify deploy token) 
- 1 for production deployment
  - Note: production is currently in Netlify but [it should move to our own hosting](https://github.com/jenkins-infra/helpdesk/issues/4958) one of these days