### PR TITLE
feat(privatek8s/infra.ci.jenkins.io) split the docs.jenkins.io project into 2 distinct jobs (PR previews and deployment)

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -658,22 +658,12 @@ jobsDefinition:
         disableBranchDiscovery: true
         allowUntrustedChanges: true
       docs.jenkins.io:
-        name: docs.jenkins.io
-        description: "Versioned docs of jenkins.io"
+        name: docs.jenkins.io PR previews
         jenkinsfilePath: Jenkinsfile
         enableGitHubChecks: true
-        credentials:
-          infraci-docs-jenkins-io-fileshare-service-principal-writer:
-            kind: azure-serviceprincipal
-            azureEnvironmentName: "Azure"
-            clientId: "${DOCS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
-            clientSecret: "${DOCS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET}"
-            description: "docs.jenkins.io File Share Service Principal Writer"
-            subscriptionId: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
-            tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
-          fastly-api-token-purge:
-            secret: "${FASTLY_API_TOKEN_PURGE}"
-            description: "Fastly API token used for purging CDN pages"
+        disableTagDiscovery: true
+        disableBranchDiscovery: true
+        allowUntrustedChanges: true
       stats.jenkins.io:
         name: stats.jenkins.io PR previews
         jenkinsfilePath: Jenkinsfile_previews
@@ -700,6 +690,24 @@ jobsDefinition:
             clientId: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
             clientSecret: "${CONTRIBUTORS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET}"
             description: "Contributors.jenkins.io File Share Service Principal Writer"
+            subscriptionId: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+            tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
+          fastly-api-token-purge:
+            secret: "${FASTLY_API_TOKEN_PURGE}"
+            description: "Fastly API token used for purging CDN pages"
+      docs.jenkins.io:
+        name: docs.jenkins.io
+        jenkinsfilePath: Jenkinsfile
+        branchIncludes: main
+        disableTagDiscovery: true
+        disablePullRequests: true
+        credentials:
+          infraci-docs-jenkins-io-fileshare-service-principal-writer:
+            kind: azure-serviceprincipal
+            azureEnvironmentName: "Azure"
+            clientId: "${DOCS_SERVICE_PRINCIPAL_WRITER_CLIENT_ID}"
+            clientSecret: "${DOCS_SERVICE_PRINCIPAL_WRITER_CLIENT_SECRET}"
+            description: "docs.jenkins.io File Share Service Principal Writer"
             subscriptionId: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
             tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
           fastly-api-token-purge:


### PR DESCRIPTION
Same as https://github.com/jenkins-infra/kubernetes-management/pull/7695 for docs.jenkins.io:

Let's split the docs.jenkins.io project, in infra.ci.jenkins.io jobs, into 2 distinct jobs:

- 1 for PR previews
  - Will be triggered by external contributors (It reverts the safety setup put in place in https://github.com/jenkins-infra/helpdesk/issues/4282 as no more credentials in this job except the Netlify deploy token) 
- 1 for production deployment