### PR TITLE
cleanup(privatek8s/release.ci) remove obsolete credentials

### DIFF
--- a/config/jenkins_release.ci.jenkins.io.yaml
+++ b/config/jenkins_release.ci.jenkins.io.yaml
@@ -115,11 +115,6 @@ controller:
                     description: Fastly pkg.jenkins.io service id used for invalidating cache
                 - string:
                     scope: GLOBAL
-                    id: "release-gpg-passphrase-2023"
-                    secret: "${RELEASE_GPG_PASSPHRASE_2023}"
-                    description: Release GPG Key passphrase 2023 version
-                - string:
-                    scope: GLOBAL
                     id: "release-gpg-passphrase-2026"
                     secret: "${RELEASE_GPG_PASSPHRASE_2026}"
                     description: Release GPG Key passphrase 2026 version
@@ -133,11 +128,6 @@ controller:
                     id: "maven-repository-password"
                     secret: "${MAVEN_REPOSITORY_PASSWORD}"
                     description: "PASSWORD used by maven release plugin to publish artifacts on a maven repository"
-                - string:
-                    scope: GLOBAL
-                    id: "signing-cert-pass-2023"
-                    secret: "${RELEASE_CERTIFICATE_PASSWORD_2023}"
-                    description: Password used by maven signer plugin to unlock the signing certificate 2023 version
                 - basicSSHUserPrivateKey:
                     scope: GLOBAL
                     id: "release-key"
@@ -181,12 +171,6 @@ controller:
                     id: "lf-msi-sign-azure-client-secret"
                     secret: "${LF_MSI_SIGN_AZURE_CLIENT_SECRET}"
                     description: Secret of the Linux Foundation Azure account used to sign the Jenkins MSI package. Ref. https://github.com/jenkins-infra/helpdesk/issues/4923.
-                - file:
-                    description: JSON metadata file used to sign the MSI Core package. Ref. https://github.com/jenkins-infra/helpdesk/issues/4923.
-                    fileName: metadata.json
-                    id: core-package-msi-signtool-metadata-json
-                    scope: GLOBAL
-                    secretBytes: "${base64:${CORE_PACKAGE_MSI_SIGNTOOL_METADATA_JSON}}"
       agent-settings: |
         jenkins:
           numExecutors: 0


### PR DESCRIPTION
This PR removes 3 unused credentials from release.ci.jenkins.io:

- `signing-cert-pass-2023` as part of https://github.com/jenkins-infra/helpdesk/issues/4923#issuecomment-4475443817. We do not use the Digicert certificate (expired) anymore.
- `release-gpg-passphrase-2023` as the GPG key has been removed (expired) and is not used
- `core-package-msi-signtool-metadata-json` because its content is directly in the publication script (no sensitive content)