### PR TITLE
feat: add `privatek8s-sponsored` with `datadog` release

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'publick8s', 'privatek8s', 'cijioagents2', 'infracijioagents1'
+            values 'publick8s', 'privatek8s', 'privatek8s-sponsored', 'cijioagents2', 'infracijioagents1'
           }
         } // axes
         agent {

--- a/clusters/privatek8s-sponsored.yaml
+++ b/clusters/privatek8s-sponsored.yaml
@@ -32,7 +32,7 @@ releases:
       - ../config/datadog.yaml.gotmpl
       - ../config/privatek8s-sponsored/datadog.yaml
     secrets:
-      - ../secrets/config/datadog/privatek8s-secrets.yaml
+      - ../secrets/config/datadog/privatek8s-sponsored-secrets.yaml
   # - name: cert-manager
   #   namespace: cert-manager
   #   chart: jetstack/cert-manager

--- a/clusters/privatek8s-sponsored.yaml
+++ b/clusters/privatek8s-sponsored.yaml
@@ -1,0 +1,127 @@
+---
+helmDefaults:
+  atomic: true
+  force: false
+  timeout: 300
+  wait: true
+repositories:
+  # https://github.com/DataDog/helm-charts/
+  - name: datadog
+    url: https://helm.datadoghq.com
+  # https://github.com/timja/github-comment-ops/
+  - name: github-comment-ops
+    url: https://timja.github.io/github-comment-ops/
+  # https://github.com/kubernetes/ingress-nginx/
+  - name: ingress-nginx
+    url: https://kubernetes.github.io/ingress-nginx
+  # https://github.com/jenkinsci/helm-charts/
+  - name: jenkins
+    url: https://charts.jenkins.io
+  # https://github.com/jenkins-infra/helm-charts/
+  - name: jenkins-infra
+    url: https://jenkins-infra.github.io/helm-charts
+  # https://github.com/cert-manager/cert-manager/
+  - name: jetstack
+    url: https://charts.jetstack.io
+releases:
+  - name: datadog
+    namespace: datadog
+    chart: datadog/datadog
+    version: 3.214.0
+    values:
+      - ../config/datadog.yaml.gotmpl
+      - ../config/datadog_privatek8s.yaml
+    secrets:
+      - ../secrets/config/datadog/privatek8s-secrets.yaml
+  - name: cert-manager
+    namespace: cert-manager
+    chart: jetstack/cert-manager
+    version: v1.20.2
+    values:
+      - ../config/cert-manager.yaml
+  - name: acme
+    namespace: cert-manager
+    chart: jenkins-infra/acme
+    version: 0.1.4
+    needs:
+      # CRDs must be installed BEFORE any diff or apply operation
+      - cert-manager/cert-manager
+    values:
+      - ../config/acme.yaml
+    secrets:
+      - ../secrets/config/acme/jenkins.io-secrets.yaml
+  - name: private-nginx-ingress
+    namespace: private-nginx-ingress
+    chart: ingress-nginx/ingress-nginx
+    version: 4.11.8
+    values:
+      - ../config/private-nginx-ingress__common.yaml
+      - ../config/private-nginx-ingress_privatek8s.yaml
+  - name: public-nginx-ingress
+    namespace: public-nginx-ingress
+    chart: ingress-nginx/ingress-nginx
+    version: 4.11.8
+    values:
+      - ../config/public-nginx-ingress__common.yaml
+      - ../config/public-nginx-ingress_privatek8s.yaml
+  - name: infra-ci-jenkins-io-jobs
+    namespace: infra-ci-jenkins-io
+    chart: jenkins-infra/jenkins-jobs
+    version: 3.2.0
+    values:
+      - ../config/jenkins-jobs_infra.ci.jenkins.io.yaml
+  - name: infra-ci-jenkins-io
+    namespace: infra-ci-jenkins-io
+    chart: jenkins/jenkins
+    version: 5.9.22
+    needs:
+      # Required to generate the job definition in a configmap
+      - infra-ci-jenkins-io-jobs
+      # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
+      - public-nginx-ingress/public-nginx-ingress
+      # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
+      - private-nginx-ingress/private-nginx-ingress
+    values:
+      - ../config/jenkins_infra.ci.jenkins.io.yaml
+    secrets:
+      - ../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml
+  - name: release-ci-jenkins-io-agents
+    namespace: release-ci-jenkins-io-agents
+    chart: jenkins-infra/jenkins-kubernetes-agents
+    version: 1.1.1
+    values:
+      - ../config/jenkins-kubernetes-agents_release.ci.jenkins.io.yaml
+  - name: release-ci-jenkins-io
+    namespace: release-ci-jenkins-io
+    chart: jenkins/jenkins
+    version: 5.9.22
+    timeout: 600
+    needs:
+      # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
+      - public-nginx-ingress/public-nginx-ingress
+      # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
+      - private-nginx-ingress/private-nginx-ingress
+    values:
+      - ../config/jenkins_release.ci.jenkins.io.yaml
+    secrets:
+      - ../secrets/config/release.ci.jenkins.io/jenkins-secrets.yaml
+  - name: rss2twitter
+    namespace: rss2twitter
+    chart: jenkins-infra/rss2twitter
+    version: 0.1.0
+    values:
+      - ../config/rss2twitter.yaml
+    secrets:
+      # @jenkins_release Twitter dev account credentials
+      - ../secrets/config/rss2twitter/secrets.yaml
+  - name: github-comment-ops
+    namespace: github-comment-ops
+    chart: github-comment-ops/github-comment-ops
+    version: 1.5.2
+    needs:
+      # Required to expose the webhooks endpoint
+      - public-nginx-ingress/public-nginx-ingress
+    values:
+      - ../config/github-comment-ops.yaml
+    secrets:
+      - ../secrets/config/github-comment-ops/secrets.yaml

--- a/clusters/privatek8s-sponsored.yaml
+++ b/clusters/privatek8s-sponsored.yaml
@@ -24,15 +24,15 @@ repositories:
   - name: jetstack
     url: https://charts.jetstack.io
 releases:
-  # - name: datadog
-  #   namespace: datadog
-  #   chart: datadog/datadog
-  #   version: 3.214.0
-  #   values:
-  #     - ../config/datadog.yaml.gotmpl
-  #     - ../config/datadog_privatek8s.yaml
-  #   secrets:
-  #     - ../secrets/config/datadog/privatek8s-secrets.yaml
+  - name: datadog
+    namespace: datadog
+    chart: datadog/datadog
+    version: 3.214.0
+    values:
+      - ../config/datadog.yaml.gotmpl
+      - ../config/privatek8s-sponsored/datadog.yaml
+    secrets:
+      - ../secrets/config/datadog/privatek8s-secrets.yaml
   # - name: cert-manager
   #   namespace: cert-manager
   #   chart: jetstack/cert-manager

--- a/clusters/privatek8s-sponsored.yaml
+++ b/clusters/privatek8s-sponsored.yaml
@@ -24,104 +24,104 @@ repositories:
   - name: jetstack
     url: https://charts.jetstack.io
 releases:
-  - name: datadog
-    namespace: datadog
-    chart: datadog/datadog
-    version: 3.214.0
-    values:
-      - ../config/datadog.yaml.gotmpl
-      - ../config/datadog_privatek8s.yaml
-    secrets:
-      - ../secrets/config/datadog/privatek8s-secrets.yaml
-  - name: cert-manager
-    namespace: cert-manager
-    chart: jetstack/cert-manager
-    version: v1.20.2
-    values:
-      - ../config/cert-manager.yaml
-  - name: acme
-    namespace: cert-manager
-    chart: jenkins-infra/acme
-    version: 0.1.4
-    needs:
-      # CRDs must be installed BEFORE any diff or apply operation
-      - cert-manager/cert-manager
-    values:
-      - ../config/acme.yaml
-    secrets:
-      - ../secrets/config/acme/jenkins.io-secrets.yaml
-  - name: private-nginx-ingress
-    namespace: private-nginx-ingress
-    chart: ingress-nginx/ingress-nginx
-    version: 4.11.8
-    values:
-      - ../config/private-nginx-ingress__common.yaml
-      - ../config/private-nginx-ingress_privatek8s.yaml
-  - name: public-nginx-ingress
-    namespace: public-nginx-ingress
-    chart: ingress-nginx/ingress-nginx
-    version: 4.11.8
-    values:
-      - ../config/public-nginx-ingress__common.yaml
-      - ../config/public-nginx-ingress_privatek8s.yaml
-  - name: infra-ci-jenkins-io-jobs
-    namespace: infra-ci-jenkins-io
-    chart: jenkins-infra/jenkins-jobs
-    version: 3.2.0
-    values:
-      - ../config/jenkins-jobs_infra.ci.jenkins.io.yaml
-  - name: infra-ci-jenkins-io
-    namespace: infra-ci-jenkins-io
-    chart: jenkins/jenkins
-    version: 5.9.22
-    needs:
-      # Required to generate the job definition in a configmap
-      - infra-ci-jenkins-io-jobs
-      # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
-      - public-nginx-ingress/public-nginx-ingress
-      # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
-      - private-nginx-ingress/private-nginx-ingress
-    values:
-      - ../config/jenkins_infra.ci.jenkins.io.yaml
-    secrets:
-      - ../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml
-  - name: release-ci-jenkins-io-agents
-    namespace: release-ci-jenkins-io-agents
-    chart: jenkins-infra/jenkins-kubernetes-agents
-    version: 1.1.1
-    values:
-      - ../config/jenkins-kubernetes-agents_release.ci.jenkins.io.yaml
-  - name: release-ci-jenkins-io
-    namespace: release-ci-jenkins-io
-    chart: jenkins/jenkins
-    version: 5.9.22
-    timeout: 600
-    needs:
-      # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
-      - public-nginx-ingress/public-nginx-ingress
-      # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
-      - private-nginx-ingress/private-nginx-ingress
-    values:
-      - ../config/jenkins_release.ci.jenkins.io.yaml
-    secrets:
-      - ../secrets/config/release.ci.jenkins.io/jenkins-secrets.yaml
-  - name: rss2twitter
-    namespace: rss2twitter
-    chart: jenkins-infra/rss2twitter
-    version: 0.1.0
-    values:
-      - ../config/rss2twitter.yaml
-    secrets:
-      # @jenkins_release Twitter dev account credentials
-      - ../secrets/config/rss2twitter/secrets.yaml
-  - name: github-comment-ops
-    namespace: github-comment-ops
-    chart: github-comment-ops/github-comment-ops
-    version: 1.5.2
-    needs:
-      # Required to expose the webhooks endpoint
-      - public-nginx-ingress/public-nginx-ingress
-    values:
-      - ../config/github-comment-ops.yaml
-    secrets:
-      - ../secrets/config/github-comment-ops/secrets.yaml
+  # - name: datadog
+  #   namespace: datadog
+  #   chart: datadog/datadog
+  #   version: 3.214.0
+  #   values:
+  #     - ../config/datadog.yaml.gotmpl
+  #     - ../config/datadog_privatek8s.yaml
+  #   secrets:
+  #     - ../secrets/config/datadog/privatek8s-secrets.yaml
+  # - name: cert-manager
+  #   namespace: cert-manager
+  #   chart: jetstack/cert-manager
+  #   version: v1.20.2
+  #   values:
+  #     - ../config/cert-manager.yaml
+  # - name: acme
+  #   namespace: cert-manager
+  #   chart: jenkins-infra/acme
+  #   version: 0.1.4
+  #   needs:
+  #     # CRDs must be installed BEFORE any diff or apply operation
+  #     - cert-manager/cert-manager
+  #   values:
+  #     - ../config/acme.yaml
+  #   secrets:
+  #     - ../secrets/config/acme/jenkins.io-secrets.yaml
+  # - name: private-nginx-ingress
+  #   namespace: private-nginx-ingress
+  #   chart: ingress-nginx/ingress-nginx
+  #   version: 4.11.8
+  #   values:
+  #     - ../config/private-nginx-ingress__common.yaml
+  #     - ../config/private-nginx-ingress_privatek8s.yaml
+  # - name: public-nginx-ingress
+  #   namespace: public-nginx-ingress
+  #   chart: ingress-nginx/ingress-nginx
+  #   version: 4.11.8
+  #   values:
+  #     - ../config/public-nginx-ingress__common.yaml
+  #     - ../config/public-nginx-ingress_privatek8s.yaml
+  # - name: infra-ci-jenkins-io-jobs
+  #   namespace: infra-ci-jenkins-io
+  #   chart: jenkins-infra/jenkins-jobs
+  #   version: 3.2.0
+  #   values:
+  #     - ../config/jenkins-jobs_infra.ci.jenkins.io.yaml
+  # - name: infra-ci-jenkins-io
+  #   namespace: infra-ci-jenkins-io
+  #   chart: jenkins/jenkins
+  #   version: 5.9.22
+  #   needs:
+  #     # Required to generate the job definition in a configmap
+  #     - infra-ci-jenkins-io-jobs
+  #     # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
+  #     - public-nginx-ingress/public-nginx-ingress
+  #     # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
+  #     - private-nginx-ingress/private-nginx-ingress
+  #   values:
+  #     - ../config/jenkins_infra.ci.jenkins.io.yaml
+  #   secrets:
+  #     - ../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml
+  # - name: release-ci-jenkins-io-agents
+  #   namespace: release-ci-jenkins-io-agents
+  #   chart: jenkins-infra/jenkins-kubernetes-agents
+  #   version: 1.1.1
+  #   values:
+  #     - ../config/jenkins-kubernetes-agents_release.ci.jenkins.io.yaml
+  # - name: release-ci-jenkins-io
+  #   namespace: release-ci-jenkins-io
+  #   chart: jenkins/jenkins
+  #   version: 5.9.22
+  #   timeout: 600
+  #   needs:
+  #     # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
+  #     - public-nginx-ingress/public-nginx-ingress
+  #     # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
+  #     - private-nginx-ingress/private-nginx-ingress
+  #   values:
+  #     - ../config/jenkins_release.ci.jenkins.io.yaml
+  #   secrets:
+  #     - ../secrets/config/release.ci.jenkins.io/jenkins-secrets.yaml
+  # - name: rss2twitter
+  #   namespace: rss2twitter
+  #   chart: jenkins-infra/rss2twitter
+  #   version: 0.1.0
+  #   values:
+  #     - ../config/rss2twitter.yaml
+  #   secrets:
+  #     # @jenkins_release Twitter dev account credentials
+  #     - ../secrets/config/rss2twitter/secrets.yaml
+  # - name: github-comment-ops
+  #   namespace: github-comment-ops
+  #   chart: github-comment-ops/github-comment-ops
+  #   version: 1.5.2
+  #   needs:
+  #     # Required to expose the webhooks endpoint
+  #     - public-nginx-ingress/public-nginx-ingress
+  #   values:
+  #     - ../config/github-comment-ops.yaml
+  #   secrets:
+  #     - ../secrets/config/github-comment-ops/secrets.yaml

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -181,10 +181,6 @@ jobsDefinition:
             fileName: "kubeconfig"
             description: "Kubeconfig file for privatek8s"
             secretBytes: "${base64:${KUBECONFIG_PRIVATEK8S}}"
-          kubeconfig-privatek8s-sponsored:
-            fileName: "kubeconfig"
-            description: "Kubeconfig file for privatek8s-sponsored"
-            secretBytes: "${base64:${KUBECONFIG_PRIVATEK8S_SPONSORED}}"
           kubeconfig-publick8s:
             fileName: "kubeconfig"
             description: "Kubeconfig file for publick8s"

--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -181,6 +181,10 @@ jobsDefinition:
             fileName: "kubeconfig"
             description: "Kubeconfig file for privatek8s"
             secretBytes: "${base64:${KUBECONFIG_PRIVATEK8S}}"
+          kubeconfig-privatek8s-sponsored:
+            fileName: "kubeconfig"
+            description: "Kubeconfig file for privatek8s-sponsored"
+            secretBytes: "${base64:${KUBECONFIG_PRIVATEK8S_SPONSORED}}"
           kubeconfig-publick8s:
             fileName: "kubeconfig"
             description: "Kubeconfig file for publick8s"

--- a/config/privatek8s-sponsored/datadog.yaml
+++ b/config/privatek8s-sponsored/datadog.yaml
@@ -1,0 +1,36 @@
+providers:
+  aks:
+    enabled: true
+datadog:
+  clusterName: 'privatek8s'
+  env:
+    - name: DD_HOSTNAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+agents:
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
+    - key: "CriticalAddonsOnly"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"
+    - key: "jenkins"
+      operator: "Equal"
+      value: "infra.ci.jenkins.io"
+      effect: "NoSchedule"
+    - key: "jenkins"
+      operator: "Equal"
+      value: "release.ci.jenkins.io"
+      effect: "NoSchedule"
+    - key: "jenkins-component"
+      operator: "Equal"
+      value: "controller"
+      effect: "NoSchedule"
+    - key: "kubernetes.azure.com/scalesetpriority"
+      operator: "Equal"
+      value: "spot"
+      effect: "NoSchedule"

--- a/config/privatek8s-sponsored/datadog.yaml
+++ b/config/privatek8s-sponsored/datadog.yaml
@@ -2,7 +2,7 @@ providers:
   aks:
     enabled: true
 datadog:
-  clusterName: 'privatek8s'
+  clusterName: 'privatek8s-sponsored'
   env:
     - name: DD_HOSTNAME
       valueFrom:


### PR DESCRIPTION
This change adds the new cluster, and starts putting its config files in their own folder, with common values staying at the root of ./config folder.

Refs:
- https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952
- https://github.com/jenkins-infra/charts-secrets/commit/6c5fcc4658fcdd03c8e328df473ad93c3afac5fb (for datadog secret)