### PR TITLE
feat(privatek8s-sponsored/release.ci.jenkins.io) setup controller after first bootstrap

### DIFF
--- a/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
+++ b/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
@@ -66,14 +66,13 @@ controller:
     ## Commented out after initial installation
     # fsGroup: 1000 # Uncomment once for new volumes
     # fsGroupChangePolicy: OnRootMismatch # Uncomment once for new volumes
-  # TODO: uncomment once bootstrapped
-  # probes:
-  #   startupProbe:
-  #     initialDelaySeconds: 120
-  #   livenessProbe:
-  #     initialDelaySeconds: 120
-  #   readinessProbe:
-  #     initialDelaySeconds: 120
+  probes:
+    startupProbe:
+      initialDelaySeconds: 60
+    livenessProbe:
+      initialDelaySeconds: 60
+    readinessProbe:
+      initialDelaySeconds: 60
   testEnabled: false
   overwritePlugins: true
   serviceType: "ClusterIP"

--- a/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
+++ b/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
@@ -63,8 +63,9 @@ controller:
     runAsUser: 1000
     runAsNonRoot: true
     supplementalGroups: [1000]
-    fsGroup: 1000 # Uncomment once for new volumes
-    fsGroupChangePolicy: OnRootMismatch # Uncomment once for new volumes
+    ## Commented out after initial installation
+    # fsGroup: 1000 # Uncomment once for new volumes
+    # fsGroupChangePolicy: OnRootMismatch # Uncomment once for new volumes
   # TODO: uncomment once bootstrapped
   # probes:
   #   startupProbe:

--- a/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
+++ b/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
@@ -32,7 +32,7 @@ controller:
   image:
     registry: dockerhubmirror.azurecr.io
     repository: jenkinsciinfra/jenkins-lts
-    tag: 2.3.81-2.555.2
+    tag: 2.3.83-2.555.2
     pullPolicy: IfNotPresent
   nodeSelector:
     kubernetes.io/os: linux


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952

Following successful deployment of https://github.com/jenkins-infra/kubernetes-management/pull/7749, this PR sets up the controller after its initial bootstrap with the following changes:

- [feat(privatek8s-sponsored/release.ci.jenkins.io) disable AKS CSI fsgroup options after first initialization](https://github.com/jenkins-infra/kubernetes-management/pull/7753/changes/141c7db4ccc1317c18f50f85c3f0241303cc34e7) as the controller successfully started, showing the default `root:root` ownership of the data volume was changed with success
  - Reverts https://github.com/jenkins-infra/kubernetes-management/pull/7749/changes/eae7c11f1da3733f3d36f086e57a2e0c6f796612
- [feat(privatek8s-sponsored/release.ci.jenkins.io) setup controller after first bootstrap](https://github.com/jenkins-infra/kubernetes-management/pull/7753/changes/ed45754d011597385e0c06c12800a228dd6146ce)
  - Currently [disabled on current `privatek8s` cluster](https://github.com/jenkins-infra/kubernetes-management/blob/ef01e116d14e38c87b86e804ed91358939c1f141/config/jenkins_release.ci.jenkins.io.yaml#L63-L70) for release.ci.jenkins.io 🤦 
  - Using the same [values as infra.ci.jenkins.io](https://github.com/jenkins-infra/kubernetes-management/blob/ef01e116d14e38c87b86e804ed91358939c1f141/config/jenkins_infra.ci.jenkins.io.yaml#L31-L37)

- [Bump Jenkins LTS docker image version to 2.3.83-2.555.2](https://github.com/jenkins-infra/kubernetes-management/pull/7753/changes/5ab9c2325221b374cb6181268ae93e3524077c0f) as we need a controller restart to fully test the PR configuration changes once deployed. Transplanted from https://github.com/jenkins-infra/kubernetes-management/pull/7751