### PR TITLE
feat(privatek8s/infra.ci): use anchor to duplicate kubeconfig credentials between `kubernetes-management` and `acceptance-tests`

### DIFF
--- a/config/jenkins-jobs_infra.ci.jenkins.io.yaml
+++ b/config/jenkins-jobs_infra.ci.jenkins.io.yaml
@@ -1,5 +1,26 @@
 jenkinsName: infra-ci-jenkins-io
 jenkinsFqdn: infra.ci.jenkins.io
+x-kubeconfigCredentials: &kubeconfigCredentials
+  kubeconfig-privatek8s:
+    fileName: "kubeconfig"
+    description: "Kubeconfig file for privatek8s"
+    secretBytes: "${base64:${KUBECONFIG_PRIVATEK8S}}"
+  kubeconfig-privatek8s-sponsored:
+    fileName: "kubeconfig"
+    description: "Kubeconfig file for privatek8s"
+    secretBytes: "${base64:${KUBECONFIG_PRIVATEK8S_SPONSORED}}"
+  kubeconfig-publick8s:
+    fileName: "kubeconfig"
+    description: "Kubeconfig file for publick8s"
+    secretBytes: "${base64:${KUBECONFIG_PUBLICK8S}}"
+  kubeconfig-cijioagents2:
+    fileName: "kubeconfig"
+    description: "Kubeconfig file for cijioagents2"
+    secretBytes: "${base64:${KUBECONFIG_CIJIOAGENTS2}}"
+  kubeconfig-infracijioagents1:
+    fileName: "kubeconfig"
+    description: "Kubeconfig file for infracijenkinsio-agents-1"
+    secretBytes: "${base64:${KUBECONFIG_INFRACIJIOAGENTS1}}"
 jobsDefinition:
   acceptance-tests:
     name: Jenkins Infrastructure acceptance tests
@@ -9,6 +30,8 @@ jobsDefinition:
         jenkinsfilePath: infra.ci.jenkins.io/Jenkinsfile
         branchIncludes: check-agent-availability
         disableTagDiscovery: true
+        credentials:
+          <<: *kubeconfigCredentials
   cronjobs:
     name: Jenkins Infrastructure Cron Jobs
     description: Each branch of this repository hosts an infra.ci.jenkins.io pipeline to run repetitive ("cron-like") task for the Jenkins infrastructure.
@@ -177,26 +200,7 @@ jobsDefinition:
           sops-tenant-id:
             secret: "${SOPS_TENANT_ID}"
             description: Azure tenant id used by sops to decrypt secrets
-          kubeconfig-privatek8s:
-            fileName: "kubeconfig"
-            description: "Kubeconfig file for privatek8s"
-            secretBytes: "${base64:${KUBECONFIG_PRIVATEK8S}}"
-          kubeconfig-privatek8s-sponsored:
-            fileName: "kubeconfig"
-            description: "Kubeconfig file for privatek8s"
-            secretBytes: "${base64:${KUBECONFIG_PRIVATEK8S_SPONSORED}}"
-          kubeconfig-publick8s:
-            fileName: "kubeconfig"
-            description: "Kubeconfig file for publick8s"
-            secretBytes: "${base64:${KUBECONFIG_PUBLICK8S}}"
-          kubeconfig-cijioagents2:
-            fileName: "kubeconfig"
-            description: "Kubeconfig file for cijioagents2"
-            secretBytes: "${base64:${KUBECONFIG_CIJIOAGENTS2}}"
-          kubeconfig-infracijioagents1:
-            fileName: "kubeconfig"
-            description: "Kubeconfig file for infracijenkinsio-agents-1"
-            secretBytes: "${base64:${KUBECONFIG_INFRACIJIOAGENTS1}}"
+          <<: *kubeconfigCredentials
   reports:
     name: Reports
     description: Folder hosting all the reporting tasks jobs


### PR DESCRIPTION
This change will allow using the kubectl credentials in https://github.com/jenkins-infra/acceptance-tests for infra.ci.jenkins.io

Refs:
- https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952
- https://github.com/jenkins-infra/helpdesk/issues/5043#issuecomment-4144879015