### PR TITLE
feat(privatek8s-sponsored/release.ci.jenkins.io) add `infra-agents-health` job

### DIFF
--- a/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
+++ b/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
@@ -193,8 +193,78 @@ controller:
                     value: "true"
                   - key: "azure.workload.identity/use"
                     value: "true"
-      # jobs-settings: |
-      #   jobs:
+      jobs-settings: |
+        jobs:
+          - script: >
+              multibranchPipelineJob('infra-agents-health') {
+                description('ddu-6')
+
+                triggers {
+                  periodicFolderTrigger {
+                    interval('@daily')
+                  }
+                }
+
+                branchSources {
+                  branchSource {
+                    source {
+                      github {
+                        id('infra-agents-health')
+                        configuredByUrl(true)
+                        repositoryUrl('https://github.com/jenkins-infra/release')
+                        repoOwner('jenkins-infra')
+                        repository('release')
+                        traits {
+                          gitHubSCMSourceStatusChecksTrait {
+                            // Note: changing this name might have impact on github branch protections if they specify status names
+                            name('jenkins')
+                            skip(true)
+                            skipProgressUpdates(true)
+                            // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
+                            skipNotifications(true)
+                            // Default value: false. Warning: risk of secret leak in console if the build fails
+                            // Please note that it only disable the detailed logs. If you really want no logs, then use "skip(false)' instead
+                            suppressLogs(true)
+                            unstableBuildNeutral(false)
+                          }
+                          gitHubBranchDiscovery {
+                            strategyId(1) // 1-only branches that are not pull requests
+                          }
+                          pruneStaleBranchTrait()
+                          // Select branches and tags to build based on these filters
+                          headWildcardFilterWithPR {
+                            includes('chore/helpdesk-5091') // only branches listed here
+                            excludes('')
+                            tagIncludes('*')
+                            tagExcludes('')
+                          }
+                        }
+                      }
+                      buildStrategies {
+                        buildAnyBranches {
+                          strategies {
+                            skipInitialBuildOnFirstBranchIndexing()
+                            buildRegularBranches()
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                factory {
+                  workflowBranchProjectFactory {
+                    scriptPath('Jenkinsfile.d/infra-agents-health')
+                  }
+                }
+                orphanedItemStrategy {
+                  defaultOrphanedItemStrategy {
+                    pruneDeadBranches(true)
+                    daysToKeepStr("")
+                    numToKeepStr("")
+                    abortBuilds(true)
+                  }
+                }
+              }
       #     - script: >
       #         folder('core') {
       #           displayName('Core')

--- a/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
+++ b/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
@@ -197,8 +197,6 @@ controller:
         jobs:
           - script: >
               multibranchPipelineJob('infra-agents-health') {
-                description('ddu-6')
-
                 triggers {
                   periodicFolderTrigger {
                     interval('@daily')


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952

This PR defines the `infra-agents-health` as code for release.ci.jenkins.io controller in the new `privatek8s-sponsored` cluster.

It introduces a few changes compared to its "manually-managed" original twin from `privatek8s`:

- Type is a Multibranch job with restricted branch name, no PR, no tags and no github checks (instead of single pipeline job)
  - Note: the credential is set up to an empty value which means it might be rate limited 
- It uses the source branch of https://github.com/jenkins-infra/release/pull/908 as there are changed parameters (node pool named) compared to the original. We'll merge and update once migration is performed