### PR TITLE
 feat(privatek8s-sponsored/infra.ci) init. empty controller (initial data volume fsgroup AKS CSI setup and no startup probes)

### DIFF
--- a/clusters/privatek8s-sponsored.yaml
+++ b/clusters/privatek8s-sponsored.yaml
@@ -70,21 +70,21 @@ releases:
     version: 3.2.0
     values:
       - ../config/privatek8s-sponsored/infra-ci-jenkins-io-jobs.yaml
-  # - name: infra-ci-jenkins-io
-  #   namespace: infra-ci-jenkins-io
-  #   chart: jenkins/jenkins
-  #   version: 5.9.22
-  #   needs:
-  #     # Required to generate the job definition in a configmap
-  #     - infra-ci-jenkins-io-jobs
-  #     # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
-  #     - public-nginx-ingress/public-nginx-ingress
-  #     # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
-  #     - private-nginx-ingress/private-nginx-ingress
-  #   values:
-  #     - ../config/jenkins_infra.ci.jenkins.io.yaml
-  #   secrets:
-  #     - ../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml
+  - name: infra-ci-jenkins-io
+    namespace: infra-ci-jenkins-io
+    chart: jenkins/jenkins
+    version: 5.9.22
+    needs:
+      # Required to generate the job definition in a configmap
+      - infra-ci-jenkins-io-jobs
+      # Required to expose the webhooks endpoint (secondary ingress of the jenkins helm chart)
+      - public-nginx-ingress/public-nginx-ingress
+      # Required to expose the Web UI to the VPN (primary ingress of the jenkins helm chart)
+      - private-nginx-ingress/private-nginx-ingress
+    values:
+      - ../config/privatek8s-sponsored/infra.ci.jenkins.io.yaml
+    secrets:
+      - ../secrets/config/infra.ci.jenkins.io/jenkins-secrets.yaml
   - name: release-ci-jenkins-io-agents
     namespace: release-ci-jenkins-io-agents
     chart: jenkins-infra/jenkins-kubernetes-agents

--- a/config/privatek8s-sponsored/infra-ci-jenkins-io-jobs.yaml
+++ b/config/privatek8s-sponsored/infra-ci-jenkins-io-jobs.yaml
@@ -1,5 +1,26 @@
 jenkinsName: infra-ci-jenkins-io
 jenkinsFqdn: infra.ci.jenkins.io
+x-kubeconfigCredentials: &kubeconfigCredentials
+  kubeconfig-privatek8s:
+    fileName: "kubeconfig"
+    description: "Kubeconfig file for privatek8s"
+    secretBytes: "${base64:${KUBECONFIG_PRIVATEK8S}}"
+  kubeconfig-privatek8s-sponsored:
+    fileName: "kubeconfig"
+    description: "Kubeconfig file for privatek8s"
+    secretBytes: "${base64:${KUBECONFIG_PRIVATEK8S_SPONSORED}}"
+  kubeconfig-publick8s:
+    fileName: "kubeconfig"
+    description: "Kubeconfig file for publick8s"
+    secretBytes: "${base64:${KUBECONFIG_PUBLICK8S}}"
+  kubeconfig-cijioagents2:
+    fileName: "kubeconfig"
+    description: "Kubeconfig file for cijioagents2"
+    secretBytes: "${base64:${KUBECONFIG_CIJIOAGENTS2}}"
+  kubeconfig-infracijioagents1:
+    fileName: "kubeconfig"
+    description: "Kubeconfig file for infracijenkinsio-agents-1"
+    secretBytes: "${base64:${KUBECONFIG_INFRACIJIOAGENTS1}}"
 jobsDefinition:
   acceptance-tests:
     name: Jenkins Infrastructure acceptance tests
@@ -9,6 +30,10 @@ jobsDefinition:
         jenkinsfilePath: infra.ci.jenkins.io/Jenkinsfile
         branchIncludes: check-agent-availability
         disableTagDiscovery: true
+        disableGitHubNotifications: true
+        disablePullRequests: true
+        credentials:
+          <<: *kubeconfigCredentials
   # cronjobs:
   #   name: Jenkins Infrastructure Cron Jobs
   #   description: Each branch of this repository hosts an infra.ci.jenkins.io pipeline to run repetitive ("cron-like") task for the Jenkins infrastructure.

--- a/config/privatek8s-sponsored/infra.ci.jenkins.io.yaml
+++ b/config/privatek8s-sponsored/infra.ci.jenkins.io.yaml
@@ -1,0 +1,839 @@
+serviceAccount:
+  create: false
+  # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+  name: infra-ci-jenkins-io-controller
+serviceAccountAgent:
+  create: false
+rbac:
+  create: true
+  readSecrets: true
+persistence:
+  enabled: true
+  # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+  existingClaim: infra-ci-jenkins-io-data
+agent:
+  componentName: "agent"
+networkPolicy:
+  enabled: true
+  internalAgents:
+    allowed: true
+    namespaceLabels:
+      name: "infra-ci-jenkins-io"
+controller:
+  podLabels:
+    "azure.workload.identity/use": "true"
+  podSecurityContextOverride:
+    runAsUser: 1000
+    runAsNonRoot: true
+    supplementalGroups: [1000]
+    # fsGroup: 1000 # Uncomment once for new volumes
+    # fsGroupChangePolicy: OnRootMismatch # Uncomment once for new volumes
+  probes:
+    startupProbe:
+      initialDelaySeconds: 60
+    livenessProbe:
+      initialDelaySeconds: 60
+    readinessProbe:
+      initialDelaySeconds: 60
+  image:
+    registry: dockerhubmirror.azurecr.io
+    repository: jenkinsciinfra/jenkins-infraci
+    tag: 3.10.56-2.566
+    pullPolicy: IfNotPresent
+  nodeSelector:
+    kubernetes.io/os: linux
+    kubernetes.azure.com/agentpool: infracictrl
+    kubernetes.io/arch: arm64
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
+    - key: "jenkins"
+      operator: "Equal"
+      value: "infra.ci.jenkins.io"
+      effect: "NoSchedule"
+    - key: "jenkins-component"
+      operator: "Equal"
+      value: "controller"
+      effect: "NoSchedule"
+  resources:
+    limits:
+      cpu: "2"
+      memory: "8Gi"
+    requests:
+      cpu: "2"
+      memory: "8Gi"
+  testEnabled: false
+  # This setting deletes the content of $ JENKINS_HOME/plugins on each pod restart to ensure only container image plugins are used
+  overwritePlugins: true
+  javaOpts: >-
+    -XshowSettings:vm -XX:+UseStringDeduplication -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:+AlwaysPreTouch -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp/ -XX:+UseG1GC -Djava.net.preferIPv4Stack=true
+  JCasC:
+    enabled: true
+    defaultConfig: false
+    configScripts:
+      credentials: |
+        credentials:
+          system:
+            domainCredentials:
+              - credentials:
+                - gitHubApp:
+                    appID: "${GITHUB_APP_ID}"
+                    description: "GitHub App for infra.ci.jenkins.io"
+                    id: "github-app-infra"
+                    privateKey: "${GITHUB_APP_PRIVATE_KEY}"
+                    scope: GLOBAL
+                    repositoryAccessStrategy:
+                      specificRepositories:
+                        owner: "jenkins-infra"
+                - azureImds:
+                    azureEnvName: "Azure"
+                    description: "infra.ci.jenkins.io's Azure Managed Identity used for spawning\
+                      \ agents in the CDF subscription"
+                    id: "azure-jenkins-cdf-managed-identity"
+                    scope: SYSTEM
+                    subscriptionId: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+                - azureImds:
+                    azureEnvName: "Azure"
+                    description: "infra.ci.jenkins.io's Azure Managed Identity used for spawning agents in Jenkins Sponsored subscription"
+                    id: "azure-jenkins-sponsored-managed-identity"
+                    scope: SYSTEM
+                    subscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
+                - usernamePassword:
+                    description: "Credentials to access the azure agents VMs"
+                    id: "azure-login"
+                    password: "${AZURE_LOGIN_VM_PASS}"
+                    scope: SYSTEM
+                    username: "${AZURE_LOGIN_VM_USER}"
+                - string:
+                    description: "Token of the Service Account 'jenkins-agent' on the Kubernetes cluster 'infraci.jenkins.io-agents-1'"
+                    id: "infraci.jenkins.io-agents-1-jenkins-agent-sa-token"
+                    scope: SYSTEM
+                    secret: "${INFRACIJENKINSIO_AGENTS_1_TOKEN}"
+      agent-settings: |
+        jenkins:
+          numExecutors: 0
+          updateCenter:
+            sites:
+              - id: "default"
+                url: "https://azure.updates.jenkins.io/update-center.json"
+          clouds:
+            - kubernetes:
+                containerCapStr: "100"
+                credentialsId: "infraci.jenkins.io-agents-1-jenkins-agent-sa-token"
+                serverCertificate: "${decodeBase64:${INFRACIJENKINSIO_AGENTS_1_CACRT}}"
+                # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+                serverUrl: "https://infracijenkinsioagents1-wzkg3k2f.hcp.eastus2.azmk8s.io:443"
+                maxRequestsPerHostStr: "300"
+                webSocket: true
+                name: "kubernetes_infracijioagents1"
+                namespace: "jenkins-infra-agents"
+                podLabels:
+                  - key: "jenkins"
+                    value: "agent"
+                  - key: "azure.workload.identity/use"
+                    value: "true"
+                podRetention: "Never"
+                templates:
+                  - name: jnlp-linux-amd64
+                    nodeSelector: "kubernetes.io/arch=amd64"
+                    containers:
+                      - name: jnlp
+                        image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.105.0
+                        command: "/usr/local/bin/jenkins-agent"
+                        args: ""
+                        envVars:
+                        - envVar:
+                            key: "JENKINS_JAVA_BIN"
+                            value: "/opt/jdk-25/bin/java"
+                        - envVar:
+                            key: "JAVA_HOME"
+                            value: "/opt/jdk-25"
+                        - envVar:
+                            key: "JENKINS_JAVA_OPTS"
+                            value: "-XX:+PrintCommandLineFlags"
+                        - envVar:
+                            key: "PATH"
+                            value: "~/.asdf/shims:~/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
+                        resourceLimitMemory: "8G"
+                        resourceRequestCpu: "500m"
+                        resourceRequestMemory: "1G"
+                        alwaysPullImage: true
+                    label: "linux jnlp-linux jnlp-linux-amd64 container kubernetes node ruby webbuilder"
+                    # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+                    serviceAccount: "jenkins-infra-agent"
+                    yamlMergeStrategy: "merge"
+                    yaml: |-
+                      apiVersion: v1
+                      kind: Pod
+                      spec:
+                        tolerations:
+                        - key: "jenkins"
+                          operator: "Equal"
+                          value: "infra.ci.jenkins.io"
+                          effect: "NoSchedule"
+                        - key: "infra.ci.jenkins.io/agents"
+                          operator: "Equal"
+                          value: "true"
+                          effect: "NoSchedule"
+                        - key: "kubernetes.azure.com/scalesetpriority"
+                          operator: "Equal"
+                          value: "spot"
+                          effect: "NoSchedule"
+                  - name: jnlp-linux-arm64
+                    nodeSelector: "kubernetes.io/arch=arm64"
+                    containers:
+                      - name: jnlp
+                        image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.105.0
+                        command: "/usr/local/bin/jenkins-agent"
+                        args: ""
+                        envVars:
+                        - envVar:
+                            key: "JENKINS_JAVA_BIN"
+                            value: "/opt/jdk-25/bin/java"
+                        - envVar:
+                            key: "JAVA_HOME"
+                            value: "/opt/jdk-25"
+                        resourceLimitMemory: "2048Mi"
+                        resourceRequestCpu: "500m"
+                        resourceRequestMemory: "512Mi"
+                        alwaysPullImage: true
+                    label: "jnlp-linux-arm64"
+                    # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
+                    serviceAccount: "jenkins-infra-agent"
+                    yamlMergeStrategy: "merge"
+                    yaml: |-
+                      apiVersion: v1
+                      kind: Pod
+                      spec:
+                        tolerations:
+                        - key: "jenkins"
+                          operator: "Equal"
+                          value: "infra.ci.jenkins.io"
+                          effect: "NoSchedule"
+                        - key: "kubernetes.io/arch"
+                          operator: "Equal"
+                          value: "arm64"
+                          effect: "NoSchedule"
+                        - key: "infra.ci.jenkins.io/agents"
+                          operator: "Equal"
+                          value: "true"
+                          effect: "NoSchedule"
+                        - key: "kubernetes.azure.com/scalesetpriority"
+                          operator: "Equal"
+                          value: "spot"
+                          effect: "NoSchedule"
+            - azureVM:
+                azureCredentialsId: "azure-jenkins-sponsored-managed-identity"
+                name: "azure-vms-jenkins-sponsored"
+                deploymentTimeout: 1200
+                existingResourceGroupName: "infra-ci-jenkins-io-ephemeral-agents"
+                maxVirtualMachinesLimit: 50
+                resourceGroupReferenceType: "existing"
+                vmTemplates:
+                - launcher: "ssh"
+                  agentWorkspace: "/home/jenkins"
+                  credentialsId: "azure-login"
+                  diskType: "managed"
+                  doNotUseMachineIfInitFails: false
+                  encryptionAtHost: true
+                  ephemeralOSDisk: true
+                  executeInitScriptAsRoot: true
+                  imageReference:
+                    galleryImageDefinition: "jenkins-agent-ubuntu-22.04-amd64"
+                    galleryImageVersion: "2.105.0"
+                    galleryName: "prod_packer_images"
+                    galleryResourceGroup: "prod-packer-images"
+                    gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
+                  imageTopLevelType: "advanced"
+                  initScript: |-
+                    #!/bin/bash
+                    set -eux
+                    echo "START CLOUDINIT"
+                    # Setup Datadog service
+                    (
+                      systemctl stop datadog-agent.service
+                      mkdir -p /var/log/datadog /etc/datadog-agent
+                      sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                      echo "tags: [\"jenkins_controller:infra.ci.jenkins.io\", \"jenkins_agent_type:ephemeral_azurevm\"]" >> /etc/datadog-agent/datadog.yaml
+                      sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+                      chmod 640 /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /var/log/datadog
+                      chmod 770 /var/log/datadog
+                      systemctl daemon-reload
+                      systemctl enable datadog-agent.service
+                      systemctl start datadog-agent.service
+                    ) 2>&1 | tee /var/log/agent-init-datadog.log
+                    # Setup Docker Engine
+                    mkdir -p /etc/docker
+                    cat <<EOF >/etc/docker/daemon.json
+                    {
+                      "registry-mirrors": ["https://dockerhubmirror.azurecr.io"]
+                    }
+                    EOF
+                    systemctl daemon-reload
+                    systemctl restart docker
+                    export DEFAULT_JDK=/opt/jdk-21
+                    update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
+                    rm -f /etc/sudoers.d/90-cloud-init-users
+                    echo "END CLOUDINIT"
+                  javaPath: "/opt/jdk-25/bin/java"
+                  jvmOptions: "-XX:+PrintCommandLineFlags"
+                  labels: "linux-amd64 linux-amd64-docker"
+                  location: "East US 2"
+                  maxVirtualMachinesLimit: 50
+                  existingStorageAccountName: "infraciagentssponso"
+                  noOfParallelJobs: 1
+                  osDiskSize: 150
+                  osDiskStorageAccountType: "Standard_LRS"
+                  osType: "Linux"
+                  retentionStrategy: "azureVMCloudOnce"
+                  spotInstance: false
+                  storageAccountNameReferenceType: "existing"
+                  storageAccountType: "Standard_LRS"
+                  subnetName: "infra-ci-jenkins-io-sponsored-vnet-ephemeral-agents"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 LTS x86_64 machine"
+                  templateName: "ubuntu-22"
+                  trustedLaunch: true
+                  enableUAMI: true
+                  uamiID: "/subscriptions/1e7d5219-acbc-4495-8629-bdbb22e9b3ed/resourceGroups/infra-ci-jenkins-io-sponsored-commons/providers/Microsoft.ManagedIdentity/userAssignedIdentities/infra-ci-jenkins-io-sponsored-agents"
+                  usageMode: NORMAL
+                  usePrivateIP: true
+                  virtualMachineSize: "Standard_D4ads_v7" # 4 vCPUS / 16 Gb / Max 150 Gb local storage
+                  virtualNetworkName: "infra-ci-jenkins-io-sponsored-vnet"
+                  virtualNetworkResourceGroupName: "infra-ci-jenkins-io-sponsored"
+                - launcher: "ssh"
+                  agentWorkspace: "/home/jenkins"
+                  credentialsId: "azure-login"
+                  diskType: "managed"
+                  doNotUseMachineIfInitFails: false
+                  encryptionAtHost: true
+                  ephemeralOSDisk: true
+                  executeInitScriptAsRoot: true
+                  imageReference:
+                    galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
+                    galleryImageVersion: "2.105.0"
+                    galleryName: "prod_packer_images"
+                    galleryResourceGroup: "prod-packer-images"
+                    gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
+                  imageTopLevelType: "advanced"
+                  initScript: |-
+                    #!/bin/bash
+                    set -eux
+                    echo "START CLOUDINIT"
+                    # Setup Datadog service
+                    (
+                      systemctl stop datadog-agent.service
+                      mkdir -p /var/log/datadog /etc/datadog-agent
+                      sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                      echo "tags: [\"jenkins_controller:infra.ci.jenkins.io\", \"jenkins_agent_type:ephemeral_azurevm\"]" >> /etc/datadog-agent/datadog.yaml
+                      sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+                      chmod 640 /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /var/log/datadog
+                      chmod 770 /var/log/datadog
+                      systemctl daemon-reload
+                      systemctl enable datadog-agent.service
+                      systemctl start datadog-agent.service
+                    ) 2>&1 | tee /var/log/agent-init-datadog.log
+                    # Setup Docker Engine
+                    mkdir -p /etc/docker
+                    cat <<EOF >/etc/docker/daemon.json
+                    {
+                      "registry-mirrors": ["https://dockerhubmirror.azurecr.io"]
+                    }
+                    EOF
+                    systemctl daemon-reload
+                    systemctl restart docker
+                    export DEFAULT_JDK=/opt/jdk-21
+                    update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
+                    rm -f /etc/sudoers.d/90-cloud-init-users
+                    echo "END CLOUDINIT"
+                  javaPath: "/opt/jdk-25/bin/java"
+                  jvmOptions: "-XX:+PrintCommandLineFlags"
+                  labels: "linux-arm64 linux-arm64-docker arm64linux jdk21 maven-21 ubuntu-22-arm64 ubuntu-arm64"
+                  location: "East US 2"
+                  maxVirtualMachinesLimit: 50
+                  existingStorageAccountName: "infraciagentssponso"
+                  noOfParallelJobs: 1
+                  osDiskSize: 100 # https://github.com/jenkins-infra/helpdesk/issues/3812
+                  osDiskStorageAccountType: "Standard_LRS"
+                  osType: "Linux"
+                  retentionStrategy: "azureVMCloudOnce"
+                  spotInstance: false
+                  storageAccountNameReferenceType: "existing"
+                  storageAccountType: "Standard_LRS"
+                  subnetName: "infra-ci-jenkins-io-sponsored-vnet-ephemeral-agents"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 LTS arm64 machine"
+                  templateName: "ubuntu-22-arm64"
+                  trustedLaunch: true
+                  enableUAMI: true
+                  uamiID: "/subscriptions/1e7d5219-acbc-4495-8629-bdbb22e9b3ed/resourceGroups/infra-ci-jenkins-io-sponsored-commons/providers/Microsoft.ManagedIdentity/userAssignedIdentities/infra-ci-jenkins-io-sponsored-agents"
+                  usageMode: NORMAL
+                  usePrivateIP: true
+                  virtualMachineSize: "Standard_D4pds_v6" # 4 vCPUS / 16 Gb / Max 100 Gb OsCacheDisk local storage (150 temp)
+                  virtualNetworkName: "infra-ci-jenkins-io-sponsored-vnet"
+                  virtualNetworkResourceGroupName: "infra-ci-jenkins-io-sponsored"
+                - launcher: "ssh"
+                  agentWorkspace: "/home/jenkins"
+                  credentialsId: "azure-login"
+                  diskType: "managed"
+                  doNotUseMachineIfInitFails: false
+                  encryptionAtHost: true
+                  ephemeralOSDisk: true
+                  executeInitScriptAsRoot: true
+                  imageReference:
+                    galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
+                    galleryImageVersion: "2.105.0"
+                    galleryName: "prod_packer_images"
+                    galleryResourceGroup: "prod-packer-images"
+                    gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
+                  imageTopLevelType: "advanced"
+                  initScript: |-
+                    #!/bin/bash
+                    set -eux
+                    echo "START CLOUDINIT"
+                    # Setup Datadog service
+                    (
+                      systemctl stop datadog-agent.service
+                      mkdir -p /var/log/datadog /etc/datadog-agent
+                      sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                      echo "tags: [\"jenkins_controller:infra.ci.jenkins.io\", \"jenkins_agent_type:ephemeral_azurevm\"]" >> /etc/datadog-agent/datadog.yaml
+                      sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+                      chmod 640 /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /var/log/datadog
+                      chmod 770 /var/log/datadog
+                      systemctl daemon-reload
+                      systemctl enable datadog-agent.service
+                      systemctl start datadog-agent.service
+                    ) 2>&1 | tee /var/log/agent-init-datadog.log
+                    # Setup Docker Engine
+                    mkdir -p /etc/docker
+                    cat <<EOF >/etc/docker/daemon.json
+                    {
+                      "registry-mirrors": ["https://dockerhubmirror.azurecr.io"]
+                    }
+                    EOF
+                    systemctl daemon-reload
+                    systemctl restart docker
+                    export DEFAULT_JDK=/opt/jdk-17
+                    update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
+                    rm -f /etc/sudoers.d/90-cloud-init-users
+                    echo "END CLOUDINIT"
+                  javaPath: "/opt/jdk-25/bin/java"
+                  jvmOptions: "-XX:+PrintCommandLineFlags"
+                  labels: "linux-arm64-maven-17 jdk17 maven-17 ubuntu-22-arm64-maven-17 ubuntu-arm64-maven-17"
+                  location: "East US 2"
+                  maxVirtualMachinesLimit: 50
+                  existingStorageAccountName: "infraciagentssponso"
+                  noOfParallelJobs: 1
+                  osDiskSize: 100 # https://github.com/jenkins-infra/helpdesk/issues/3812
+                  osDiskStorageAccountType: "Standard_LRS"
+                  osType: "Linux"
+                  retentionStrategy: "azureVMCloudOnce"
+                  spotInstance: false
+                  storageAccountNameReferenceType: "existing"
+                  storageAccountType: "Standard_LRS"
+                  subnetName: "infra-ci-jenkins-io-sponsored-vnet-ephemeral-agents"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-17 LTS arm64 machine"
+                  templateName: "ubuntu-22-arm64-maven-17"
+                  trustedLaunch: true
+                  enableUAMI: true
+                  uamiID: "/subscriptions/1e7d5219-acbc-4495-8629-bdbb22e9b3ed/resourceGroups/infra-ci-jenkins-io-sponsored-commons/providers/Microsoft.ManagedIdentity/userAssignedIdentities/infra-ci-jenkins-io-sponsored-agents"
+                  usageMode: NORMAL
+                  usePrivateIP: true
+                  virtualMachineSize: "Standard_D4pds_v6" # 4 vCPUS / 16 Gb / Max 100 Gb OsCacheDisk local storage (150 temp)
+                  virtualNetworkName: "infra-ci-jenkins-io-sponsored-vnet"
+                  virtualNetworkResourceGroupName: "infra-ci-jenkins-io-sponsored"
+                - launcher: "ssh"
+                  agentWorkspace: "/home/jenkins"
+                  credentialsId: "azure-login"
+                  diskType: "managed"
+                  doNotUseMachineIfInitFails: false
+                  encryptionAtHost: true
+                  ephemeralOSDisk: true
+                  executeInitScriptAsRoot: true
+                  imageReference:
+                    galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
+                    galleryImageVersion: "2.105.0"
+                    galleryName: "prod_packer_images"
+                    galleryResourceGroup: "prod-packer-images"
+                    gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
+                  imageTopLevelType: "advanced"
+                  initScript: |-
+                    #!/bin/bash
+                    set -eux
+                    echo "START CLOUDINIT"
+                    # Setup Datadog service
+                    (
+                      systemctl stop datadog-agent.service
+                      mkdir -p /var/log/datadog /etc/datadog-agent
+                      sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                      echo "tags: [\"jenkins_controller:infra.ci.jenkins.io\", \"jenkins_agent_type:ephemeral_azurevm\"]" >> /etc/datadog-agent/datadog.yaml
+                      sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+                      chmod 640 /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /var/log/datadog
+                      chmod 770 /var/log/datadog
+                      systemctl daemon-reload
+                      systemctl enable datadog-agent.service
+                      systemctl start datadog-agent.service
+                    ) 2>&1 | tee /var/log/agent-init-datadog.log
+                    # Setup Docker Engine
+                    mkdir -p /etc/docker
+                    cat <<EOF >/etc/docker/daemon.json
+                    {
+                      "registry-mirrors": ["https://dockerhubmirror.azurecr.io"]
+                    }
+                    EOF
+                    systemctl daemon-reload
+                    systemctl restart docker
+                    export DEFAULT_JDK=/opt/jdk-21
+                    update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
+                    rm -f /etc/sudoers.d/90-cloud-init-users
+                    echo "END CLOUDINIT"
+                  javaPath: "/opt/jdk-25/bin/java"
+                  jvmOptions: "-XX:+PrintCommandLineFlags"
+                  labels: "linux-arm64-maven-21 jdk21 maven-21 ubuntu-22-arm64-maven-21 ubuntu-arm64-maven-21"
+                  location: "East US 2"
+                  maxVirtualMachinesLimit: 50
+                  existingStorageAccountName: "infraciagentssponso"
+                  noOfParallelJobs: 1
+                  osDiskSize: 100 # https://github.com/jenkins-infra/helpdesk/issues/3812
+                  osDiskStorageAccountType: "Standard_LRS"
+                  osType: "Linux"
+                  retentionStrategy: "azureVMCloudOnce"
+                  spotInstance: false
+                  storageAccountNameReferenceType: "existing"
+                  storageAccountType: "Standard_LRS"
+                  subnetName: "infra-ci-jenkins-io-sponsored-vnet-ephemeral-agents"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-21 LTS arm64 machine"
+                  templateName: "ubuntu-22-arm64-maven-21"
+                  trustedLaunch: true
+                  enableUAMI: true
+                  uamiID: "/subscriptions/1e7d5219-acbc-4495-8629-bdbb22e9b3ed/resourceGroups/infra-ci-jenkins-io-sponsored-commons/providers/Microsoft.ManagedIdentity/userAssignedIdentities/infra-ci-jenkins-io-sponsored-agents"
+                  usageMode: NORMAL
+                  usePrivateIP: true
+                  virtualMachineSize: "Standard_D4pds_v6" # 4 vCPUS / 16 Gb / Max 100 Gb OsCacheDisk local storage (150 temp)
+                  virtualNetworkName: "infra-ci-jenkins-io-sponsored-vnet"
+                  virtualNetworkResourceGroupName: "infra-ci-jenkins-io-sponsored"
+                - launcher: "ssh"
+                  agentWorkspace: "/home/jenkins"
+                  credentialsId: "azure-login"
+                  diskType: "managed"
+                  doNotUseMachineIfInitFails: false
+                  encryptionAtHost: true
+                  ephemeralOSDisk: true
+                  executeInitScriptAsRoot: true
+                  imageReference:
+                    galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
+                    galleryImageVersion: "2.105.0"
+                    galleryName: "prod_packer_images"
+                    galleryResourceGroup: "prod-packer-images"
+                    gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
+                  imageTopLevelType: "advanced"
+                  initScript: |-
+                    #!/bin/bash
+                    set -eux
+                    echo "START CLOUDINIT"
+                    # Setup Datadog service
+                    (
+                      systemctl stop datadog-agent.service
+                      mkdir -p /var/log/datadog /etc/datadog-agent
+                      sed 's/api_key:.*/api_key: ${JENKINS_CI_DATADOG_API_KEY}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+                      echo "tags: [\"jenkins_controller:infra.ci.jenkins.io\", \"jenkins_agent_type:ephemeral_azurevm\"]" >> /etc/datadog-agent/datadog.yaml
+                      sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+                      chmod 640 /etc/datadog-agent/datadog.yaml
+                      chown dd-agent:dd-agent /var/log/datadog
+                      chmod 770 /var/log/datadog
+                      systemctl daemon-reload
+                      systemctl enable datadog-agent.service
+                      systemctl start datadog-agent.service
+                    ) 2>&1 | tee /var/log/agent-init-datadog.log
+                    # Setup Docker Engine
+                    mkdir -p /etc/docker
+                    cat <<EOF >/etc/docker/daemon.json
+                    {
+                      "registry-mirrors": ["https://dockerhubmirror.azurecr.io"]
+                    }
+                    EOF
+                    systemctl daemon-reload
+                    systemctl restart docker
+                    export DEFAULT_JDK=/opt/jdk-21
+                    update-alternatives --install /usr/bin/java java "^${DEFAULT_JDK}/bin/java" 2000
+                    echo "JAVA_HOME=^${DEFAULT_JDK}" >> /etc/environment
+                    rm -f /etc/sudoers.d/90-cloud-init-users
+                    echo "END CLOUDINIT"
+                  javaPath: "/opt/jdk-25/bin/java"
+                  jvmOptions: "-XX:+PrintCommandLineFlags"
+                  labels: "ubuntu-22-arm64-maven-21-nonspot linux-arm64-maven-21-nonspot linux-arm64-nonspot"
+                  location: "East US 2"
+                  maxVirtualMachinesLimit: 50
+                  existingStorageAccountName: "infraciagentssponso"
+                  noOfParallelJobs: 1
+                  osDiskSize: 100 # https://github.com/jenkins-infra/helpdesk/issues/3812
+                  osDiskStorageAccountType: "Standard_LRS"
+                  osType: "Linux"
+                  retentionStrategy: "azureVMCloudOnce"
+                  spotInstance: false
+                  storageAccountNameReferenceType: "existing"
+                  storageAccountType: "Standard_LRS"
+                  subnetName: "infra-ci-jenkins-io-sponsored-vnet-ephemeral-agents"
+                  templateDesc: "Dynamically provisioned Ubuntu 22.04 maven-21 LTS arm64 machine nonspot"
+                  templateName: "ubuntu-22-arm64-maven-21-nonspot"
+                  trustedLaunch: true
+                  enableUAMI: true
+                  uamiID: "/subscriptions/1e7d5219-acbc-4495-8629-bdbb22e9b3ed/resourceGroups/infra-ci-jenkins-io-sponsored-commons/providers/Microsoft.ManagedIdentity/userAssignedIdentities/infra-ci-jenkins-io-sponsored-agents"
+                  usageMode: NORMAL
+                  usePrivateIP: true
+                  virtualMachineSize: "Standard_D4pds_v6" # 4 vCPUS / 16 Gb / Max 100 Gb OsCacheDisk local storage (150 temp)
+                  virtualNetworkName: "infra-ci-jenkins-io-sponsored-vnet"
+                  virtualNetworkResourceGroupName: "infra-ci-jenkins-io-sponsored"
+      security: |
+        security:
+          contentSecurityPolicy:
+            enforce: true
+          scriptApproval:
+            approvedSignatures:
+              - "method org.jenkinsci.plugins.workflow.steps.FlowInterruptedException getCauses"
+              - "new java.lang.RuntimeException java.lang.Throwable"
+          gitHostKeyVerificationConfiguration:
+            sshHostKeyVerificationStrategy:
+              manuallyProvidedKeyVerificationStrategy:
+                approvedHostKeys: "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+      ldap-settings: |
+        jenkins:
+          securityRealm:
+            ldap:
+              configurations:
+                - server: "${LDAP_SERVER}"
+                  rootDN: "${LDAP_ROOT_DN}"
+                  managerDN: "${LDAP_MANAGER_DN}"
+                  managerPasswordSecret: "${LDAP_MANAGER_PASSWORD}"
+                  mailAddressAttributeName: "mail"
+                  userSearch: cn={0}
+                  userSearchBase: "ou=people"
+                  groupSearchBase: "ou=groups"
+              disableMailAddressResolver: false
+              groupIdStrategy: "caseInsensitive"
+              userIdStrategy: "caseInsensitive"
+              cache:
+                size: 100
+                ttl: 300
+      advisor-settings: |
+        jenkins:
+          disabledAdministrativeMonitors:
+            - com.cloudbees.jenkins.plugins.advisor.Reminder
+        advisor:
+          acceptToS: true
+          ccs:
+          - "damien.duportal@gmail.com"
+          email: "jenkins-infra-team@googlegroups.com"
+          excludedComponents:
+            - "ItemsContent"
+            - "GCLogs"
+            - "Agents"
+            - "RootCAs"
+            - "SlaveLogs"
+            - "HeapUsageHistogram"
+          nagDisabled: true
+      jenkins-url-and-resource-root: |
+        unclassified:
+          location:
+            url: "https://infra.ci.jenkins.io"
+          resourceRoot:
+            url: "https://assets.infra.ci.jenkins.io"
+      pipeline-library: |
+        unclassified:
+          globalLibraries:
+            libraries:
+            - cachingConfiguration:
+                excludedVersionsStr: "pull/"
+                refreshTimeMinutes: 180
+              defaultVersion: "master"
+              implicit: true
+              includeInChangesets: false
+              name: "pipeline-library"
+              retriever:
+                modernSCM:
+                  libraryPath: "./"
+                  scm:
+                    gitSource:
+                      remote: "https://github.com/jenkins-infra/pipeline-library"
+                      traits:
+                      - "gitBranchDiscovery"
+                      - discoverOtherRefs:
+                          ref: "pull/*"
+                      - headWildcardFilter:
+                          includes: "*"
+      matrix-settings: |
+        jenkins:
+          authorizationStrategy:
+            globalMatrix:
+              entries:
+              - group:
+                  name: "admins"
+                  permissions:
+                  - "Overall/Administer"
+              - group:
+                  name: "authenticated"
+                  permissions:
+                  - "Job/Build"
+                  - "Job/ExtendedRead"
+                  - "Job/Read"
+                  - "Overall/Read"
+                  - "Overall/SystemRead"
+              - group:
+                  name: "jenkins-admins"
+                  permissions:
+                  - "Overall/Administer"
+      pipeline-settings: |
+        unclassified:
+          timestamper:
+            allPipelines: true
+          shell:
+            shell: "/bin/bash"
+      system-settings: |
+        unclassified:
+          gitHubConfiguration:
+            apiRateLimitChecker: NoThrottle
+          lockableResourcesManager:
+            declaredResources:
+            - description: "first entry for packer image builder dev"
+              labels: "dev-packerimage"
+              name: "dev-1"
+              reservedBy: "PackerImages"
+            - description: "second entry for packer image builder dev"
+              labels: "dev-packerimage"
+              name: "dev-2"
+              reservedBy: "PackerImages"
+            - description: "third entry for packer image builder dev"
+              labels: "dev-packerimage"
+              name: "dev-3"
+              reservedBy: "PackerImages"
+            - description: "fourth entry for packer image builder dev"
+              labels: "dev-packerimage"
+              name: "dev-4"
+              reservedBy: "PackerImages"
+            - description: "fifh entry for packer image builder dev"
+              labels: "dev-packerimage"
+              name: "dev-5"
+              reservedBy: "PackerImages"
+            - description: "first entry for packer image builder staging"
+              labels: "staging-packerimage"
+              name: "staging-1"
+              reservedBy: "PackerImages"
+            - description: "first entry for packer image builder prod"
+              labels: "prod-packerimage"
+              name: "prod-1"
+              reservedBy: "PackerImages"
+          defaultFolderConfiguration:
+            # Keep healthMetrics an empty list to ensure weather is disabled
+            healthMetrics: []
+        jenkins:
+          quietPeriod: 0 # No need to wait between build scheduling
+          disabledAdministrativeMonitors:
+            - "jenkins.security.QueueItemAuthenticatorMonitor"
+        appearance:
+          pipelineGraphView:
+            showGraphOnBuildPage: true
+            showGraphOnJobPage: true
+      tools-config: |
+        tool:
+          git:
+            installations:
+            - home: "git"
+              name: "git-native"
+            - name: "jgit"
+          jdk:
+            installations:
+            - name: "jdk21"
+              properties:
+              - installSource:
+                  installers:
+                  - command:
+                      command: "echo /opt/jdk-21"
+                      label: "(linux && amd64) || linux-amd64 || jdk21 || jdk-21 || maven-21"
+                      toolHome: "/opt/jdk-21"
+                  - command:
+                      command: "echo /opt/jdk-21"
+                      label: "(linux && arm64) || linux-arm64"
+                      toolHome: "/opt/jdk-21"
+                  - command:
+                      command: "echo /opt/jdk-21"
+                      label: "s390x || s390xdocker"
+                      toolHome: "/opt/jdk-21"
+            - name: "jdk25"
+              properties:
+              - installSource:
+                  installers:
+                  - command:
+                      command: "echo /opt/jdk-25"
+                      label: "(linux && amd64) || linux-amd64 || jdk25 || jdk-25 || maven-25"
+                      toolHome: "/opt/jdk-25"
+                  - command:
+                      command: "echo /opt/jdk-25"
+                      label: "(linux && arm64) || linux-arm64"
+                      toolHome: "/opt/jdk-25"
+                  - command:
+                      command: "echo /opt/jdk-25"
+                      label: "s390x || s390xdocker"
+                      toolHome: "/opt/jdk-25"
+          maven:
+            installations:
+            - name: "mvn"
+              properties:
+              - installSource:
+                  installers:
+                  - maven:
+                      id: "3.9.16"
+      custom-header: |
+        appearance:
+          customHeader:
+            enabled: true
+            header: "logo"
+            headerColor:
+              backgroundColor: "linear-gradient(90deg, rgba(239,192,92,1) 0%, rgba(171,28,28,1) 100%);"
+              color: "white"
+            logo:
+              image:
+                logoUrl: "/userContent/logos/beekeeper.png"
+            logoText: "Jenkins Infra"
+      default-notification-url: |
+        unclassified:
+          defaultDisplayUrlProvider:
+            providerId: "org.jenkinsci.plugins.displayurlapi.ClassicDisplayURLProvider"
+  installPlugins: false
+  ingress:
+    enabled: true
+    hostName: infra.ci.jenkins.io
+    resourceRootUrl: assets.infra.ci.jenkins.io
+    annotations:
+      "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+      "nginx.ingress.kubernetes.io/proxy-body-size": "500m"
+    ingressClassName: private-nginx
+    tls:
+      - hosts:
+          - infra.ci.jenkins.io
+        secretName: infra.ci.jenkins.io-cert
+  secondaryingress:
+    enabled: true
+    paths:
+      - /github-webhook
+    hostName: infra-webhooks.ci.jenkins.io
+    ingressClassName: public-nginx
+    annotations:
+      "cert-manager.io/cluster-issuer": "letsencrypt-prod"
+      "nginx.ingress.kubernetes.io/ssl-redirect": "true"
+    tls:
+      - hosts:
+          - infra-webhooks.ci.jenkins.io
+        secretName: infra-webhooks.ci.jenkins.io-cert

--- a/config/privatek8s-sponsored/infra.ci.jenkins.io.yaml
+++ b/config/privatek8s-sponsored/infra.ci.jenkins.io.yaml
@@ -1,8 +1,10 @@
 serviceAccount:
+# Managed by Terraform to allow enabling Federated Identities
   create: false
   # TODO: track with updatecli from https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
   name: infra-ci-jenkins-io-controller
 serviceAccountAgent:
+  # Managed by Terraform to allow enabling Federated Identities
   create: false
 rbac:
   create: true
@@ -26,15 +28,15 @@ controller:
     runAsUser: 1000
     runAsNonRoot: true
     supplementalGroups: [1000]
-    # fsGroup: 1000 # Uncomment once for new volumes
-    # fsGroupChangePolicy: OnRootMismatch # Uncomment once for new volumes
-  probes:
-    startupProbe:
-      initialDelaySeconds: 60
-    livenessProbe:
-      initialDelaySeconds: 60
-    readinessProbe:
-      initialDelaySeconds: 60
+    fsGroup: 1000 # Uncomment once for new volumes
+    fsGroupChangePolicy: OnRootMismatch # Uncomment once for new volumes
+  # probes:
+  #   startupProbe:
+  #     initialDelaySeconds: 60
+  #   livenessProbe:
+  #     initialDelaySeconds: 60
+  #   readinessProbe:
+  #     initialDelaySeconds: 60
   image:
     registry: dockerhubmirror.azurecr.io
     repository: jenkinsciinfra/jenkins-infraci


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952

Same as #7749 but for infra.ci.jenkins.io: This PR initializes infra.ci.jenkins.io as an empty controller to ensure it can start in the new cluster, prior to verifying its "acceptance" test jobs passes.

As such it has the following properties which will be changed before production but after validations:

- Data disk is empty and new. As such it requires the AKS CSI driver to set up the permissions: fsgroup and associated configs are enabled (one time thing)
  - On production migration, we'll rely on the permissions from the `privatek8s` controller data disk
- No startup probes (for now)
- The `infra-ci-jenkins-io-jobs` release is also updated to get the latest setup of the acceptance test (from #7754 and #7755).

----

Note: Will need subsequent PR (one or many) before production to:
- Disable the fsgroup AKS CSI stuff
- Enable probes