### PR TITLE
fix(privatek8s-sponsored/release.ci) configuration fixes: use git for health job and send advisory to team mailing list

### DIFF
--- a/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
+++ b/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
@@ -206,35 +206,14 @@ controller:
                 branchSources {
                   branchSource {
                     source {
-                      github {
+                      git {
                         id('infra-agents-health')
-                        configuredByUrl(true)
-                        repositoryUrl('https://github.com/jenkins-infra/release')
-                        repoOwner('jenkins-infra')
-                        repository('release')
+                        remote('https://github.com/jenkins-infra/release')
                         traits {
-                          gitHubSCMSourceStatusChecksTrait {
-                            // Note: changing this name might have impact on github branch protections if they specify status names
-                            name('jenkins')
-                            skip(true)
-                            skipProgressUpdates(true)
-                            // If this option is checked, the notifications sent by the GitHub Branch Source Plugin will be disabled.
-                            skipNotifications(true)
-                            // Default value: false. Warning: risk of secret leak in console if the build fails
-                            // Please note that it only disable the detailed logs. If you really want no logs, then use "skip(false)' instead
-                            suppressLogs(true)
-                            unstableBuildNeutral(false)
-                          }
-                          gitHubBranchDiscovery {
-                            strategyId(1) // 1-only branches that are not pull requests
-                          }
-                          pruneStaleBranchTrait()
-                          // Select branches and tags to build based on these filters
-                          headWildcardFilterWithPR {
-                            includes('chore/helpdesk-5091') // only branches listed here
+                          gitBranchDiscovery()
+                          headWildcardFilter {
+                            includes('chore/helpdesk-5091')
                             excludes('')
-                            tagIncludes('*')
-                            tagExcludes('')
                           }
                         }
                       }

--- a/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
+++ b/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
@@ -439,7 +439,7 @@ controller:
           acceptToS: true
           ccs:
           - "damien.duportal@gmail.com"
-          email: "jenkins@oblak.com"
+          email: "jenkins-infra-team@googlegroups.com"
           excludedComponents:
             - "ItemsContent"
             - "GCLogs"


### PR DESCRIPTION
Fixup of #7757 to avoid GitHub API rate limit

Also a minor config along the way