### PR TITLE
fix(privatek8s-sponsored/release.ci): remove outdated trigger of `infra-agents-health` job definition

### DIFF
--- a/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
+++ b/config/privatek8s-sponsored/release.ci.jenkins.io.yaml
@@ -197,12 +197,6 @@ controller:
         jobs:
           - script: >
               multibranchPipelineJob('infra-agents-health') {
-                triggers {
-                  periodicFolderTrigger {
-                    interval('@daily')
-                  }
-                }
-
                 branchSources {
                   branchSource {
                     source {


### PR DESCRIPTION
This change removes the trigger from this job definition as its type changed from "Pipeline" to "Multibranch pipeline", thus that syntax doesn't work anymore.

Related:
- https://github.com/jenkins-infra/release/pull/909

Fixup of:
- https://github.com/jenkins-infra/kubernetes-management/pull/7757

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952