### PR TITLE
cleanup(privatek8s-sponsored/infra.ci) remove unused credentials on `docs.jenkins.io` job

### DIFF
--- a/config/privatek8s-sponsored/infra-ci-jenkins-io-jobs.yaml
+++ b/config/privatek8s-sponsored/infra-ci-jenkins-io-jobs.yaml
@@ -715,9 +715,6 @@ jobsDefinition:
             description: "docs.jenkins.io File Share Service Principal Writer"
             subscriptionId: "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
             tenant: "${JENKINSINFRA_AZURE_TENANT_ID}"
-          fastly-api-token-purge:
-            secret: "${FASTLY_API_TOKEN_PURGE}"
-            description: "Fastly API token used for purging CDN pages"
       gatsby-plugin-jenkins-layout:
         name: Gatsby plugin for standard Jenkins.io layout Production Deployment
         jenkinsfilePath: Jenkinsfile


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4911#issuecomment-4490026760