### PR TITLE
refactor(buildReportStalenessCheck): reconstruct build report URLs from job path and controller

### DIFF
--- a/config/publick8s/datadog_confd_checksd.yaml.gotmpl
+++ b/config/publick8s/datadog_confd_checksd.yaml.gotmpl
@@ -11,4 +11,12 @@ datadog:
     http_check.yaml: |-
 {{ readFile "./datadog_confd_checksd/http_check.yaml" | indent 6 }}
     buildReportStalenessCheck.yaml: |-
-{{ readFile "./datadog_confd_checksd/buildReportStalenessCheck.yaml" | indent 6 }}
+      init_config:
+
+      instances:
+{{- $cfg := readFile "./datadog_confd_checksd/buildReportStalenessCheck.yaml" | fromYaml }}
+{{- range $name, $job := $cfg.build_report_jobs }}
+        - controller: {{ $job.controller }}
+          job: {{ $job.job }}
+          threshold_minutes: {{ $job.threshold_minutes }}
+{{- end }}

--- a/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.py
+++ b/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.py
@@ -8,6 +8,7 @@ from urllib.error import URLError, HTTPError
 
 from datadog_checks.base.checks import AgentCheck
 
+BUILD_REPORTS_BASE = 'https://builds.reports.jenkins.io/build_status_reports'
 
 class BuildReportStaleness(AgentCheck):
     """
@@ -41,8 +42,11 @@ class BuildReportStaleness(AgentCheck):
         """
         controller = instance['controller']
         job = instance['job']
+        url = f"{BUILD_REPORTS_BASE}/{controller}/{job}/status.json"
         threshold_in_minutes = instance['threshold_minutes']
-        url = f"https://builds.reports.jenkins.io/build_status_reports/{controller}/{job}/status.json"
+        base_tags = [f"controller:{controller}"]
+
+        self.warning(f"BuildReportStaleness: {controller}")
 
         base_tags = [f"controller:{controller}"]
 

--- a/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.py
+++ b/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.py
@@ -39,9 +39,11 @@ class BuildReportStaleness(AgentCheck):
         """
             Datadog custom check
         """
-        url = instance['url']
-        controller = instance.get('controller', 'unknown')
-        threshold_in_minutes = instance['threshold_in_minutes']
+        controller = instance['controller']
+        job = instance['job']
+        threshold_in_minutes = instance['threshold_minutes']
+        url = f"https://builds.reports.jenkins.io/build_status_reports/{controller}/{job}/status.json"
+
         base_tags = [f"controller:{controller}"]
 
         self.warning(f"BuildReportStaleness: {controller}")

--- a/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
+++ b/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
@@ -3,14 +3,10 @@ init_config:
 instances:
   ## infra.ci.jenkins.io jobs
   - controller: infra.ci.jenkins.io
-    job: docker-jobs/docker-404/main
-    threshold_minutes: 1440
-    # TODO: restore 5 mins after jenkins-infra/helpdesk#2843
-    min_collection_interval: 60
-  - controller: infra.ci.jenkins.io
     job: acceptance-tests/acceptance-tests/check-agent-availability
     threshold_minutes: 1440
     min_collection_interval: 60
+  # TODO: restore 5 mins after jenkins-infra/helpdesk#2843
   - controller: infra.ci.jenkins.io
     job: kubernetes-jobs/kubernetes-management/main
     threshold_minutes: 1440

--- a/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
+++ b/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
@@ -2,72 +2,72 @@ init_config:
 
 instances:
   ## infra.ci.jenkins.io jobs
-  - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/docker-jobs/docker-404/main/status.json
-    controller: infra.ci.jenkins.io
-    threshold_in_minutes: 1440
+  - controller: infra.ci.jenkins.io
+    job: docker-jobs/docker-404/main
+    threshold_minutes: 1440
     # TODO: restore 5 mins after jenkins-infra/helpdesk#2843
     min_collection_interval: 60
-  - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/acceptance-tests/acceptance-tests/check-agent-availability/status.json
-    controller: infra.ci.jenkins.io
-    threshold_in_minutes: 1440
+  - controller: infra.ci.jenkins.io
+    job: acceptance-tests/acceptance-tests/check-agent-availability
+    threshold_minutes: 1440
     min_collection_interval: 60
-  - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/kubernetes-jobs/kubernetes-management/main/status.json
-    controller: infra.ci.jenkins.io
-    threshold_in_minutes: 1440
+  - controller: infra.ci.jenkins.io
+    job: kubernetes-jobs/kubernetes-management/main
+    threshold_minutes: 1440
     min_collection_interval: 60
-  - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/terraform-jobs/azure/main/status.json
-    controller: infra.ci.jenkins.io
-    threshold_in_minutes: 1440
+  - controller: infra.ci.jenkins.io
+    job: terraform-jobs/azure/main
+    threshold_minutes: 1440
     min_collection_interval: 60
-  - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/terraform-jobs/azure-net/main/status.json
-    controller: infra.ci.jenkins.io
-    threshold_in_minutes: 1440
+  - controller: infra.ci.jenkins.io
+    job: terraform-jobs/azure-net/main
+    threshold_minutes: 1440
     min_collection_interval: 60
-  - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/terraform-jobs/datadog/main/status.json
-    controller: infra.ci.jenkins.io
-    threshold_in_minutes: 1440
+  - controller: infra.ci.jenkins.io
+    job: terraform-jobs/datadog/main
+    threshold_minutes: 1440
     min_collection_interval: 60
-  - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/terraform-jobs/digitalocean/main/status.json
-    controller: infra.ci.jenkins.io
-    threshold_in_minutes: 1440
+  - controller: infra.ci.jenkins.io
+    job: terraform-jobs/digitalocean/main
+    threshold_minutes: 1440
     min_collection_interval: 60
-  - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/terraform-jobs/terraform-aws-sponsorship/main/status.json
-    controller: infra.ci.jenkins.io
-    threshold_in_minutes: 1440
+  - controller: infra.ci.jenkins.io
+    job: terraform-jobs/terraform-aws-sponsorship/main
+    threshold_minutes: 1440
     min_collection_interval: 60
   ## release.ci.jenkins.io jobs
-  - url: https://builds.reports.jenkins.io/build_status_reports/release.ci.jenkins.io/infra-agents-health/master/status.json
-    controller: release.ci.jenkins.io
-    threshold_in_minutes: 1440
+  - controller: release.ci.jenkins.io
+    job: infra-agents-health/master
+    threshold_minutes: 1440
     min_collection_interval: 60
   ## trusted.ci.jenkins.io jobs
-  - url: https://builds.reports.jenkins.io/build_status_reports/trusted.ci.jenkins.io/acceptance-tests-check-agent-availability/status.json
-    controller: trusted.ci.jenkins.io
-    threshold_in_minutes: 1440
+  - controller: trusted.ci.jenkins.io
+    job: acceptance-tests-check-agent-availability
+    threshold_minutes: 1440
     min_collection_interval: 60
-  - url: https://builds.reports.jenkins.io/build_status_reports/trusted.ci.jenkins.io/core-taglibs-report-generator/status.json
-    controller: trusted.ci.jenkins.io
-    threshold_in_minutes: 10080  # 1 week (1 build)
+  - controller: trusted.ci.jenkins.io
+    job: core-taglibs-report-generator
+    threshold_minutes: 10080  # 1 week (1 build)
     min_collection_interval: 60
-  - url: https://builds.reports.jenkins.io/build_status_reports/trusted.ci.jenkins.io/crawler/status.json
-    controller: trusted.ci.jenkins.io
-    threshold_in_minutes: 240  # 4 hours (1 build)
+  - controller: trusted.ci.jenkins.io
+    job: crawler
+    threshold_minutes: 240  # 4 hours (1 build)
     min_collection_interval: 60
-  - url: https://builds.reports.jenkins.io/build_status_reports/trusted.ci.jenkins.io/javadoc/status.json
-    controller: trusted.ci.jenkins.io
-    threshold_in_minutes: 10080  # 1 week (1 build)
+  - controller: trusted.ci.jenkins.io
+    job: javadoc
+    threshold_minutes: 10080  # 1 week (1 build)
     min_collection_interval: 60
-  - url: https://builds.reports.jenkins.io/build_status_reports/trusted.ci.jenkins.io/jenkins.io/status.json
-    controller: trusted.ci.jenkins.io
-    threshold_in_minutes: 60  # (2 builds)
+  - controller: trusted.ci.jenkins.io
+    job: jenkins.io
+    threshold_minutes: 60  # (2 builds)
     min_collection_interval: 60
-  - url: https://builds.reports.jenkins.io/build_status_reports/trusted.ci.jenkins.io/repository-permissions-updater/status.json
-    controller: trusted.ci.jenkins.io
-    threshold_in_minutes: 360  # (2 builds)
+  - controller: trusted.ci.jenkins.io
+    job: repository-permissions-updater
+    threshold_minutes: 360  # (2 builds)
     min_collection_interval: 60
-  - url: https://builds.reports.jenkins.io/build_status_reports/trusted.ci.jenkins.io/update_center/status.json
-    controller: trusted.ci.jenkins.io
-    threshold_in_minutes: 20  # (2 builds)
+  - controller: trusted.ci.jenkins.io
+    job: update_center
+    threshold_minutes: 20  # (2 builds)
     min_collection_interval: 60
   - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/website-production-jobs/docs.jenkins.io/main/status.json
     controller: infra.ci.jenkins.io

--- a/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
+++ b/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
@@ -1,75 +1,76 @@
-init_config:
-
-instances:
+build_report_jobs:
   ## infra.ci.jenkins.io jobs
-  - controller: infra.ci.jenkins.io
-    job: docker-jobs/docker-404/main
-    threshold_minutes: 1440
-    # TODO: restore 5 mins after jenkins-infra/helpdesk#2843
-    min_collection_interval: 60
-  - controller: infra.ci.jenkins.io
+  acceptance-tests-infra-ci:
+    controller: infra.ci.jenkins.io
     job: acceptance-tests/acceptance-tests/check-agent-availability
     threshold_minutes: 1440
-    min_collection_interval: 60
-  - controller: infra.ci.jenkins.io
+  kubernetes-management:
+    controller: infra.ci.jenkins.io
     job: kubernetes-jobs/kubernetes-management/main
     threshold_minutes: 1440
-    min_collection_interval: 60
-  - controller: infra.ci.jenkins.io
+  terraform-azure:
+    controller: infra.ci.jenkins.io
     job: terraform-jobs/azure/main
     threshold_minutes: 1440
-    min_collection_interval: 60
-  - controller: infra.ci.jenkins.io
+  terraform-azure-net:
+    controller: infra.ci.jenkins.io
     job: terraform-jobs/azure-net/main
     threshold_minutes: 1440
-    min_collection_interval: 60
-  - controller: infra.ci.jenkins.io
+  terraform-datadog:
+    controller: infra.ci.jenkins.io
     job: terraform-jobs/datadog/main
     threshold_minutes: 1440
-    min_collection_interval: 60
-  - controller: infra.ci.jenkins.io
+  terraform-digitalocean:
+    controller: infra.ci.jenkins.io
     job: terraform-jobs/digitalocean/main
     threshold_minutes: 1440
-    min_collection_interval: 60
-  - controller: infra.ci.jenkins.io
+  terraform-aws-sponsorship:
+    controller: infra.ci.jenkins.io
     job: terraform-jobs/terraform-aws-sponsorship/main
     threshold_minutes: 1440
-    min_collection_interval: 60
-  ## release.ci.jenkins.io jobs
-  - controller: release.ci.jenkins.io
-    job: infra-agents-health/master
+  docs-jenkins-io:
+    controller: infra.ci.jenkins.io
+    job: website-production-jobs/docs.jenkins.io/main
     threshold_minutes: 1440
-    min_collection_interval: 60
+  ## release.ci.jenkins.io jobs
+  acceptance-tests-release-ci:
+    controller: release.ci.jenkins.io
+    job: infra-agents-health/master
+    threshold_minutes: 1440  # 1 day (1 build)
   ## trusted.ci.jenkins.io jobs
-  - controller: trusted.ci.jenkins.io
+  acceptance-tests-trusted-ci:
+    controller: trusted.ci.jenkins.io
     job: acceptance-tests-check-agent-availability
     threshold_minutes: 1440
-    min_collection_interval: 60
-  - controller: trusted.ci.jenkins.io
+  core-taglibs-report-generator:
+    controller: trusted.ci.jenkins.io
     job: core-taglibs-report-generator
     threshold_minutes: 10080  # 1 week (1 build)
-    min_collection_interval: 60
-  - controller: trusted.ci.jenkins.io
+  crawler:
+    controller: trusted.ci.jenkins.io
     job: crawler
     threshold_minutes: 240  # 4 hours (1 build)
-    min_collection_interval: 60
-  - controller: trusted.ci.jenkins.io
+  javadoc:
+    controller: trusted.ci.jenkins.io
     job: javadoc
     threshold_minutes: 10080  # 1 week (1 build)
-    min_collection_interval: 60
-  - controller: trusted.ci.jenkins.io
+  jenkins-io:
+    controller: trusted.ci.jenkins.io
     job: jenkins.io
     threshold_minutes: 60  # (2 builds)
-    min_collection_interval: 60
-  - controller: trusted.ci.jenkins.io
+  repository-permissions-updater:
+    controller: trusted.ci.jenkins.io
     job: repository-permissions-updater
     threshold_minutes: 360  # (2 builds)
-    min_collection_interval: 60
-  - controller: trusted.ci.jenkins.io
+  update-center:
+    controller: trusted.ci.jenkins.io
     job: update_center
     threshold_minutes: 20  # (2 builds)
+<<<<<<< HEAD
     min_collection_interval: 60
   - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/website-production-jobs/docs.jenkins.io/main/status.json
     controller: infra.ci.jenkins.io
     threshold_in_minutes: 1440
     min_collection_interval: 60
+=======
+>>>>>>> fa055e40 (Refactor buildReportStalenessCheck to map-based job config)

--- a/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
+++ b/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
@@ -3,10 +3,14 @@ init_config:
 instances:
   ## infra.ci.jenkins.io jobs
   - controller: infra.ci.jenkins.io
+    job: docker-jobs/docker-404/main
+    threshold_minutes: 1440
+    # TODO: restore 5 mins after jenkins-infra/helpdesk#2843
+    min_collection_interval: 60
+  - controller: infra.ci.jenkins.io
     job: acceptance-tests/acceptance-tests/check-agent-availability
     threshold_minutes: 1440
     min_collection_interval: 60
-  # TODO: restore 5 mins after jenkins-infra/helpdesk#2843
   - controller: infra.ci.jenkins.io
     job: kubernetes-jobs/kubernetes-management/main
     threshold_minutes: 1440

--- a/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
+++ b/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
@@ -66,11 +66,3 @@ build_report_jobs:
     controller: trusted.ci.jenkins.io
     job: update_center
     threshold_minutes: 20  # (2 builds)
-<<<<<<< HEAD
-    min_collection_interval: 60
-  - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/website-production-jobs/docs.jenkins.io/main/status.json
-    controller: infra.ci.jenkins.io
-    threshold_in_minutes: 1440
-    min_collection_interval: 60
-=======
->>>>>>> fa055e40 (Refactor buildReportStalenessCheck to map-based job config)


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5135

Follow-up to #7778, refactoring `buildReportStalenessCheck` to converge the
config format between kubernetes-management and the datadog repo
(`build-report-jobs.yaml`). This is a prerequisite for auto-syncing jobs
between the two repos via updatecli.

## Changes

- `buildReportStalenessCheck.yaml`: Converted from an `instances:` list to a `build_report_jobs:` map keyed by job name, matching the format in the datadog repo. Each entry now uses `controller` + `job` instead of a full `url`, and `threshold_in_minutes` is renamed to `threshold_minutes`.
- `datadog_confd_checksd.yaml.gotmpl`: The template now parses the map (`fromYaml`) and renders it into the `instances:` list the Datadog Agent expects, via `range`.
- `buildReportStalenessCheck.py`: The report URL is reconstructed at runtimef rom `controller` + `job` instead of reading a hardcoded `url`, and the check now reads `threshold_minutes`.

## Testing

```bash
helmfile template -f ./clusters/publick8s.yaml -l name=datadog > after.yaml
```
