### PR TITLE
chore(infra.ci.jenkins.io): remove publick8s from kubernetes-management

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            values 'publick8s', 'privatek8s-sponsored', 'cijioagents2'
+            // values 'publick8s', 'privatek8s-sponsored', 'cijioagents2'
           }
         } // axes
         agent {

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,7 +27,7 @@ pipeline {
         axes {
           axis {
             name 'K8S_CLUSTER'
-            // values 'publick8s', 'privatek8s-sponsored', 'cijioagents2'
+            values 'privatek8s-sponsored', 'cijioagents2', 'infracijioagents1'
           }
         } // axes
         agent {


### PR DESCRIPTION
This PR removes `publick8s` from `kubernetes-management` job to upgrade `publick8s` to Kubernetes 1.34.

Ref:
-  https://github.com/jenkins-infra/helpdesk/issues/4908#issuecomment-4603087452