### PR TITLE
fix(publick8s/datadog/buildReportsStalenessCheck) change staleness threshold for docs.jio to 24h

### DIFF
--- a/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
+++ b/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
@@ -71,5 +71,5 @@ instances:
     min_collection_interval: 60
   - url: https://builds.reports.jenkins.io/build_status_reports/infra.ci.jenkins.io/website-production-jobs/docs.jenkins.io/main/status.json
     controller: infra.ci.jenkins.io
-    threshold_in_minutes: 10
+    threshold_in_minutes: 1440
     min_collection_interval: 60


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5159

This PR change staleness threshold for docs.jio build report to 24h