### PR TITLE
Revert "Bump agent templates for infra.ci.jenkins.io (packer-image 2.108.0)"

### DIFF
--- a/config/cijioagents2-maven-cacher.yaml
+++ b/config/cijioagents2-maven-cacher.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: 2.108.0
+  tag: 2.107.0
 
 nodeSelector:
   kubernetes.io/arch: arm64

--- a/config/privatek8s-sponsored/infra.ci.jenkins.io.yaml
+++ b/config/privatek8s-sponsored/infra.ci.jenkins.io.yaml
@@ -141,7 +141,7 @@ controller:
                     nodeSelector: "kubernetes.io/arch=amd64"
                     containers:
                       - name: jnlp
-                        image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.108.0
+                        image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.107.0
                         command: "/usr/local/bin/jenkins-agent"
                         args: ""
                         envVars:
@@ -186,7 +186,7 @@ controller:
                     nodeSelector: "kubernetes.io/arch=arm64"
                     containers:
                       - name: jnlp
-                        image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.108.0
+                        image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-agent-ubuntu-22.04:2.107.0
                         command: "/usr/local/bin/jenkins-agent"
                         args: ""
                         envVars:
@@ -243,7 +243,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-amd64"
-                    galleryImageVersion: "2.108.0"
+                    galleryImageVersion: "2.107.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
@@ -316,7 +316,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
-                    galleryImageVersion: "2.108.0"
+                    galleryImageVersion: "2.107.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
@@ -389,7 +389,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
-                    galleryImageVersion: "2.108.0"
+                    galleryImageVersion: "2.107.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
@@ -462,7 +462,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
-                    galleryImageVersion: "2.108.0"
+                    galleryImageVersion: "2.107.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"
@@ -535,7 +535,7 @@ controller:
                   executeInitScriptAsRoot: true
                   imageReference:
                     galleryImageDefinition: "jenkins-agent-ubuntu-22.04-arm64"
-                    galleryImageVersion: "2.108.0"
+                    galleryImageVersion: "2.107.0"
                     galleryName: "prod_packer_images"
                     galleryResourceGroup: "prod-packer-images"
                     gallerySubscriptionId: "1e7d5219-acbc-4495-8629-bdbb22e9b3ed"


### PR DESCRIPTION
Reverts jenkins-infra/kubernetes-management#7803 as it breaks NodeJS (Ref. https://github.com/jenkins-infra/helpdesk/issues/5093#issuecomment-4646255283)