### PR TITLE
fix(all/datadog): replace deprecated value `<component>.createPodDisruptionBudget` by `<component>.pdb.create`

### DIFF
--- a/config/datadog.yaml.gotmpl
+++ b/config/datadog.yaml.gotmpl
@@ -46,4 +46,5 @@ clusterAgent:
     create: true
   # Run the clusterAgent in HA mode
   replicas: 2
-  createPodDisruptionBudget: true
+  pdb:
+    create: true


### PR DESCRIPTION
The `helmfile apply` logs from our pipelines show the following deprecation message from the `datadog` chart (on all clusters):

```
05:53:54  #################################################################
05:53:54  ####               WARNING: Deprecation notice               ####
05:53:54  #################################################################
05:53:54  
05:53:54  The option `<component>.createPodDisruptionBudget` has been deprecated, please use `<component>.pdb.create` instead.
05:53:54  You can further configure the PodDisruptionBudget using `<component>.pdb.minAvailable` or `<component>.pdb.maxUnavailable`.
```

This value was deprecated some time ago in https://github.com/DataDog/helm-charts/blob/main/charts/datadog/CHANGELOG.md#31340, which we merged in https://github.com/jenkins-infra/kubernetes-management/pull/7058.


This PR replaces the deprecated attribute by the recommended one.
