### PR TITLE
chore(updatecli): push build-report jobs from kubernetes-management to datadog

### DIFF
--- a/updatecli/updatecli.d/sync-build-report-jobs.yaml
+++ b/updatecli/updatecli.d/sync-build-report-jobs.yaml
@@ -1,0 +1,39 @@
+---
+name: Sync build report jobs from kubernetes-management
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: datadog
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  buildReportJobs:
+    name: Read the build report jobs file from kubernetes-management
+    kind: file
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/kubernetes-management/main/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
+
+targets:
+  syncBuildReportJobs:
+    name: Sync build report jobs into build-report-jobs.yaml
+    kind: file
+    sourceid: buildReportJobs
+    scmid: default
+    spec:
+      file: build-report-jobs.yaml
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Sync build report jobs from kubernetes-management
+    spec:
+      labels:
+        - datadog


### PR DESCRIPTION
Ref: 
- https://github.com/jenkins-infra/helpdesk/issues/5159

Companion to jenkins-infra/kubernetes-management#7809 and jenkins-infra/datadog#366.

Adds an updatecli manifest that keeps datadog's `build-report-jobs.yaml` in sync with the source list in kubernetes-management (`config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml`).

Following the team discussion on 
- https://github.com/jenkins-infra/helpdesk/issues/5159#issuecomment-4707638574 
 this is the **push** approach: the manifest lives here (jenkins-infra) and writes the list into the datadog repo when the source changes, rather than datadog pulling it on its own schedule. This ties the sync to the actual change in the source list and keeps it consistent with the existing push-style manifests.

## Note
This uses a whole-file sync (`kind: file`), so datadog's `build-report-jobs.yaml` becomes a direct mirror of the source. The descriptive header currently in datadog's copy will be replaced by the source content on first sync, both files share the same `instances:` structure that `monitor-build-reports.tf` consumes, so the Terraform side is unaffected.