### PR TITLE
refactor(buildReportStalenessCheck) rename `threshold_minutes` to `threshold_in_minutes`

### DIFF
--- a/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.py
+++ b/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.py
@@ -43,7 +43,7 @@ class BuildReportStaleness(AgentCheck):
         controller = instance['controller']
         job = instance['job']
         url = f"{BUILD_REPORTS_BASE}/{controller}/{job}/status.json"
-        threshold_minutes = instance['threshold_minutes']
+        threshold_in_minutes = instance['threshold_in_minutes']
         base_tags = [f"controller:{controller}"]
 
         self.warning(f"BuildReportStaleness: {controller}")
@@ -73,7 +73,7 @@ class BuildReportStaleness(AgentCheck):
         try:
             ts = datetime.fromtimestamp(int(data['report_timestamp']), tz=timezone.utc)
             age_in_hours = (datetime.now(timezone.utc) - ts).total_seconds() / 3600
-            threshold_in_hours = threshold_minutes / 60
+            threshold_in_hours = threshold_in_minutes / 60
             stale = age_in_hours > threshold_in_hours
             staleness_tags = tags + [f"threshold_in_hours:{int(threshold_in_hours)}"]
             self.gauge('jenkins.build_report.age_in_hours', round(age_in_hours, 2), tags=staleness_tags)

--- a/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
+++ b/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
@@ -2,51 +2,51 @@ instances:
   ## infra.ci.jenkins.io jobs
   - controller: infra.ci.jenkins.io
     job: acceptance-tests/acceptance-tests/check-agent-availability
-    threshold_minutes: 1440
+    threshold_in_minutes: 1440
   - controller: infra.ci.jenkins.io
     job: kubernetes-jobs/kubernetes-management/main
-    threshold_minutes: 1440
+    threshold_in_minutes: 1440
   - controller: infra.ci.jenkins.io
     job: terraform-jobs/azure/main
-    threshold_minutes: 1440
+    threshold_in_minutes: 1440
   - controller: infra.ci.jenkins.io
     job: terraform-jobs/azure-net/main
-    threshold_minutes: 1440
+    threshold_in_minutes: 1440
   - controller: infra.ci.jenkins.io
     job: terraform-jobs/datadog/main
-    threshold_minutes: 1440
+    threshold_in_minutes: 1440
   - controller: infra.ci.jenkins.io
     job: terraform-jobs/digitalocean/main
-    threshold_minutes: 1440
+    threshold_in_minutes: 1440
   - controller: infra.ci.jenkins.io
     job: terraform-jobs/terraform-aws-sponsorship/main
-    threshold_minutes: 1440
+    threshold_in_minutes: 1440
   - controller: infra.ci.jenkins.io
     job: website-production-jobs/docs.jenkins.io/main
-    threshold_minutes: 1440
+    threshold_in_minutes: 1440
   ## release.ci.jenkins.io jobs
   - controller: release.ci.jenkins.io
     job: infra-agents-health/master
-    threshold_minutes: 1440
+    threshold_in_minutes: 1440
   ## trusted.ci.jenkins.io jobs
   - controller: trusted.ci.jenkins.io
     job: acceptance-tests-check-agent-availability
-    threshold_minutes: 1440
+    threshold_in_minutes: 1440
   - controller: trusted.ci.jenkins.io
     job: core-taglibs-report-generator
-    threshold_minutes: 10080  # 1 week (1 build)
+    threshold_in_minutes: 10080  # 1 week (1 build)
   - controller: trusted.ci.jenkins.io
     job: crawler
-    threshold_minutes: 240  # 4 hours (1 build)
+    threshold_in_minutes: 240  # 4 hours (1 build)
   - controller: trusted.ci.jenkins.io
     job: javadoc
-    threshold_minutes: 10080  # 1 week (1 build)
+    threshold_in_minutes: 10080  # 1 week (1 build)
   - controller: trusted.ci.jenkins.io
     job: jenkins.io
-    threshold_minutes: 60  # (2 builds)
+    threshold_in_minutes: 60  # (2 builds)
   - controller: trusted.ci.jenkins.io
     job: repository-permissions-updater
-    threshold_minutes: 360  # (2 builds)
+    threshold_in_minutes: 360  # (2 builds)
   - controller: trusted.ci.jenkins.io
     job: update_center
-    threshold_minutes: 20  # (2 builds)
+    threshold_in_minutes: 20  # (2 builds)


### PR DESCRIPTION
Rename the threshold key (and the matching Python variable) from `threshold_minutes` to `threshold_in_minutes` for readability, per discussion with the team. The datadog side is updated to match in the companion PR so the mirrored list and the Agent check stay in sync.


Companion datadog PR opened automatically by #7821 updates the mirrored `build-report-jobs.yaml` to the same key. The push manifest (#7821) keeps the two in sync going forward.
