### PR TITLE
chore(datadog): add all reports infra.ci jobs for build staleness monitoring

### DIFF
--- a/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
+++ b/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
@@ -44,6 +44,40 @@ instances:
   - controller: infra.ci.jenkins.io
     job: website-production-jobs/stories/main
     threshold_in_minutes: 1440
+  ## infra.ci.jenkins.io reports jobs
+  - controller: infra.ci.jenkins.io
+    job: reports/artifactory-users-report/main
+    threshold_in_minutes: 180  # @hourly
+  - controller: infra.ci.jenkins.io
+    job: reports/fork-report/main
+    threshold_in_minutes: 2880  # @daily
+  - controller: infra.ci.jenkins.io
+    job: reports/jenkins-infra-data/main
+    threshold_in_minutes: 180  # @hourly
+  - controller: infra.ci.jenkins.io
+    job: reports/jira-users-report/main
+    threshold_in_minutes: 360  # every 2h
+  - controller: infra.ci.jenkins.io
+    job: reports/maintainers-info-report/main
+    threshold_in_minutes: 2880  # @daily
+  - controller: infra.ci.jenkins.io
+    job: reports/permissions-report/main
+    threshold_in_minutes: 2880  # @daily
+  - controller: infra.ci.jenkins.io
+    job: reports/plugin-health-scoring/main
+    threshold_in_minutes: 180  # @hourly
+  - controller: infra.ci.jenkins.io
+    job: reports/backend-extension-indexer/master
+    threshold_in_minutes: 11520  # weekly (Sundays)
+  - controller: infra.ci.jenkins.io
+    job: reports/csp-compatibility/main
+    threshold_in_minutes: 180  # @hourly
+  - controller: infra.ci.jenkins.io
+    job: reports/pipeline-steps-doc-generator/master
+    threshold_in_minutes: 11520  # weekly (Sundays)
+  - controller: infra.ci.jenkins.io
+    job: reports/plugin-site-api/master
+    threshold_in_minutes: 60  # every 10 min
   ## release.ci.jenkins.io jobs
   - controller: release.ci.jenkins.io
     job: infra-agents-health/master


### PR DESCRIPTION
Ref: 
- https://github.com/jenkins-infra/helpdesk/issues/5135

This PR adds each of the 11 report infra.ci jobs for build staleness monitoring

| Job | Cron | Interval | Threshold |
|---|---|---|---|
| artifactory-users-report | `@hourly` | 1h | 180 min |
| fork-report | `@daily` | 24h | 2880 min |
| jenkins-infra-data | `@hourly` | 1h | 180 min |
| jira-users-report | `H H/2 * * *` | 2h | 360 min |
| maintainers-info-report | `@daily` | 24h | 2880 min |
| permissions-report | `@daily` | 24h | 2880 min |
| plugin-health-scoring | `@hourly` | 1h | 180 min |
| backend-extension-indexer | `H H * * 0` | weekly | 11520 min (8 days) |
| csp-compatibility | `@hourly` | 1h | 180 min |
| pipeline-steps-doc-generator | `H H * * 0` | weekly | 11520 min (8 days) |
| plugin-site-api | `H/10 * * * *` | 10 min | 60 min |


