### PR TITLE
feat(cijioagents2/maven-cacher) ensure cache is efficient and up to date with latest BOM branches and ACP setup

### DIFF
--- a/clusters/cijioagents2.yaml
+++ b/clusters/cijioagents2.yaml
@@ -56,6 +56,6 @@ releases:
   - name: maven-cacher
     namespace: maven-cache
     chart: jenkins-infra/maven-cacher
-    version: 0.0.4
+    version: 1.0.0
     values:
       - ../config/cijioagents2-maven-cacher.yaml

--- a/config/cijioagents2-maven-cacher.yaml
+++ b/config/cijioagents2-maven-cacher.yaml
@@ -40,5 +40,7 @@ mavenMirror:
   # TODO: track with updatecli from jenkins)-infra/kubernetes-management (acp release)
   url: http://k8s-artifact-artifact-3d1949c260-a3739c22ffe2d924.elb.us-east-2.amazonaws.com:8080/
   # TODO: track with updatecli from https://github.com/jenkins-infra/jenkins-infra/blob/production/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb#L14
-  mirrorOf: "external:*,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io,!space-maven"
+  mirrorOf: 'external:*,!incrementals,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io,!space-maven'
   mirrorId: artifact-caching-proxy
+# TODO: track with updatecli from jenkinsci/bom with 'echo "weekly $(grep -F '.x</bom>' sample-plugin/pom.xml | sed -E 's, *<bom>(.+)</bom>,\1,g' | sort -rn | xargs)"'
+releaseLines: 'weekly 2.555.x 2.541.x 2.528.x'


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5192

This PR updates 2 items in the maven-cacher setup:

- Lines used from `"weekly" "2.504.x" "2.516.x" "2.528.x"` to `weekly 2.555.x 2.541.x 2.528.x`
- Removes the `incrementals` from ACP requests (direct download if any)