### PR TITLE
chore(updatecli) fix deprecation warnings (dasel/v2 and yaml queries)

### DIFF
--- a/updatecli/updatecli.d/configs/allowed-github-hooks-ips.yaml
+++ b/updatecli/updatecli.d/configs/allowed-github-hooks-ips.yaml
@@ -34,7 +34,7 @@ targets:
     scmid: default
     spec:
       file: config/privatek8s-sponsored/public-nginx-ingress.yaml
-      key: controller.config.whitelist-source-range
+      key: $.controller.config.whitelist-source-range
   allowIPsLB:
     name: Update allowed IPs
     # It does not seem possible to split a string to a YAML array so using regexp in file mode instead

--- a/updatecli/updatecli.d/configs/cijenkinsioagents2-acp-lb.yaml
+++ b/updatecli/updatecli.d/configs/cijenkinsioagents2-acp-lb.yaml
@@ -18,6 +18,7 @@ sources:
     kind: json
     name: Retrieve the list of subnet IDS for the ACP AWS LB from infra report
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
       key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.artifact-caching-proxy.subnet_ids
     transformers:
@@ -30,6 +31,7 @@ sources:
     kind: json
     name: Retrieve the list of subnet IDS for the ACP AWS LB from infra report
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
       key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.artifact-caching-proxy.ips
     transformers:
@@ -42,6 +44,7 @@ sources:
     kind: json
     name: Retrieve the storage class to use for the ACP storage
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
       key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.artifact-caching-proxy.storage_class
 
@@ -50,9 +53,6 @@ targets:
     name: Update ACP LB IPv4
     sourceid: acpLbIps
     kind: yaml
-    transformers:
-      - addprefix: '"'
-      - addsuffix: '"'
     spec:
       file: config/artifact-caching-proxy_aws-cijenkinsio-agents-2.yaml
       key: $.service.annotations.'service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses'

--- a/updatecli/updatecli.d/configs/cijenkinsioagents2-hub-mirror.yaml
+++ b/updatecli/updatecli.d/configs/cijenkinsioagents2-hub-mirror.yaml
@@ -18,6 +18,7 @@ sources:
     kind: json
     name: Retrieve the storage class to use for the "Docker Hub Registry Mirror" storage
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
       key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.hub-mirror.storage_class
 
@@ -25,6 +26,7 @@ sources:
     kind: json
     name: Retrieve the list of subnet IDS for the "Docker Hub Registry Mirror" AWS LB
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
       key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.hub-mirror.subnet_ids
     transformers:
@@ -37,6 +39,7 @@ sources:
     kind: json
     name: Retrieve the list of subnet IDS for the "Docker Hub Registry Mirror" AWS LB
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
       key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.hub-mirror.ips
     transformers:
@@ -50,9 +53,6 @@ targets:
     name: Update the "Docker Hub Registry Mirror" LB IPv4
     sourceid: hubMirrorLbIps
     kind: yaml
-    transformers:
-      - addprefix: '"'
-      - addsuffix: '"'
     spec:
       file: config/hub-mirror_cijioagents2.yaml
       key: $.service.annotations.'service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses'

--- a/updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
+++ b/updatecli/updatecli.d/configs/ldap-restricted-ips.yaml
@@ -15,15 +15,19 @@ scms:
 sources:
   puppet.jenkins.io:
     kind: json
+    name: Retrieve the puppet master outbound IPs
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .puppet\.jenkins\.io.outbound_ips
     transformers:
       - addsuffix: '/32'
 
   publick8s-lb:
+    name: Retrieve the publick8s outbound IPs
     kind: json
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .publick8s.lb_outbound_ips.ipv4
     transformers:
@@ -35,19 +39,22 @@ sources:
       - addsuffix: '/32'
 
   publick8s-pods:
+    name: Retrieve the publick8s pod CNI CIDR
     kind: json
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       # Ipv4 is always the first element
       key: .publick8s.pod_cidrs.[0]
 
   # https://jfrog.com/knowledge-base/what-are-artifactory-cloud-nated-ips/
   jfrog:
+    name: Retrieve the Jfrog (repo.jenkins-cio.org) outbound IPs
     kind: json
     spec:
+      engine: dasel/v2
       file: https://my.jfrog.com/api/jmis/v1/ip-ranges
-      # Dasel v1 query
-      key: .(cloud=aws)(region=us-east-1)(service=jfrog_cloud_cidr).cidr
+      key: all().filter(equal(cloud,aws)).filter(equal(region,us-east-1)).filter(equal(service,jfrog_cloud_cidr)).cidr.all().merge()
     # Change the json list to a comma-separated list into a single string
     transformers:
       - trimprefix: '['
@@ -57,8 +64,10 @@ sources:
           to: ','
 
   aws-ci-jenkins-io:
+    name: Retrieve the ci.jenkins.io outbound IPs from AWS
     kind: json
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
       key: .aws\.ci\.jenkins\.io.service_ips.ipv4
     transformers:

--- a/updatecli/updatecli.d/configs/pvc-get-jenkins-io-httpd.yaml
+++ b/updatecli/updatecli.d/configs/pvc-get-jenkins-io-httpd.yaml
@@ -18,12 +18,14 @@ sources:
     kind: json
     name: Retrieve the pvc name for get-jenkins-io-httpd
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .get\.jenkins\.io.httpd.pvc_name
   subDir:
     kind: json
     name: Retrieve the subDir name for get-jenkins-io-httpd
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .get\.jenkins\.io.httpd.share_uri
     transformers:

--- a/updatecli/updatecli.d/configs/pvc-get-jenkins-io-mirrorbits.yaml
+++ b/updatecli/updatecli.d/configs/pvc-get-jenkins-io-mirrorbits.yaml
@@ -18,12 +18,14 @@ sources:
     kind: json
     name: Retrieve the PVC name for get-jenkins-io
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .get\.jenkins\.io.mirrorbits.pvc_name
   contentPvcSubdir:
     kind: json
     name: Retrieve the subdir inside the PVC for component "mirrorbits" in get-jenkins-io
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .get\.jenkins\.io.mirrorbits.share_uri
     transformers:
@@ -32,12 +34,14 @@ sources:
     kind: json
     name: Retrieve the pvc name for geoipdata
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .get\.jenkins\.io.geoipdata.pvc_name
   geoipdataPvcSubdir:
     kind: json
     name: Retrieve the subdir inside the PVC for component "geoipdata" in get-jenkins-io
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .get\.jenkins\.io.geoipdata.share_uri
     transformers:

--- a/updatecli/updatecli.d/configs/pvc-ldap.yaml
+++ b/updatecli/updatecli.d/configs/pvc-ldap.yaml
@@ -18,12 +18,14 @@ sources:
     kind: json
     name: Retrieve LDAP data PVC name
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .ldap\.jenkins\.io.data.pvc_name
   getBackupPvcName:
     kind: json
     name: Retrieve LDAP backup PVC name
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .ldap\.jenkins\.io.backup.pvc_name
 

--- a/updatecli/updatecli.d/configs/pvc-updates-jenkins-io-content.yaml
+++ b/updatecli/updatecli.d/configs/pvc-updates-jenkins-io-content.yaml
@@ -18,12 +18,14 @@ sources:
     kind: json
     name: Retrieve the PVC name for updates-jenkins-io
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .updates\.jenkins\.io.content.pvc_name
   contentPvcSubdir:
     kind: json
     name: Retrieve the subdir inside the PVC for component "content" in updates-jenkins-io
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .updates\.jenkins\.io.content.share_uri
     transformers:
@@ -32,12 +34,14 @@ sources:
     kind: json
     name: Retrieve the pvc name for geoipdata
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .updates\.jenkins\.io.geoipdata.pvc_name
   geoipdataPvcSubdir:
     kind: json
     name: Retrieve the subdir inside the PVC for component "geoipdata" in updates-jenkins-io
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .updates\.jenkins\.io.geoipdata.share_uri
     transformers:

--- a/updatecli/updatecli.d/configs/pvc-updates-jenkins-io-redirections.yaml
+++ b/updatecli/updatecli.d/configs/pvc-updates-jenkins-io-redirections.yaml
@@ -18,12 +18,14 @@ sources:
     kind: json
     name: Retrieve the pvc name for updates-jenkins-io-redirects
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .updates\.jenkins\.io.redirections.pvc_name
   subDir:
     kind: json
     name: Retrieve the subDir name for updates-jenkins-io-redirects
     spec:
+      engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
       key: .updates\.jenkins\.io.redirections.share_uri
     transformers:


### PR DESCRIPTION
This PR updates our `updatecli` manifests to fix deprecation warning messages:

- 1 YAML query is missing the `$` at the begginning.
- Many `json` resources did not have the JSON engine specified, we now explicitly used `dasel/v2`
  - Note: JFrog public IPs retrieval was usinbg Dasel/v1 only syntax: it has been updated

Note: will fix the diff for https://github.com/jenkins-infra/kubernetes-management/pull/7253 and https://github.com/jenkins-infra/kubernetes-management/pull/7019