### PR TITLE
chore(updatecli) fix cijenkinsioagents2 ACP/DockerHubMirror network setup retrieval

### DIFF
--- a/updatecli/updatecli.d/configs/cijenkinsioagents2-acp-lb.yaml
+++ b/updatecli/updatecli.d/configs/cijenkinsioagents2-acp-lb.yaml
@@ -14,32 +14,20 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  acpAwsSubnets:
+  acpAwsSubnet:
     kind: json
-    name: Retrieve the list of subnet IDS for the ACP AWS LB from infra report
+    name: Retrieve the subnet ID for the ACP AWS LB from infra report
     spec:
       engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
-      key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.artifact-caching-proxy.subnet_ids
-    transformers:
-      - trimprefix: '['
-      - trimsuffix: ']'
-      - replacer:
-          from: ' '
-          to: ','
-  acpLbIps:
+      key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.artifact-caching-proxy.subnet_id
+  acpLbIp:
     kind: json
-    name: Retrieve the list of subnet IDS for the ACP AWS LB from infra report
+    name: Retrieve the LB private IP for the ACP AWS LB from infra report
     spec:
       engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
-      key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.artifact-caching-proxy.ips
-    transformers:
-      - trimprefix: '['
-      - trimsuffix: ']'
-      - replacer:
-          from: ' '
-          to: ','
+      key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.artifact-caching-proxy.private_ip
   acpStorageClass:
     kind: json
     name: Retrieve the storage class to use for the ACP storage
@@ -49,22 +37,21 @@ sources:
       key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.artifact-caching-proxy.storage_class
 
 targets:
-  updateAcpLbIps:
+  updateAcpLbIp:
     name: Update ACP LB IPv4
-    sourceid: acpLbIps
+    sourceid: acpLbIp
     kind: yaml
     spec:
       file: config/artifact-caching-proxy_aws-cijenkinsio-agents-2.yaml
       key: $.service.annotations.'service.beta.kubernetes.io/aws-load-balancer-private-ipv4-addresses'
     scmid: default
-  updateAcpLbSubnets:
-    name: Update ACP LB Subnets
-    disablesourceinput: true # We need to combine 2 sources
+  updateAcpLbSubnet:
+    name: Update ACP LB Subnet
+    sourceid: acpAwsSubnet
     kind: yaml
     spec:
       file: config/artifact-caching-proxy_aws-cijenkinsio-agents-2.yaml
       key: $.service.annotations.'service.beta.kubernetes.io/aws-load-balancer-subnets'
-      value: '"{{ source `acpAwsSubnets` }}"'
     scmid: default
   updateAcpStorageClass:
     name: Update ACP Storage Class

--- a/updatecli/updatecli.d/configs/cijenkinsioagents2-hub-mirror.yaml
+++ b/updatecli/updatecli.d/configs/cijenkinsioagents2-hub-mirror.yaml
@@ -22,36 +22,25 @@ sources:
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
       key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.hub-mirror.storage_class
 
-  hubMirrorAwsSubnets:
+  hubMirrorAwsSubnet:
     kind: json
-    name: Retrieve the list of subnet IDS for the "Docker Hub Registry Mirror" AWS LB
+    name: Retrieve the subnet ID for the "Docker Hub Registry Mirror" AWS LB
     spec:
       engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
-      key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.hub-mirror.subnet_ids
-    transformers:
-      - trimprefix: '['
-      - trimsuffix: ']'
-      - replacer:
-          from: ' '
-          to: ','
-  hubMirrorLbIps:
+      key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.hub-mirror.subnet_id
+  hubMirrorLbIp:
     kind: json
-    name: Retrieve the list of subnet IDS for the "Docker Hub Registry Mirror" AWS LB
+    name: Retrieve the private IP for the "Docker Hub Registry Mirror" AWS LB
     spec:
       engine: dasel/v2
       file: https://reports.jenkins.io/jenkins-infra-data-reports/aws-sponsorship.json
-      key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.hub-mirror.ips
-    transformers:
-      - trimprefix: '['
-      - trimsuffix: ']'
-      - replacer:
-          from: ' '
-          to: ','
+      key: aws\.ci\.jenkins\.io.agents_kubernetes_clusters.cijenkinsio-agents-2.services.hub-mirror.private_ip
+
 targets:
   updateHubMirrorLbIps:
     name: Update the "Docker Hub Registry Mirror" LB IPv4
-    sourceid: hubMirrorLbIps
+    sourceid: hubMirrorLbIp
     kind: yaml
     spec:
       file: config/hub-mirror_cijioagents2.yaml
@@ -59,12 +48,11 @@ targets:
     scmid: default
   updateHubMirrorLbSubnets:
     name: Update the "Docker Hub Registry Mirror" LB Subnets
-    disablesourceinput: true # We need to combine 2 sources
+    sourceid: hubMirrorAwsSubnet
     kind: yaml
     spec:
       file: config/hub-mirror_cijioagents2.yaml
       key: $.service.annotations.'service.beta.kubernetes.io/aws-load-balancer-subnets'
-      value: '"{{ source `hubMirrorAwsSubnets` }}"'
     scmid: default
 
 actions:


### PR DESCRIPTION
Following the report's content change introduced in https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/540 and https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/541, we now only have 1 subnet and 1 private IP per service.

Related to https://github.com/jenkins-infra/helpdesk/issues/5185#issuecomment-4768473422

Closes #7019 and #7253 for good!