### PR TITLE
chore(updatecli): keep BOM release lines up to date in `maven-cacher` configuration

### DIFF
--- a/config/cijioagents2-maven-cacher.yaml
+++ b/config/cijioagents2-maven-cacher.yaml
@@ -42,5 +42,5 @@ mavenMirror:
   # TODO: track with updatecli from https://github.com/jenkins-infra/jenkins-infra/blob/production/dist/profile/templates/jenkinscontroller/casc/artifact-caching-proxy.yaml.erb#L14
   mirrorOf: 'external:*,!incrementals,!chimera-releases,!chimera-snapshots,!atlassian-public,!org.zowe.sdk,!jitpack.io,!space-maven'
   mirrorId: artifact-caching-proxy
-# TODO: track with updatecli from jenkinsci/bom with 'echo "weekly $(grep -F '.x</bom>' sample-plugin/pom.xml | sed -E 's, *<bom>(.+)</bom>,\1,g' | sort -rn | xargs)"'
+# Tracked by updatecli/updatecli.d/configs/cijenkinsioagents2-maven-cacher-bom-release-lines.yaml
 releaseLines: 'weekly 2.555.x 2.541.x 2.528.x'

--- a/updatecli/updatecli.d/configs/cijenkinsioagents2-maven-cacher-bom-release-lines.yaml
+++ b/updatecli/updatecli.d/configs/cijenkinsioagents2-maven-cacher-bom-release-lines.yaml
@@ -1,0 +1,44 @@
+name: Update BOM release lines in `maven-cacher` configuration
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getBomReleaseLines:
+    kind: shell
+    name: Get BOM release lines
+    spec:
+      command: |
+        git clone https://github.com/jenkinsci/bom
+        cd bom
+        echo "weekly $(grep -F '.x</bom>' sample-plugin/pom.xml | sed -E 's, *<bom>(.+)</bom>,\1,g' | sort -rn | xargs)"
+
+targets:
+  updateBomReleaseLinesInConfig:
+    name: Update BOM release lines in the configuration
+    kind: yaml
+    sourceid: getBomReleaseLines
+    spec:
+      file: ./config/cijioagents2-maven-cacher.yaml
+      key: $.releaseLines
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Update BOM release lines in `maven-cacher` configuration
+    spec:
+      labels:
+        - maven-cacher
+        - cijioagents2
+        - bom-release-lines


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5192#issuecomment-4788619481

#### Testing done

<details><summary>updatecli diff --config updatecli/updatecli.d/configs/cijenkinsioagents2-maven-cacher-bom-release-lines.yaml --values updatecli/values.yaml</summary>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/configs/cijenkinsioagents2-maven-cacher-bom-release-lines.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++


############################################################
# UPDATE BOM RELEASE LINES IN `MAVEN-CACHER` CONFIGURATION #
############################################################

Pipeline ID     : 2819cc98a62559499ba4769a81c3aa47a4d9b22e81cdd50b5b9119ad62ed3ab0
Dry Run         : enabled

source: getBomReleaseLines
--------------------------

The shell 🐚 command "/bin/sh /var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/bin/b6eb0b83c6d091eb12d8f70d01aa9b0efdf5c9f3c69047f27cbdbfea073c160b.sh" ran successfully with the following output:
----
weekly 2.568.x 2.555.x 2.541.x
----
✔ shell command executed successfully

target: updateBomReleaseLinesInConfig
-------------------------------------

Repository      : github.com/jenkins-infra/kubernetes-management@main

⚠ - change detected:
        * key "$.releaseLines" should be updated from "'weekly 2.555.x 2.541.x 2.528.x'" to "weekly 2.568.x 2.555.x 2.541.x", in file "./config/cijioagents2-maven-cacher.yaml"


ACTIONS
========

---
Pipeline Name   : Update BOM release lines in `maven-cacher` configuration
Pipeline ID     : 2819cc98a62559499ba4769a81c3aa47a4d9b22e81cdd50b5b9119ad62ed3ab0
Dry run         : true
Repository      : github.com/jenkins-infra/kubernetes-management@main
Action          : Update BOM release lines in `maven-cacher` configuration
---

An action of kind "github/pullrequest" is expected.

=============================

SUMMARY:

⚠ Update BOM release lines in `maven-cacher` configuration:
        Source:
                ✔ [getBomReleaseLines] Get BOM release lines
        Target:
                ⚠ [updateBomReleaseLinesInConfig] Update BOM release lines in the configuration
                      * Repository: https://github.com/jenkins-infra/kubernetes-management.git (branch: main)


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
```

</details>