### PR TITLE
chore(helmfile): rename atomic rollback-on-failure for Helm 4 [DRAFT/DO-NOT-MERGE]

### DIFF
--- a/clusters/cijioagents2.yaml
+++ b/clusters/cijioagents2.yaml
@@ -1,6 +1,6 @@
 ---
 helmDefaults:
-  atomic: true
+  rollbackOnFailure: true
   force: false
   timeout: 300
   wait: true

--- a/clusters/infracijioagents1.yaml
+++ b/clusters/infracijioagents1.yaml
@@ -1,6 +1,6 @@
 ---
 helmDefaults:
-  atomic: true
+  rollbackOnFailure: true
   force: false
   timeout: 300
   wait: true

--- a/clusters/privatek8s-sponsored.yaml
+++ b/clusters/privatek8s-sponsored.yaml
@@ -1,6 +1,6 @@
 ---
 helmDefaults:
-  atomic: true
+  rollbackOnFailure: true
   force: false
   timeout: 300
   wait: true

--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -1,6 +1,6 @@
 ---
 helmDefaults:
-  atomic: true
+  rollbackOnFailure: true
   force: false
   timeout: 600
   wait: true


### PR DESCRIPTION
Ref: 
- jenkins-infra/helpdesk#5127

Helm 4 deprecated --atomic in favour of --rollback-on-failure (helm/helm#13629), removed in Helm 5. Draft only: demonstrates that the CI helmfile diff stays clean even though helmfile 1.7.0 does not understand the rollbackOnFailure key, which is why this must NOT be merged until helmfile support proved.

