### PR TITLE
feat(publick8s/datadog/checksd/buildStaleness) RPU now runs every 2 hours

### DIFF
--- a/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
+++ b/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
@@ -100,7 +100,7 @@ instances:
     threshold_in_minutes: 60  # (2 builds)
   - controller: trusted.ci.jenkins.io
     job: repository-permissions-updater
-    threshold_in_minutes: 360  # (2 builds)
+    threshold_in_minutes: 240  # (2 builds)
   - controller: trusted.ci.jenkins.io
     job: update_center
     threshold_in_minutes: 20  # (2 builds)


### PR DESCRIPTION
Follow up of https://github.com/jenkins-infra/repository-permissions-updater/pull/5160

Related to https://github.com/jenkins-infra/helpdesk/issues/5225