### PR TITLE
feat(publick8s/datadog/checks) add a new build report probe for cert.ci.jenkins.io acceptance test job

### DIFF
--- a/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
+++ b/config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
@@ -82,6 +82,10 @@ instances:
   - controller: release.ci.jenkins.io
     job: infra-agents-health/master
     threshold_in_minutes: 1440
+  ## cert.ci.jenkins.io jobs
+  - controller: cert.ci.jenkins.io
+    job: acceptance-tests-check-agent-availability
+    threshold_in_minutes: 1440
   ## trusted.ci.jenkins.io jobs
   - controller: trusted.ci.jenkins.io
     job: acceptance-tests-check-agent-availability


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5123

Fail after 3 consecutive failed or stalled build