### PR TITLE
feat(publick8s/LDAP) allow the new cert.ci.jenkins.io sponsored controller to access LDAP for authentication

### DIFF
--- a/config/publick8s/ldap-jenkins-io.yaml
+++ b/config/publick8s/ldap-jenkins-io.yaml
@@ -14,11 +14,11 @@ service:
     trusted.ci.jenkins.io: '20.110.255.213/32'
     # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
     private.vpn.jenkins.io: '52.232.183.117/32'
-    # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure.json
-    cert.ci.jenkins.io: '104.209.153.13/32'
-    # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json (privatek8s-sponsored)
+    # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+    cert.ci.jenkins.io: '104.209.153.13/32 4.223.174.131/32 20.91.220.227/32'
+    # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
     infra.ci.jenkins.io: 20.186.168.195/32,20.65.112.39/32
-    # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json (privatek8s-sponsored)
+    # TODO: track with updatecli - https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
     release.ci.jenkins.io: 20.186.168.195/32,20.65.112.39/32
     # Provided by LF
     linuxfoundation-staging: '34.211.101.61/32'


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5089#issuecomment-5540956527

```
$ curl --silent --location https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json | jq -r '.["cert.ci.jenkins.io"]["outbound_ips"]'

[
  "104.209.153.13",
  "4.223.174.131",
  "20.91.220.227"
]
```