### PR TITLE
chore(pipeline): lint YAML files from `cluster` and `updatecli` folders too

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -19,7 +19,7 @@ pipeline {
         label 'jnlp-linux-arm64'
       }
       steps {
-        sh 'yamllint --config-file yamllint.config config'
+        sh 'yamllint --config-file yamllint.config config clusters updatecli'
       }
     } // stage 'Yaml Lint'
     stage('Kubernetes Management Tasks') {

--- a/config/cijioagents2/maven-cacher.yaml
+++ b/config/cijioagents2/maven-cacher.yaml
@@ -21,8 +21,8 @@ resources:
     memory: 2048Mi
 
 podSecurityContext:
-  runAsUser: 1001 # User 'jenkins'
-  runAsGroup: 1001 # Group 'jenkins'
+  runAsUser: 1001  # User 'jenkins'
+  runAsGroup: 1001  # Group 'jenkins'
   runAsNonRoot: true
 
 containerSecurityContext:
@@ -33,7 +33,7 @@ containerSecurityContext:
       - ALL
 
 cachePvc: ci-jenkins-io-maven-cache
-#TODO: track with updatecli from https://github.com/jenkins-infra/jenkins-infra/blob/17784f9d822e974154515cddf589eb3beb3a7813/hieradata/common.yaml#L218
+# TODO: track with updatecli from https://github.com/jenkins-infra/jenkins-infra/blob/17784f9d822e974154515cddf589eb3beb3a7813/hieradata/common.yaml#L218
 javaHome: /opt/jdk-21
 mavenMirror:
   enable: true

--- a/updatecli/updatecli.d/charts/falco.yaml
+++ b/updatecli/updatecli.d/charts/falco.yaml
@@ -27,7 +27,7 @@ targets:
     scmid: default
     spec:
       files:
-       - clusters/publick8s.yaml
+        - clusters/publick8s.yaml
       engine: yamlpath
       key: $.releases[?(@.chart == 'falco/falco')].version
 

--- a/updatecli/updatecli.d/docker-images/jenkins-weekly_infra.ci.jenkins.io.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-weekly_infra.ci.jenkins.io.yaml
@@ -30,7 +30,7 @@ conditions:
       image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-infraci
       ## Tag from source
       architectures:
-      - arm64
+        - arm64
 
 targets:
   updateReleaseInConfig:

--- a/updatecli/updatecli.d/docker-images/jenkins-weekly_weekly.ci.jenkins.io.yaml
+++ b/updatecli/updatecli.d/docker-images/jenkins-weekly_weekly.ci.jenkins.io.yaml
@@ -30,7 +30,7 @@ conditions:
       image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-weeklyci
       ## Tag from source
       architectures:
-      - arm64
+        - arm64
 
 targets:
   updateReleaseInConfig:

--- a/updatecli/updatecli.d/docker-images/keycloak-theme.yaml
+++ b/updatecli/updatecli.d/docker-images/keycloak-theme.yaml
@@ -30,7 +30,7 @@ conditions:
       image: dockerhubmirror.azurecr.io/jenkinsciinfra/keycloak-theme
       ## Tag from source
       architectures:
-      - arm64
+        - arm64
 
 targets:
   updateReleaseInConfig:

--- a/updatecli/updatecli.d/jenkins-controllers/jenkins-agents-infra.ci.jenkins.io.yaml
+++ b/updatecli/updatecli.d/jenkins-controllers/jenkins-agents-infra.ci.jenkins.io.yaml
@@ -64,8 +64,8 @@ conditions:
       image: dockerhubmirror.azurecr.io/jenkinsciinfra/jenkins-agent-ubuntu-22.04
       ## Tag from source
       architectures:
-      - arm64
-      - amd64
+        - arm64
+        - amd64
 
 targets:
   setAzureGalleryImageVersion:


### PR DESCRIPTION
This change ensures all YAML files are linted, not only the ones in `config` folder.