### PR TITLE
feat(publick8s/get.jenkins.io) bump mirrorbits chart to `5.11.0` (with mirrorbits `v0.6.2`)

### DIFF
--- a/clusters/publick8s.yaml
+++ b/clusters/publick8s.yaml
@@ -174,7 +174,7 @@ releases:
   - name: get-jenkins-io-mirrorbits
     namespace: get-jenkins-io
     chart: jenkins-infra/mirrorbits
-    version: 5.10.19
+    version: 5.11.0
     values:
       - ../config/publick8s/get-jenkins-io-mirrorbits.yaml
     secrets:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5279